### PR TITLE
[Fix-#68] Post not supported 수정하기

### DIFF
--- a/src/main/java/com/kustacks/kuring/worker/scrap/client/notice/LatestPageNoticeApiClient.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/client/notice/LatestPageNoticeApiClient.java
@@ -20,7 +20,8 @@ public class LatestPageNoticeApiClient implements NoticeApiClient<ScrapingResult
 
     private static final int PAGE_NUM = 1;    // recentPage는 pageNum 인자가 1부터 시작
     private static final int ARTICLE_NUMBERS_PER_PAGE = 12;
-    private static final int LATEST_SCRAP_TIMEOUT = 300000; // 5분
+    private static final int LATEST_SCRAP_TIMEOUT = 60000; // 1분
+    private static final int LATEST_SCRAP_ALL_TIMEOUT = 120000; // 2분
 
     private final JsoupClient jsoupClient;
 
@@ -35,7 +36,7 @@ public class LatestPageNoticeApiClient implements NoticeApiClient<ScrapingResult
         List<ScrapingResultDto> reqResults = new LinkedList<>();
         for(int i = 0; i < size; i++) {
             try {
-                ScrapingResultDto resultDto = getScrapingResultDto(i, deptInfo, ARTICLE_NUMBERS_PER_PAGE);
+                ScrapingResultDto resultDto = getScrapingResultDto(i, deptInfo, ARTICLE_NUMBERS_PER_PAGE, LATEST_SCRAP_TIMEOUT);
                 reqResults.add(resultDto);
             } catch (IOException e) {
                 throw new InternalLogicException(ErrorCode.NOTICE_SCRAPER_CANNOT_SCRAP, e);
@@ -56,7 +57,7 @@ public class LatestPageNoticeApiClient implements NoticeApiClient<ScrapingResult
             try {
                 int totalNoticeSize = getTotalNoticeSize(i, deptInfo);
 
-                ScrapingResultDto resultDto = getScrapingResultDto(i, deptInfo, totalNoticeSize);
+                ScrapingResultDto resultDto = getScrapingResultDto(i, deptInfo, totalNoticeSize, LATEST_SCRAP_ALL_TIMEOUT);
                 reqResults.add(resultDto);
             } catch (IOException e) {
                 throw new InternalLogicException(ErrorCode.NOTICE_SCRAPER_CANNOT_SCRAP, e);
@@ -72,11 +73,11 @@ public class LatestPageNoticeApiClient implements NoticeApiClient<ScrapingResult
         return deptInfo.getNoticeScrapInfo().getBoardSeqs().size();
     }
 
-    private ScrapingResultDto getScrapingResultDto(int index, DeptInfo deptInfo, int totalNoticeSize) throws IOException {
+    private ScrapingResultDto getScrapingResultDto(int index, DeptInfo deptInfo, int totalNoticeSize, int timeout) throws IOException {
         String requestUrl = deptInfo.createRequestUrl(index, totalNoticeSize, PAGE_NUM);
         String viewUrl = deptInfo.createViewUrl(index);
 
-        Document document = jsoupClient.get(requestUrl, LATEST_SCRAP_TIMEOUT);
+        Document document = jsoupClient.get(requestUrl, timeout);
 
         return new ScrapingResultDto(document, viewUrl);
     }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/DeptInfo.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/DeptInfo.java
@@ -40,6 +40,10 @@ public class DeptInfo {
         return departmentName.getKorName();
     }
 
+    public boolean isSameDepartment(DepartmentName departmentName) {
+        return this.departmentName.equals(departmentName);
+    }
+
     public String createRequestUrl(int index, int curPage, int pageNum) {
         return UriComponentsBuilder.fromUriString(latestPageNoticeProperties.getListUrl())
                 .queryParam("siteId", noticeScrapInfo.getSiteId())

--- a/src/main/java/com/kustacks/kuring/worker/update/notice/DepartmentNoticeUpdater.java
+++ b/src/main/java/com/kustacks/kuring/worker/update/notice/DepartmentNoticeUpdater.java
@@ -26,6 +26,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.kustacks.kuring.notice.domain.DepartmentName.REAL_ESTATE;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -40,7 +42,7 @@ public class DepartmentNoticeUpdater {
 
     private static long startTime = 0L;
 
-    @Scheduled(cron = "0 5/10 8-18 * * *", zone = "Asia/Seoul") // 학교 공지는 오전 8:10 ~ 오후 6:55분 사이에 20분마다 업데이트 된다.
+    @Scheduled(cron = "0 5/10 8-19 * * *", zone = "Asia/Seoul") // 학교 공지는 오전 8:10 ~ 오후 7:55분 사이에 10분마다 업데이트 된다.
     public void update() {
         log.info("******** 학과별 최신 공지 업데이트 시작 ********");
         startTime = System.currentTimeMillis();
@@ -59,6 +61,10 @@ public class DepartmentNoticeUpdater {
         startTime = System.currentTimeMillis();
 
         for (DeptInfo deptInfo : deptInfoList) {
+            if(deptInfo.isSameDepartment(REAL_ESTATE)) {
+                continue;
+            }
+
             CompletableFuture
                     .supplyAsync(() -> updateDepartmentAsync(deptInfo, DeptInfo::scrapAllPageHtml), noticeUpdaterThreadTaskExecutor)
                     .thenAccept(scrapResults -> compareAllAndUpdateDB(scrapResults, deptInfo.getDeptName()));


### PR DESCRIPTION
부동산 학과의 경우 한번에 모든 공지를 로딩해올수가 없었다.
전체 공지페이지가 68페이지 인데, 68번의 요청을 보내고 있었다.
따라서 부동산 학과의 경우 단일페이지 스크랩만 제공하도록 변경하였다.