### PR TITLE
[Fix] FirebaseSubscribeService의 토큰 검증 로직 변경

### DIFF
--- a/src/main/java/com/kustacks/kuring/message/application/service/FirebaseSubscribeService.java
+++ b/src/main/java/com/kustacks/kuring/message/application/service/FirebaseSubscribeService.java
@@ -1,22 +1,21 @@
 package com.kustacks.kuring.message.application.service;
 
-import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.TopicManagementResponse;
 import com.kustacks.kuring.common.annotation.UseCase;
 import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.message.application.port.in.FirebaseWithUserUseCase;
 import com.kustacks.kuring.message.application.port.in.dto.UserSubscribeCommand;
 import com.kustacks.kuring.message.application.port.in.dto.UserUnsubscribeCommand;
-import com.kustacks.kuring.message.application.port.out.FirebaseAuthPort;
+import com.kustacks.kuring.message.application.port.out.FirebaseMessagingPort;
 import com.kustacks.kuring.message.application.port.out.FirebaseSubscribePort;
 import com.kustacks.kuring.message.application.service.exception.FirebaseInvalidTokenException;
 import com.kustacks.kuring.message.application.service.exception.FirebaseSubscribeException;
 import com.kustacks.kuring.message.application.service.exception.FirebaseUnSubscribeException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
 
 @Slf4j
 @UseCase
@@ -26,14 +25,15 @@ public class FirebaseSubscribeService implements FirebaseWithUserUseCase {
     public static final String ALL_DEVICE_SUBSCRIBED_TOPIC = "allDevice";
 
     private final FirebaseSubscribePort firebaseSubscribePort;
-    private final FirebaseAuthPort firebaseAuthPort;
+    private final FirebaseMessagingPort firebaseMessagingPort;
     private final ServerProperties serverProperties;
 
     @Override
     public void validationToken(String token) throws FirebaseInvalidTokenException {
         try {
-            firebaseAuthPort.verifyIdToken(token);
-        } catch (FirebaseAuthException e) {
+            Message message = Message.builder().setToken(token).build();
+            firebaseMessagingPort.send(message);
+        } catch (FirebaseMessagingException e) {
             throw new FirebaseInvalidTokenException();
         }
     }


### PR DESCRIPTION
verifyIdToken의 경우 클라이언트 측에서 별도의 ID 토큰을 생성하여 전달해주어야 하기 때문에 일단 기존의 방식으로 변경한다