### PR TITLE
[fix-#77] Notice의 CategoryName에 대한 외래키 제약조건 제거

### DIFF
--- a/src/main/resources/db/migration/V230823__Delete_notice_foreign_key.sql
+++ b/src/main/resources/db/migration/V230823__Delete_notice_foreign_key.sql
@@ -1,0 +1,1 @@
+alter table notice drop foreign key FK2pjg4hwditxubnvu938yptsck;


### PR DESCRIPTION
close #77 