### PR TITLE
fix: 카테고리 편집 DB에 적용 안되는 버그

### DIFF
--- a/src/main/java/com/kustacks/kuring/domain/user/User.java
+++ b/src/main/java/com/kustacks/kuring/domain/user/User.java
@@ -30,7 +30,7 @@ public class User implements Serializable {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Feedback> feedbacks;
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", fetch = FetchType.EAGER)
     @Fetch(FetchMode.JOIN)
     private List<UserCategory> userCategories = new ArrayList<>();
 

--- a/src/main/java/com/kustacks/kuring/domain/user/UserRepository.java
+++ b/src/main/java/com/kustacks/kuring/domain/user/UserRepository.java
@@ -2,8 +2,12 @@ package com.kustacks.kuring.domain.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     User findByToken(String token);
+
+    @Transactional
+    void deleteByToken(String token);
 }

--- a/src/main/java/com/kustacks/kuring/event/TransactionalEventHandler.java
+++ b/src/main/java/com/kustacks/kuring/event/TransactionalEventHandler.java
@@ -32,13 +32,13 @@ public class TransactionalEventHandler {
         List<UserCategory> removedUserCategories = transactionHistory.get("remove");
 
         try {
-            log.debug("=== 신청한 구독 롤백 ===");
+            log.info("=== 신청한 구독 롤백 ===");
             for (UserCategory newUserCategory : newUserCategories) {
                 firebaseService.unsubscribe(token, newUserCategory.getCategory().getName());
                 log.info(newUserCategory.getCategory().getName());
             }
 
-            log.debug("=== 취소한 구독 롤백 ===");
+            log.info("=== 취소한 구독 롤백 ===");
             for (UserCategory removeUserCategory : removedUserCategories) {
                 firebaseService.subscribe(token, removeUserCategory.getCategory().getName());
                 log.info(removeUserCategory.getCategory().getName());

--- a/src/main/java/com/kustacks/kuring/kuapi/KuApiWatcher.java
+++ b/src/main/java/com/kustacks/kuring/kuapi/KuApiWatcher.java
@@ -5,7 +5,6 @@ import com.kustacks.kuring.controller.dto.NoticeDTO;
 import com.kustacks.kuring.controller.dto.StaffDTO;
 import com.kustacks.kuring.domain.category.Category;
 import com.kustacks.kuring.domain.category.CategoryRepository;
-import com.kustacks.kuring.domain.feedback.FeedbackRepository;
 import com.kustacks.kuring.domain.notice.Notice;
 import com.kustacks.kuring.domain.notice.NoticeRepository;
 import com.kustacks.kuring.domain.staff.Staff;
@@ -13,6 +12,7 @@ import com.kustacks.kuring.domain.staff.StaffRepository;
 import com.kustacks.kuring.domain.user.User;
 import com.kustacks.kuring.domain.user.UserRepository;
 import com.kustacks.kuring.domain.user_category.UserCategory;
+import com.kustacks.kuring.domain.user_category.UserCategoryRepository;
 import com.kustacks.kuring.error.ErrorCode;
 import com.kustacks.kuring.error.InternalLogicException;
 import com.kustacks.kuring.kuapi.request.KuisLoginRequestBody;
@@ -65,6 +65,7 @@ public class KuApiWatcher {
     private final CategoryRepository categoryRepository;
     private final StaffRepository staffRepository;
     private final UserRepository userRepository;
+    private final UserCategoryRepository userCategoryRepository;
 
     private final StaffScraper staffScraper;
     private final List<StaffDeptInfo> deptInfos;
@@ -94,6 +95,7 @@ public class KuApiWatcher {
             CategoryRepository categoryRepository,
             StaffRepository staffRepository,
             UserRepository userRepository,
+            UserCategoryRepository userCategoryRepository,
 
             StaffScraper staffScraper,
             List<StaffDeptInfo> deptInfos
@@ -106,6 +108,7 @@ public class KuApiWatcher {
         this.categoryRepository = categoryRepository;
         this.staffRepository = staffRepository;
         this.userRepository = userRepository;
+        this.userCategoryRepository = userCategoryRepository;
 
         this.staffScraper = staffScraper;
         this.deptInfos = deptInfos;
@@ -613,9 +616,11 @@ public class KuApiWatcher {
                         log.error("토큰 = {}, 카테고리 = {}", user.getToken(), userCategory.getCategory().getName());
                         Sentry.captureException(new InternalLogicException(ErrorCode.FB_FAIL_UNSUBSCRIBE, ex));
                     }
+
+                    userCategoryRepository.deleteAll(user.getUserCategories());
                 }
 
-                userRepository.delete(user);
+                userRepository.deleteByToken(user.getToken());
             }
         }
 

--- a/src/main/java/com/kustacks/kuring/service/CategoryServiceImpl.java
+++ b/src/main/java/com/kustacks/kuring/service/CategoryServiceImpl.java
@@ -125,18 +125,18 @@ public class CategoryServiceImpl implements CategoryService {
 
         List<UserCategory> newUserCategories = userCategories.get("new");
         for (UserCategory newUserCategory : newUserCategories) {
-            userCategoryRepository.save(newUserCategory);
             firebaseService.subscribe(newUserCategory.getUser().getToken(), newUserCategory.getCategory().getName());
+            userCategoryRepository.save(newUserCategory);
             transactionHistory.get("new").add(newUserCategory);
-            log.debug("구독 요청 = {}", newUserCategory.getCategory().getName());
+            log.info("구독 요청 = {}", newUserCategory.getCategory().getName());
         }
 
         List<UserCategory> removeUserCategories = userCategories.get("remove");
         for (UserCategory removeUserCategory : removeUserCategories) {
-            userCategoryRepository.delete(removeUserCategory);
             firebaseService.unsubscribe(removeUserCategory.getUser().getToken(), removeUserCategory.getCategory().getName());
+            userCategoryRepository.delete(removeUserCategory);
             transactionHistory.get("remove").add(removeUserCategory);
-            log.debug("구독 취소 = {}", removeUserCategory.getCategory().getName());
+            log.info("구독 취소 = {}", removeUserCategory.getCategory().getName());
         }
     }
 


### PR DESCRIPTION
User 엔티티의 cascade.all 속성에 의해 UserCatgory 엔티티를 삭제해도 이 내용이 User.userCategories에 반영이 되지 않아 DB에 적용이 안되는 문제였다.
User.userCategories의 Cascade.ALL을 삭제하여 userCategory 편집 시 DB에 적용되게끔 했고, Casecade제약조건을 지웠으므로 User 삭제 시 수동으로 UserCategory를 삭제해야 한다. 즉, KuApiWatcher에서 User 토큰 갱신 시 수동으로 UserCategory를 삭제하는 로직을 추가했다.