### PR TITLE
version 2.6.1

### DIFF
--- a/src/main/java/com/kustacks/kuring/worker/dto/ComplexNoticeFormatDto.java
+++ b/src/main/java/com/kustacks/kuring/worker/dto/ComplexNoticeFormatDto.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Collections;
 import java.util.List;
 
 @Getter
@@ -18,10 +17,5 @@ public class ComplexNoticeFormatDto {
 
     public int getNormalNoticeSize() {
         return normalNoticeList.size();
-    }
-
-    public void reverseEachNoticeList() {
-        Collections.reverse(importantNoticeList);
-        Collections.reverse(normalNoticeList);
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/dto/ScrapingResultDto.java
+++ b/src/main/java/com/kustacks/kuring/worker/dto/ScrapingResultDto.java
@@ -10,5 +10,5 @@ public class ScrapingResultDto {
 
     private Document document;
 
-    private String url;
+    private String viewUrl;
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/DepartmentNoticeScraperTemplate.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/DepartmentNoticeScraperTemplate.java
@@ -32,7 +32,6 @@ public class DepartmentNoticeScraperTemplate {
             }
         }
 
-
         return noticeDtoList;
     }
 
@@ -53,7 +52,7 @@ public class DepartmentNoticeScraperTemplate {
         List<ComplexNoticeFormatDto> noticeDtoList = new LinkedList<>();
         for (ScrapingResultDto reqResult : requestResults) {
             Document document = reqResult.getDocument();
-            String viewUrl = reqResult.getUrl();
+            String viewUrl = reqResult.getViewUrl();
 
             RowsDto rowsDto = deptInfo.parse(document);
             List<CommonNoticeFormatDto> importantNoticeFormatDtos = rowsDto.buildImportantRowList(viewUrl);

--- a/src/main/java/com/kustacks/kuring/worker/scrap/client/notice/KuisNoticeApiClient.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/client/notice/KuisNoticeApiClient.java
@@ -101,6 +101,6 @@ public class KuisNoticeApiClient implements NoticeApiClient<CommonNoticeFormatDt
     private List<CommonNoticeFormatDto> convertToCommonFormatDto(List<KuisNoticeDto> kuisNoticeDtoList) {
         return kuisNoticeDtoList.stream()
                 .map(dto -> (CommonNoticeFormatDto) dtoConverter.convert(dto))
-                .toList();
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/client/notice/LatestPageNoticeApiClient.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/client/notice/LatestPageNoticeApiClient.java
@@ -1,27 +1,28 @@
 package com.kustacks.kuring.worker.scrap.client.notice;
 
-import com.kustacks.kuring.common.exception.code.ErrorCode;
 import com.kustacks.kuring.common.exception.InternalLogicException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.JsoupClient;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.Collections;
 import java.util.List;
 
 @Slf4j
 @Component
 public class LatestPageNoticeApiClient implements NoticeApiClient<ScrapingResultDto, DeptInfo> {
 
-    private static final int PAGE_NUM = 1;    // recentPage는 pageNum 인자가 1부터 시작
-    private static final int ARTICLE_NUMBERS_PER_PAGE = 12;
-    private static final int LATEST_SCRAP_TIMEOUT = 60000; // 1분
-    private static final int LATEST_SCRAP_ALL_TIMEOUT = 120000; // 2분
+    private static final int START_PAGE_NUM = 1; // page는 인자가 1부터 시작
+    private static final int ROW_NUMBERS_PER_PAGE = 20;
+    private static final int LATEST_SCRAP_TIMEOUT = 2000; // 2초
+    private static final int LATEST_SCRAP_ALL_TIMEOUT = 60000; // 1분
 
     private final JsoupClient jsoupClient;
 
@@ -31,68 +32,61 @@ public class LatestPageNoticeApiClient implements NoticeApiClient<ScrapingResult
 
     @Override
     public List<ScrapingResultDto> request(DeptInfo deptInfo) throws InternalLogicException {
-        int size = getDeptInfoSize(deptInfo);
-
-        List<ScrapingResultDto> reqResults = new LinkedList<>();
-        for(int i = 0; i < size; i++) {
-            try {
-                ScrapingResultDto resultDto = getScrapingResultDto(i, deptInfo, ARTICLE_NUMBERS_PER_PAGE, LATEST_SCRAP_TIMEOUT);
-                reqResults.add(resultDto);
-            } catch (IOException e) {
-                throw new InternalLogicException(ErrorCode.NOTICE_SCRAPER_CANNOT_SCRAP, e);
-            } catch (NullPointerException | IndexOutOfBoundsException e) {
-                throw new InternalLogicException(ErrorCode.NOTICE_SCRAPER_CANNOT_PARSE, e);
-            }
+        try {
+            ScrapingResultDto resultDto = getScrapingResultDto(deptInfo, ROW_NUMBERS_PER_PAGE, LATEST_SCRAP_TIMEOUT);
+            return List.of(resultDto);
+        } catch (IOException e) {
+            throw new InternalLogicException(ErrorCode.NOTICE_SCRAPER_CANNOT_SCRAP, e);
+        } catch (NullPointerException | IndexOutOfBoundsException e) {
+            throw new InternalLogicException(ErrorCode.NOTICE_SCRAPER_CANNOT_PARSE, e);
         }
-
-        return reqResults;
     }
 
     @Override
     public List<ScrapingResultDto> requestAll(DeptInfo deptInfo) throws InternalLogicException {
-        int size = getDeptInfoSize(deptInfo);
+        try {
+            String url = buildUrlForTotalNoticeCount(deptInfo);
+            int totalNoticeSize = getTotalNoticeSize(url);
 
-        List<ScrapingResultDto> reqResults = new LinkedList<>();
-        for (int i = 0; i < size; i++) {
-            try {
-                int totalNoticeSize = getTotalNoticeSize(i, deptInfo);
-
-                ScrapingResultDto resultDto = getScrapingResultDto(i, deptInfo, totalNoticeSize, LATEST_SCRAP_ALL_TIMEOUT);
-                reqResults.add(resultDto);
-            } catch (IOException e) {
-                log.info("Department Scrap all IOException: {}", e.getMessage());
-            } catch (NullPointerException | IndexOutOfBoundsException e) {
-                throw new InternalLogicException(ErrorCode.NOTICE_SCRAPER_CANNOT_PARSE, e);
-            }
+            ScrapingResultDto resultDto = getScrapingResultDto(deptInfo, totalNoticeSize, LATEST_SCRAP_ALL_TIMEOUT);
+            return List.of(resultDto);
+        } catch (IOException e) {
+            log.info("Department Scrap all IOException: {}", e.getMessage());
+        } catch (NullPointerException | IndexOutOfBoundsException e) {
+            throw new InternalLogicException(ErrorCode.NOTICE_SCRAPER_CANNOT_PARSE, e);
         }
 
-        return reqResults;
+        return Collections.emptyList();
     }
 
-    private int getDeptInfoSize(DeptInfo deptInfo) {
-        return deptInfo.getNoticeScrapInfo().getBoardSeqs().size();
+    private String buildUrlForTotalNoticeCount(DeptInfo deptInfo) {
+        return deptInfo.createRequestUrl(1, 1);
     }
 
-    private ScrapingResultDto getScrapingResultDto(int index, DeptInfo deptInfo, int totalNoticeSize, int timeout) throws IOException {
-        String requestUrl = deptInfo.createRequestUrl(index, totalNoticeSize, PAGE_NUM);
-        String viewUrl = deptInfo.createViewUrl(index);
-
-        Document document = jsoupClient.get(requestUrl, timeout);
-
-        return new ScrapingResultDto(document, viewUrl);
-    }
-
-    private int getTotalNoticeSize(int index, DeptInfo deptInfo) throws IOException, IndexOutOfBoundsException, NullPointerException {
-        String url = deptInfo.createRequestUrl(index, 1, 1);
-
+    public int getTotalNoticeSize(String url) throws IOException, IndexOutOfBoundsException, NullPointerException {
         Document document = jsoupClient.get(url, LATEST_SCRAP_TIMEOUT);
 
-        Element totalNoticeSizeElement = document.selectFirst(".pl15 > strong");
+        Element totalNoticeSizeElement = document.selectFirst(".util-search strong");
         if (totalNoticeSizeElement == null) {
             totalNoticeSizeElement = document.selectFirst(".total_count");
         }
 
         assert totalNoticeSizeElement != null;
         return Integer.parseInt(totalNoticeSizeElement.ownText());
+    }
+
+    private ScrapingResultDto getScrapingResultDto(DeptInfo deptInfo, int rowSize, int timeout) throws IOException {
+        String requestUrl = deptInfo.createRequestUrl(START_PAGE_NUM, rowSize);
+        String viewUrl = deptInfo.createViewUrl();
+
+        StopWatch stopWatch = new StopWatch(deptInfo.getDeptName() + "Request");
+        stopWatch.start();
+
+        Document document = jsoupClient.get(requestUrl, timeout);
+
+        stopWatch.stop();
+        log.info("[{}] takes {}millis to respond", deptInfo.getDeptName(), stopWatch.getTotalTimeMillis());
+
+        return new ScrapingResultDto(document, viewUrl);
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/DeptInfo.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/DeptInfo.java
@@ -22,7 +22,6 @@ public class DeptInfo {
     protected StaffScrapInfo staffScrapInfo;
     protected DepartmentName departmentName;
     protected String collegeName;
-    protected String code;
 
     public List<ScrapingResultDto> scrapLatestPageHtml() {
         return noticeApiClient.request(this);
@@ -48,26 +47,22 @@ public class DeptInfo {
         return this.staffScrapInfo.getProfessorForumId();
     }
 
-    public String createRequestUrl(int index, int curPage, int pageNum) {
-        return UriComponentsBuilder.fromUriString(latestPageNoticeProperties.getListUrl())
-                .queryParam("siteId", noticeScrapInfo.getSiteId())
-                .queryParam("boardSeq", noticeScrapInfo.getBoardSeqs().get(index))
-                .queryParam("menuSeq", noticeScrapInfo.getMenuSeqs().get(index))
-                .queryParam("curPage", curPage)
-                .queryParam("pageNum", pageNum)
-                .buildAndExpand(departmentName.getHostPrefix())
-                .toUriString();
+    public String createRequestUrl(int page, int row) {
+        return UriComponentsBuilder
+                .fromUriString(latestPageNoticeProperties.getListUrl())
+                .queryParam("page", page)
+                .queryParam("row", row)
+                .buildAndExpand(
+                        noticeScrapInfo.getSiteName(),
+                        noticeScrapInfo.getSiteName(),
+                        noticeScrapInfo.getSiteId()
+                ).toUriString();
     }
 
-    public String createViewUrl(int index) {
-        return UriComponentsBuilder
-                .fromUriString(latestPageNoticeProperties.getViewUrl())
-                .queryParam("siteId", noticeScrapInfo.getSiteId())
-                .queryParam("boardSeq", noticeScrapInfo.getBoardSeqs().get(index))
-                .queryParam("menuSeq", noticeScrapInfo.getMenuSeqs().get(index))
-                .queryParam("seq", "")
-                .buildAndExpand(departmentName.getHostPrefix())
-                .toUriString();
+    public String createViewUrl() {
+        return latestPageNoticeProperties.getViewUrl()
+                .replaceAll("\\{department\\}", noticeScrapInfo.getSiteName())
+                .replace("{siteId}", String.valueOf(noticeScrapInfo.getSiteId()));
     }
 
     @Override

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/NoticeScrapInfo.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/NoticeScrapInfo.java
@@ -2,20 +2,14 @@ package com.kustacks.kuring.worker.scrap.deptinfo;
 
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 public class NoticeScrapInfo {
 
-    private final List<String> forumIds;
-    private final String siteId;
-    private final List<String> boardSeqs;
-    private final List<String> menuSeqs;
+    private final String siteName;
+    private final int siteId;
 
-    public NoticeScrapInfo(List<String> forumIds, String siteId, List<String> boardSeqs, List<String> menuSeqs) {
-        this.forumIds = forumIds;
+    public NoticeScrapInfo(String siteName, int siteId) {
+        this.siteName = siteName;
         this.siteId = siteId;
-        this.boardSeqs = boardSeqs;
-        this.menuSeqs = menuSeqs;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/architecture/ArchitectureDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/architecture/ArchitectureDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.architecture;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ARCHITECTURE)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ARCHITECTURE;
+
+@RegisterDepartmentMap(key = ARCHITECTURE)
 public class ArchitectureDept extends ArchitectureCollege {
 
     public ArchitectureDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class ArchitectureDept extends ArchitectureCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("11830", "17940");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("700");
-        List<String> menuSeqs = List.of("5168");
-
+        List<String> professorForumIds = List.of("9815");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "CAKU", boardSeqs, menuSeqs);
-        this.code = "127320";
-        this.departmentName = DepartmentName.ARCHITECTURE;
+        this.noticeScrapInfo = new NoticeScrapInfo(ARCHITECTURE.getHostPrefix(), 397);
+        this.departmentName = ARCHITECTURE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/ApparelDesignDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/ApparelDesignDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.art_design;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.APPAREL_DESIGN)
+import static com.kustacks.kuring.notice.domain.DepartmentName.APPAREL_DESIGN;
+
+@RegisterDepartmentMap(key = APPAREL_DESIGN)
 public class ApparelDesignDept extends ArtDesignCollege {
 
     public ApparelDesignDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class ApparelDesignDept extends ArtDesignCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("9723");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1007");
-        List<String> menuSeqs = List.of("6987");
-
+        List<String> professorForumIds = List.of("11194");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "APPAREL", boardSeqs, menuSeqs);
-        this.code = "122404";
-        this.departmentName = DepartmentName.APPAREL_DESIGN;
+        this.noticeScrapInfo = new NoticeScrapInfo(APPAREL_DESIGN.getHostPrefix(), 956);
+        this.departmentName = APPAREL_DESIGN;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/CommunicationDesignDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/CommunicationDesignDept.java
@@ -1,36 +1,32 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.art_design;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.COMM_DESIGN)
+import static com.kustacks.kuring.notice.domain.DepartmentName.COMM_DESIGN;
+
+@RegisterDepartmentMap(key = COMM_DESIGN)
 public class CommunicationDesignDept extends ArtDesignCollege {
 
     public CommunicationDesignDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                                   NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                                   NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
         List<String> professorForumIds = Collections.emptyList();
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = Collections.emptyList();
-        List<String> menuSeqs = Collections.emptyList();
-
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "COMMDESIGN", boardSeqs, menuSeqs);
-        this.code = "122402";
-        this.departmentName = DepartmentName.COMM_DESIGN;
+        this.noticeScrapInfo = new NoticeScrapInfo(COMM_DESIGN.getHostPrefix(), 0);
+        this.departmentName = COMM_DESIGN;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/ContemporaryArtDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/ContemporaryArtDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.art_design;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.CONT_ART)
+import static com.kustacks.kuring.notice.domain.DepartmentName.CONT_ART;
+
+@RegisterDepartmentMap(key = CONT_ART)
 public class ContemporaryArtDept extends ArtDesignCollege {
 
     public ContemporaryArtDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class ContemporaryArtDept extends ArtDesignCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("4089");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("986");
-        List<String> menuSeqs = List.of("6805");
-
+        List<String> professorForumIds = List.of("11236");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "CONTEMPORARYART", boardSeqs, menuSeqs);
-        this.code = "122406";
-        this.departmentName = DepartmentName.CONT_ART;
+        this.noticeScrapInfo = new NoticeScrapInfo(CONT_ART.getHostPrefix(), 489);
+        this.departmentName = CONT_ART;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/IndustrialDesignDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/IndustrialDesignDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.art_design;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.IND_DESIGN)
+import static com.kustacks.kuring.notice.domain.DepartmentName.IND_DESIGN;
+
+@RegisterDepartmentMap(key = IND_DESIGN)
 public class IndustrialDesignDept extends ArtDesignCollege {
 
     public IndustrialDesignDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class IndustrialDesignDept extends ArtDesignCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("4085");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("439");
-        List<String> menuSeqs = List.of("3015");
-
+        List<String> professorForumIds = List.of("17316");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "DESIGNID", boardSeqs, menuSeqs);
-        this.code = "122403";
-        this.departmentName = DepartmentName.IND_DESIGN;
+        this.noticeScrapInfo = new NoticeScrapInfo(IND_DESIGN.getHostPrefix(), 4017);
+        this.departmentName = IND_DESIGN;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/LivingDesignDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/LivingDesignDept.java
@@ -1,37 +1,32 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.art_design;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
+import static com.kustacks.kuring.notice.domain.DepartmentName.LIVING_DESIGN;
+
 // 교수 소개 구조 다른 홈페이지와 다름..
-@RegisterDepartmentMap(key = DepartmentName.LIVING_DESIGN)
+@RegisterDepartmentMap(key = LIVING_DESIGN)
 public class LivingDesignDept extends ArtDesignCollege {
 
     public LivingDesignDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                            NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                            NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = Collections.emptyList();
-        List<String> forumIds = List.of("15382254");
-        List<String> boardSeqs = List.of("1512");
-        List<String> menuSeqs = List.of("11325");
-
+        List<String> professorForumIds = List.of("11209");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "LIVINGDESIGN", boardSeqs, menuSeqs);
-        this.code = "126781";
-        this.departmentName = DepartmentName.LIVING_DESIGN;
+        this.noticeScrapInfo = new NoticeScrapInfo(LIVING_DESIGN.getHostPrefix(), 962);
+        this.departmentName = LIVING_DESIGN;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/MovingImageFilmDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/MovingImageFilmDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.art_design;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.MOV_IMAGE)
+import static com.kustacks.kuring.notice.domain.DepartmentName.MOV_IMAGE;
+
+@RegisterDepartmentMap(key = MOV_IMAGE)
 public class MovingImageFilmDept extends ArtDesignCollege {
 
     public MovingImageFilmDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class MovingImageFilmDept extends ArtDesignCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15032480");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("580");
-        List<String> menuSeqs = List.of("4508");
-
+        List<String> professorForumIds = List.of("11263");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "MOVINGIMAGES", boardSeqs, menuSeqs);
-        this.code = "127128";
-        this.departmentName = DepartmentName.MOV_IMAGE;
+        this.noticeScrapInfo = new NoticeScrapInfo(MOV_IMAGE.getHostPrefix(), 491);
+        this.departmentName = MOV_IMAGE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/business/BusinessAdministrationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/business/BusinessAdministrationDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.business;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.BUIS_ADMIN)
+import static com.kustacks.kuring.notice.domain.DepartmentName.BUIS_ADMIN;
+
+@RegisterDepartmentMap(key = BUIS_ADMIN)
 public class BusinessAdministrationDept extends BusinessCollege {
 
     public BusinessAdministrationDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class BusinessAdministrationDept extends BusinessCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("3685475");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("460");
-        List<String> menuSeqs = List.of("3243");
-
+        List<String> professorForumIds = List.of("10499");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "BIZ", boardSeqs, menuSeqs);
-        this.code = "126780";
-        this.departmentName = DepartmentName.BUIS_ADMIN;
+        this.noticeScrapInfo = new NoticeScrapInfo(BUIS_ADMIN.getKorName(), 441);
+        this.departmentName = BUIS_ADMIN;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/business/TechnologicalBusinessDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/business/TechnologicalBusinessDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.business;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.TECH_BUSI)
+import static com.kustacks.kuring.notice.domain.DepartmentName.TECH_BUSI;
+
+@RegisterDepartmentMap(key = TECH_BUSI)
 public class TechnologicalBusinessDept extends BusinessCollege {
 
     public TechnologicalBusinessDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class TechnologicalBusinessDept extends BusinessCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("3511696");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1168");
-        List<String> menuSeqs = List.of("8081");
-
+        List<String> professorForumIds = List.of("10526");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "MOT", boardSeqs, menuSeqs);
-        this.code = "121174";
-        this.departmentName = DepartmentName.TECH_BUSI;
+        this.noticeScrapInfo = new NoticeScrapInfo(TECH_BUSI.getHostPrefix(), 445);
+        this.departmentName = TECH_BUSI;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/EducationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/EducationDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.education;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.EDUCATION)
+import static com.kustacks.kuring.notice.domain.DepartmentName.EDUCATION;
+
+@RegisterDepartmentMap(key = EDUCATION)
 public class EducationDept extends EducationCollege {
 
     public EducationDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class EducationDept extends EducationCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("6238");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("452");
-        List<String> menuSeqs = List.of("3147");
-
+        List<String> professorForumIds = List.of("11444");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "GYOJIK", boardSeqs, menuSeqs);
-        this.code = "105041";
-        this.departmentName = DepartmentName.EDUCATION;
+        this.noticeScrapInfo = new NoticeScrapInfo(EDUCATION.getHostPrefix(), 507);
+        this.departmentName = EDUCATION;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/EducationalTechnologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/EducationalTechnologyDept.java
@@ -1,35 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.education;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.EDU_TECH)
+import static com.kustacks.kuring.notice.domain.DepartmentName.EDU_TECH;
+
+@RegisterDepartmentMap(key = EDU_TECH)
 public class EducationalTechnologyDept extends EducationCollege {
 
     public EducationalTechnologyDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                                     NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                                     NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("5099763");
-        List<String> forumIds = List.of("11707");
-        List<String> boardSeqs = List.of("1462");
-        List<String> menuSeqs = List.of("10740");
-
+        List<String> professorForumIds = List.of("16532");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "EDUTECH", boardSeqs, menuSeqs);
-        this.code = "105031";
-        this.departmentName = DepartmentName.EDU_TECH;
+        this.noticeScrapInfo = new NoticeScrapInfo(EDU_TECH.getHostPrefix(), 4020);
+        this.departmentName = EDU_TECH;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/EnglishEducationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/EnglishEducationDept.java
@@ -1,35 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.education;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ENGLISH_EDU)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ENGLISH_EDU;
+
+@RegisterDepartmentMap(key = ENGLISH_EDU)
 public class EnglishEducationDept extends EducationCollege {
 
     public EnglishEducationDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                                NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                                NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("12930");
-        List<String> forumIds = List.of("12927");
-        List<String> boardSeqs = List.of("1539");
-        List<String> menuSeqs = List.of("11460");
-
+        List<String> professorForumIds = List.of("11411");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "ENGLISHEDU", boardSeqs, menuSeqs);
-        this.code = "121175";
-        this.departmentName = DepartmentName.ENGLISH_EDU;
+        this.noticeScrapInfo = new NoticeScrapInfo(ENGLISH_EDU.getHostPrefix(), 505);
+        this.departmentName = ENGLISH_EDU;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/JapaneseLanguageDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/JapaneseLanguageDept.java
@@ -1,36 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.education;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.JAPANESE_EDU)
+import static com.kustacks.kuring.notice.domain.DepartmentName.JAPANESE_EDU;
+
+@RegisterDepartmentMap(key = JAPANESE_EDU)
 public class JapaneseLanguageDept extends EducationCollege {
 
     public JapaneseLanguageDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                                NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                                NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("12706");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1092");
-        List<String> menuSeqs = List.of("7643");
-
+        List<String> professorForumIds = List.of("11307");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "JAPAN", boardSeqs, menuSeqs);
-        this.code = "104981";
-        this.departmentName = DepartmentName.JAPANESE_EDU;
+        this.noticeScrapInfo = new NoticeScrapInfo(JAPANESE_EDU.getHostPrefix(), 497);
+        this.departmentName = JAPANESE_EDU;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/MathematicsEducationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/MathematicsEducationDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.education;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.MATH_EDU)
+import static com.kustacks.kuring.notice.domain.DepartmentName.MATH_EDU;
+
+@RegisterDepartmentMap(key = MATH_EDU)
 public class MathematicsEducationDept extends EducationCollege {
 
     public MathematicsEducationDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class MathematicsEducationDept extends EducationCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("4037");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1105");
-        List<String> menuSeqs = List.of("7747");
-
+        List<String> professorForumIds = List.of("11335");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "MATHEDU", boardSeqs, menuSeqs);
-        this.code = "104991";
-        this.departmentName = DepartmentName.MATH_EDU;
+        this.noticeScrapInfo = new NoticeScrapInfo(MATH_EDU.getHostPrefix(), 499);
+        this.departmentName = MATH_EDU;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/MusicEducationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/MusicEducationDept.java
@@ -1,35 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.education;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.MUSIC_EDU)
+import static com.kustacks.kuring.notice.domain.DepartmentName.MUSIC_EDU;
+
+@RegisterDepartmentMap(key = MUSIC_EDU)
 public class MusicEducationDept extends EducationCollege {
 
     public MusicEducationDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                              NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                              NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("9803");
-        List<String> forumIds = List.of("9801");
-        List<String> boardSeqs = List.of("1621");
-        List<String> menuSeqs = List.of("11972");
-
+        List<String> professorForumIds = List.of("11383");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "MUSIC", boardSeqs, menuSeqs);
-        this.code = "105011";
-        this.departmentName = DepartmentName.MUSIC_EDU;
+        this.noticeScrapInfo = new NoticeScrapInfo(MUSIC_EDU.getHostPrefix(), 503);
+        this.departmentName = MUSIC_EDU;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/PhysicalEducationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/PhysicalEducationDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.education;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.PHY_EDU)
+import static com.kustacks.kuring.notice.domain.DepartmentName.PHY_EDU;
+
+@RegisterDepartmentMap(key = PHY_EDU)
 public class PhysicalEducationDept extends EducationCollege {
 
     public PhysicalEducationDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class PhysicalEducationDept extends EducationCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("5703");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1097");
-        List<String> menuSeqs = List.of("7701");
-
+        List<String> professorForumIds = List.of("11357");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "KUPE", boardSeqs, menuSeqs);
-        this.code = "105001";
-        this.departmentName = DepartmentName.PHY_EDU;
+        this.noticeScrapInfo = new NoticeScrapInfo(PHY_EDU.getHostPrefix(), 501);
+        this.departmentName = PHY_EDU;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/AdvancedIndustrialFusionDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/AdvancedIndustrialFusionDept.java
@@ -1,36 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ADV_INDUSTRIAL)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ADV_INDUSTRIAL;
+
+@RegisterDepartmentMap(key = ADV_INDUSTRIAL)
 public class AdvancedIndustrialFusionDept extends EngineeringCollege {
 
     public AdvancedIndustrialFusionDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                                        NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                                        NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("4113024");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1109");
-        List<String> menuSeqs = List.of("7794");
-
+        List<String> professorForumIds = List.of("10085");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "AIF", boardSeqs, menuSeqs);
-        this.code = "127431";
-        this.departmentName = DepartmentName.ADV_INDUSTRIAL;
+        this.noticeScrapInfo = new NoticeScrapInfo(ADV_INDUSTRIAL.getHostPrefix(), 415);
+        this.departmentName = ADV_INDUSTRIAL;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/BiologicalDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/BiologicalDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.BIOLOGICAL)
+import static com.kustacks.kuring.notice.domain.DepartmentName.BIOLOGICAL;
+
+@RegisterDepartmentMap(key = BIOLOGICAL)
 public class BiologicalDept extends EngineeringCollege {
 
     public BiologicalDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class BiologicalDept extends EngineeringCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("7849");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1131");
-        List<String> menuSeqs = List.of("7888");
-
+        List<String> professorForumIds = List.of("10097");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "MICROBIO", boardSeqs, menuSeqs);
-        this.code = "122055";
-        this.departmentName = DepartmentName.BIOLOGICAL;
+        this.noticeScrapInfo = new NoticeScrapInfo(BIOLOGICAL.getHostPrefix(), 790);
+        this.departmentName = BIOLOGICAL;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ChemicalDivisionDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ChemicalDivisionDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.CHEMI_DIV)
+import static com.kustacks.kuring.notice.domain.DepartmentName.CHEMI_DIV;
+
+@RegisterDepartmentMap(key = CHEMI_DIV)
 public class ChemicalDivisionDept extends EngineeringCollege {
     
     public ChemicalDivisionDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class ChemicalDivisionDept extends EngineeringCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("18611422");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("228");
-        List<String> menuSeqs = List.of("1871");
-
+        List<String> professorForumIds = List.of("9926");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "CHEMENG", boardSeqs, menuSeqs);
-        this.code = "127111";
-        this.departmentName = DepartmentName.CHEMI_DIV;
+        this.noticeScrapInfo = new NoticeScrapInfo(CHEMI_DIV.getHostPrefix(), 409);
+        this.departmentName = CHEMI_DIV;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/CivilEnvironmentDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/CivilEnvironmentDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.CIVIL_ENV)
+import static com.kustacks.kuring.notice.domain.DepartmentName.CIVIL_ENV;
+
+@RegisterDepartmentMap(key = CIVIL_ENV)
 public class CivilEnvironmentDept extends EngineeringCollege {
     
     public CivilEnvironmentDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class CivilEnvironmentDept extends EngineeringCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("6308");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1049");
-        List<String> menuSeqs = List.of("7353");
-
+        List<String> professorForumIds = List.of("10022");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "CIVILENV", boardSeqs, menuSeqs);
-        this.code = "127108";
-        this.departmentName = DepartmentName.CIVIL_ENV;
+        this.noticeScrapInfo = new NoticeScrapInfo(CIVIL_ENV.getHostPrefix(), 401);
+        this.departmentName = CIVIL_ENV;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ComputerScienceDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ComputerScienceDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.COMPUTER)
+import static com.kustacks.kuring.notice.domain.DepartmentName.COMPUTER;
+
+@RegisterDepartmentMap(key = COMPUTER)
 public class ComputerScienceDept extends EngineeringCollege {
 
     public ComputerScienceDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class ComputerScienceDept extends EngineeringCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("12351719");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("882");
-        List<String> menuSeqs = List.of("6097");
-
+        List<String> professorForumIds = List.of("9938");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "CSE", boardSeqs, menuSeqs);
-        this.code = "127428";
-        this.departmentName = DepartmentName.COMPUTER;
+        this.noticeScrapInfo = new NoticeScrapInfo(COMPUTER.getHostPrefix(), 775);
+        this.departmentName = COMPUTER;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ElectricalElectronicsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ElectricalElectronicsDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ELEC_ELEC)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ELEC_ELEC;
+
+@RegisterDepartmentMap(key = ELEC_ELEC)
 public class ElectricalElectronicsDept extends EngineeringCollege {
 
     public ElectricalElectronicsDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class ElectricalElectronicsDept extends EngineeringCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("18634838");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("424");
-        List<String> menuSeqs = List.of("2837");
-
+        List<String> professorForumIds = List.of("10962");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "EE", boardSeqs, menuSeqs);
-        this.code = "127110";
-        this.departmentName = DepartmentName.ELEC_ELEC;
+        this.noticeScrapInfo = new NoticeScrapInfo(ELEC_ELEC.getHostPrefix(), 407);
+        this.departmentName = ELEC_ELEC;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/IndustrialDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/IndustrialDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.INDUSTRIAL)
+import static com.kustacks.kuring.notice.domain.DepartmentName.INDUSTRIAL;
+
+@RegisterDepartmentMap(key = INDUSTRIAL)
 public class IndustrialDept extends EngineeringCollege {
 
     public IndustrialDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class IndustrialDept extends EngineeringCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("4930");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("840");
-        List<String> menuSeqs = List.of("5857");
-
+        List<String> professorForumIds = List.of("9972");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "KIES", boardSeqs, menuSeqs);
-        this.code = "127430";
-        this.departmentName = DepartmentName.INDUSTRIAL;
+        this.noticeScrapInfo = new NoticeScrapInfo(INDUSTRIAL.getHostPrefix(), 413);
+        this.departmentName = INDUSTRIAL;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/KBeautyIndustryFusionDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/KBeautyIndustryFusionDept.java
@@ -1,35 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.KBEAUTY)
+import static com.kustacks.kuring.notice.domain.DepartmentName.KBEAUTY;
+
+@RegisterDepartmentMap(key = KBEAUTY)
 public class KBeautyIndustryFusionDept extends EngineeringCollege {
     
     public KBeautyIndustryFusionDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                                     NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                                     NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("17275625");
-        List<String> forumIds = List.of("17258184");
-        List<String> boardSeqs = List.of("1552");
-        List<String> menuSeqs = List.of("11545");
-
+        List<String> professorForumIds = List.of("10127");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "KBEAUTY", boardSeqs, menuSeqs);
-        this.code = "127432";
-        this.departmentName = DepartmentName.KBEAUTY;
+        this.noticeScrapInfo = new NoticeScrapInfo(KBEAUTY.getHostPrefix(), 419);
+        this.departmentName = KBEAUTY;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/MechanicalAerospaceDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/MechanicalAerospaceDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.MECH_AERO)
+import static com.kustacks.kuring.notice.domain.DepartmentName.MECH_AERO;
+
+@RegisterDepartmentMap(key = MECH_AERO)
 public class MechanicalAerospaceDept extends EngineeringCollege {
 
     public MechanicalAerospaceDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -24,13 +24,8 @@ public class MechanicalAerospaceDept extends EngineeringCollege {
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
         List<String> professorForumIds = List.of("20565480");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("988");
-        List<String> menuSeqs = List.of("6823");
-
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "MAE", boardSeqs, menuSeqs);
-        this.code = "127427";
-        this.departmentName = DepartmentName.MECH_AERO;
+        this.noticeScrapInfo = new NoticeScrapInfo(MECH_AERO.getHostPrefix(), 405);
+        this.departmentName = MECH_AERO;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/BioMedicalScienceDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/BioMedicalScienceDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.BIO_MEDICAL)
+import static com.kustacks.kuring.notice.domain.DepartmentName.BIO_MEDICAL;
+
+@RegisterDepartmentMap(key = BIO_MEDICAL)
 public class BioMedicalScienceDept extends KuIntegratedScienceCollege {
 
     public BioMedicalScienceDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class BioMedicalScienceDept extends KuIntegratedScienceCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15602966");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("291");
-        List<String> menuSeqs = List.of("2199");
-
+        List<String> professorForumIds = List.of("10770");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "BMSE", boardSeqs, menuSeqs);
-        this.code = "126918";
-        this.departmentName = DepartmentName.BIO_MEDICAL;
+        this.noticeScrapInfo = new NoticeScrapInfo(BIO_MEDICAL.getHostPrefix(), 880);
+        this.departmentName = BIO_MEDICAL;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/CosmeticsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/CosmeticsDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.COSMETICS)
+import static com.kustacks.kuring.notice.domain.DepartmentName.COSMETICS;
+
+@RegisterDepartmentMap(key = COSMETICS)
 public class CosmeticsDept extends KuIntegratedScienceCollege {
 
     public CosmeticsDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class CosmeticsDept extends KuIntegratedScienceCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15623085");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("297");
-        List<String> menuSeqs = List.of("2251");
-
+        List<String> professorForumIds = List.of("15930");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "COSMETICS", boardSeqs, menuSeqs);
-        this.code = "126916";
-        this.departmentName = DepartmentName.COSMETICS;
+        this.noticeScrapInfo = new NoticeScrapInfo(COSMETICS.getHostPrefix(), 457);
+        this.departmentName = COSMETICS;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/EnergyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/EnergyDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ENERGY)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ENERGY;
+
+@RegisterDepartmentMap(key = ENERGY)
 public class EnergyDept extends KuIntegratedScienceCollege {
 
     public EnergyDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class EnergyDept extends KuIntegratedScienceCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15618550");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("417");
-        List<String> menuSeqs = List.of("2759");
-
+        List<String> professorForumIds = List.of("10614");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "ENERGY", boardSeqs, menuSeqs);
-        this.code = "126913";
-        this.departmentName = DepartmentName.ENERGY;
+        this.noticeScrapInfo = new NoticeScrapInfo(ENERGY.getHostPrefix(), 451);
+        this.departmentName = ENERGY;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/IntergrativeBioscienceBiotechnologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/IntergrativeBioscienceBiotechnologyDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.INT_BIO_TECH)
+import static com.kustacks.kuring.notice.domain.DepartmentName.INT_BIO_TECH;
+
+@RegisterDepartmentMap(key = INT_BIO_TECH)
 public class IntergrativeBioscienceBiotechnologyDept extends KuIntegratedScienceCollege {
 
     public IntergrativeBioscienceBiotechnologyDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class IntergrativeBioscienceBiotechnologyDept extends KuIntegratedScience
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("14570494");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1154");
-        List<String> menuSeqs = List.of("8002");
-
+        List<String> professorForumIds = List.of("10837");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "IBB", boardSeqs, menuSeqs);
-        this.code = "126920";
-        this.departmentName = DepartmentName.INT_BIO_TECH;
+        this.noticeScrapInfo = new NoticeScrapInfo(INT_BIO_TECH.getHostPrefix(), 895);
+        this.departmentName = INT_BIO_TECH;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/SmartIctConvergenceDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/SmartIctConvergenceDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.SMART_ICT)
+import static com.kustacks.kuring.notice.domain.DepartmentName.SMART_ICT;
+
+@RegisterDepartmentMap(key = SMART_ICT)
 public class SmartIctConvergenceDept extends KuIntegratedScienceCollege {
 
     public SmartIctConvergenceDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class SmartIctConvergenceDept extends KuIntegratedScienceCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15596417");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("401");
-        List<String> menuSeqs = List.of("2632");
-
+        List<String> professorForumIds = List.of("10673");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "SICTE", boardSeqs, menuSeqs);
-        this.code = "126915";
-        this.departmentName = DepartmentName.SMART_ICT;
+        this.noticeScrapInfo = new NoticeScrapInfo(SMART_ICT.getHostPrefix(), 455);
+        this.departmentName = SMART_ICT;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/SmartVehicleDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/SmartVehicleDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.SMART_VEHICLE)
+import static com.kustacks.kuring.notice.domain.DepartmentName.SMART_VEHICLE;
+
+@RegisterDepartmentMap(key = SMART_VEHICLE)
 public class SmartVehicleDept extends KuIntegratedScienceCollege {
 
     public SmartVehicleDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class SmartVehicleDept extends KuIntegratedScienceCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15883304");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("405");
-        List<String> menuSeqs = List.of("2681");
-
+        List<String> professorForumIds = List.of("10656");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "SMARTVEHICLE", boardSeqs, menuSeqs);
-        this.code = "126914";
-        this.departmentName = DepartmentName.SMART_VEHICLE;
+        this.noticeScrapInfo = new NoticeScrapInfo(SMART_VEHICLE.getHostPrefix(), 453);
+        this.departmentName = SMART_VEHICLE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/StemCellRegenerativeBioTechnologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/StemCellRegenerativeBioTechnologyDept.java
@@ -1,35 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.STEM_REGEN)
+import static com.kustacks.kuring.notice.domain.DepartmentName.STEM_REGEN;
+
+@RegisterDepartmentMap(key = STEM_REGEN)
 public class StemCellRegenerativeBioTechnologyDept extends KuIntegratedScienceCollege {
 
     public StemCellRegenerativeBioTechnologyDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                                                 NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                                                 NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("14914654");
-        List<String> forumIds = List.of("14901014", "14904868");
-        List<String> boardSeqs = List.of("1518");
-        List<String> menuSeqs = List.of("11307");
-
+        List<String> professorForumIds = List.of("10744");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "SCRB", boardSeqs, menuSeqs);
-        this.code = "126917";
-        this.departmentName = DepartmentName.STEM_REGEN;
+        this.noticeScrapInfo = new NoticeScrapInfo(STEM_REGEN.getHostPrefix(), 876);
+        this.departmentName = STEM_REGEN;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/SystemBiotechnologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/SystemBiotechnologyDept.java
@@ -1,35 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.SYSTEM_BIO_TECH)
+import static com.kustacks.kuring.notice.domain.DepartmentName.SYSTEM_BIO_TECH;
+
+@RegisterDepartmentMap(key = SYSTEM_BIO_TECH)
 public class SystemBiotechnologyDept extends KuIntegratedScienceCollege {
 
     public SystemBiotechnologyDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                                   NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                                   NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("14795511");
-        List<String> forumIds = List.of("14715702");
-        List<String> boardSeqs = List.of("1544");
-        List<String> menuSeqs = List.of("11499");
-
+        List<String> professorForumIds = List.of("10810");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "KUSYSBT", boardSeqs, menuSeqs);
-        this.code = "126919";
-        this.departmentName = DepartmentName.SYSTEM_BIO_TECH;
+        this.noticeScrapInfo = new NoticeScrapInfo(SYSTEM_BIO_TECH.getHostPrefix(), 887);
+        this.departmentName = SYSTEM_BIO_TECH;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/ChineseDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/ChineseDept.java
@@ -1,35 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.CHINESE)
+import static com.kustacks.kuring.notice.domain.DepartmentName.CHINESE;
+
+@RegisterDepartmentMap(key = CHINESE)
 public class ChineseDept extends LiberalArtCollege {
 
     public ChineseDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                       NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                       NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("3086");
-        List<String> forumIds = List.of("5335");
-        List<String> boardSeqs = List.of("1606");
-        List<String> menuSeqs = List.of("12182");
-
+        List<String> professorForumIds = List.of("3989");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "CHINALL", boardSeqs, menuSeqs);
-        this.code = "121255";
-        this.departmentName = DepartmentName.CHINESE;
+        this.noticeScrapInfo = new NoticeScrapInfo(CHINESE.getHostPrefix(), 353);
+        this.departmentName = CHINESE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/CultureContentDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/CultureContentDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.CULTURE_CONT)
+import static com.kustacks.kuring.notice.domain.DepartmentName.CULTURE_CONT;
+
+@RegisterDepartmentMap(key = CULTURE_CONT)
 public class CultureContentDept extends LiberalArtCollege {
 
     public CultureContentDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class CultureContentDept extends LiberalArtCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("89388", "3934522", "14064096");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1060");
-        List<String> menuSeqs = List.of("7489");
-
+        List<String> professorForumIds = List.of("8001");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "CULTURECONTENTS", boardSeqs, menuSeqs);
-        this.code = "121259";
-        this.departmentName = DepartmentName.CULTURE_CONT;
+        this.noticeScrapInfo = new NoticeScrapInfo(CULTURE_CONT.getHostPrefix(), 661);
+        this.departmentName = CULTURE_CONT;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/EnglishDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/EnglishDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ENGLISH)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ENGLISH;
+
+@RegisterDepartmentMap(key = ENGLISH)
 public class EnglishDept extends LiberalArtCollege {
 
     public EnglishDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class EnglishDept extends LiberalArtCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("7603");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("590");
-        List<String> menuSeqs = List.of("4595");
-
+        List<String> professorForumIds = List.of("3886");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "ENGLISH", boardSeqs, menuSeqs);
-        this.code = "121254";
-        this.departmentName = DepartmentName.ENGLISH;
+        this.noticeScrapInfo = new NoticeScrapInfo(ENGLISH.getHostPrefix(), 347);
+        this.departmentName = ENGLISH;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/GeologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/GeologyDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.GEOLOGY)
+import static com.kustacks.kuring.notice.domain.DepartmentName.GEOLOGY;
+
+@RegisterDepartmentMap(key = GEOLOGY)
 public class GeologyDept extends LiberalArtCollege {
 
     public GeologyDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class GeologyDept extends LiberalArtCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("7781");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1036");
-        List<String> menuSeqs = List.of("7218");
-
+        List<String> professorForumIds = List.of("11509");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "KUGEO", boardSeqs, menuSeqs);
-        this.code = "127107";
-        this.departmentName = DepartmentName.GEOLOGY;
+        this.noticeScrapInfo = new NoticeScrapInfo(GEOLOGY.getHostPrefix(), 373);
+        this.departmentName = GEOLOGY;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/HistoryDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/HistoryDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.HISTORY)
+import static com.kustacks.kuring.notice.domain.DepartmentName.HISTORY;
+
+@RegisterDepartmentMap(key = HISTORY)
 public class HistoryDept extends LiberalArtCollege {
 
     public HistoryDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class HistoryDept extends LiberalArtCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("10839");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1259");
-        List<String> menuSeqs = List.of("8802");
-
+        List<String> professorForumIds = List.of("4110");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "KHISTORY", boardSeqs, menuSeqs);
-        this.code = "121257";
-        this.departmentName = DepartmentName.HISTORY;
+        this.noticeScrapInfo = new NoticeScrapInfo(HISTORY.getHostPrefix(), 361);
+        this.departmentName = HISTORY;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/KoreanDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/KoreanDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.KOREAN)
+import static com.kustacks.kuring.notice.domain.DepartmentName.KOREAN;
+
+@RegisterDepartmentMap(key = KOREAN)
 public class KoreanDept extends LiberalArtCollege {
 
     public KoreanDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class KoreanDept extends LiberalArtCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("31204");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("506");
-        List<String> menuSeqs = List.of("3681");
-
+        List<String> professorForumIds = List.of("3815");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "KOREA", boardSeqs, menuSeqs);
-        this.code = "121253";
-        this.departmentName = DepartmentName.KOREAN;
+        this.noticeScrapInfo = new NoticeScrapInfo(KOREAN.getHostPrefix(), 334);
+        this.departmentName = KOREAN;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/MediaCommunicationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/MediaCommunicationDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.MEDIA_COMM)
+import static com.kustacks.kuring.notice.domain.DepartmentName.MEDIA_COMM;
+
+@RegisterDepartmentMap(key = MEDIA_COMM)
 public class MediaCommunicationDept extends LiberalArtCollege {
 
     public MediaCommunicationDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class MediaCommunicationDept extends LiberalArtCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("11939245");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1043");
-        List<String> menuSeqs = List.of("7275");
-
+        List<String> professorForumIds = List.of("7879");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "COMM", boardSeqs, menuSeqs);
-        this.code = "122281";
-        this.departmentName = DepartmentName.MEDIA_COMM;
+        this.noticeScrapInfo = new NoticeScrapInfo(MEDIA_COMM.getHostPrefix(), 375);
+        this.departmentName = MEDIA_COMM;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/PhilosophyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/PhilosophyDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.PHILOSOPHY)
+import static com.kustacks.kuring.notice.domain.DepartmentName.PHILOSOPHY;
+
+@RegisterDepartmentMap(key = PHILOSOPHY)
 public class PhilosophyDept extends LiberalArtCollege {
 
     public PhilosophyDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class PhilosophyDept extends LiberalArtCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("8564");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1238");
-        List<String> menuSeqs = List.of("8686");
-
+        List<String> professorForumIds = List.of("4046");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "PHILO", boardSeqs, menuSeqs);
-        this.code = "121256";
-        this.departmentName = DepartmentName.PHILOSOPHY;
+        this.noticeScrapInfo = new NoticeScrapInfo(PHILOSOPHY.getHostPrefix(), 356);
+        this.departmentName = PHILOSOPHY;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/real_estate/RealEstateDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/real_estate/RealEstateDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.real_estate;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.REAL_ESTATE)
+import static com.kustacks.kuring.notice.domain.DepartmentName.REAL_ESTATE;
+
+@RegisterDepartmentMap(key = REAL_ESTATE)
 public class RealEstateDept extends RealEstateCollege {
 
     // 부동산학과는 교수진 정보를 렌더링하는 방법이 다름. 따라서 pfForumId 인자를 전달하지 않았다.
@@ -24,14 +24,9 @@ public class RealEstateDept extends RealEstateCollege {
         this.htmlParser = realEstateNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = Collections.emptyList();
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = Collections.emptyList();
-        List<String> menuSeqs = Collections.emptyList();
-
+        List<String> professorForumIds = List.of("13949");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "REALESTATE", boardSeqs, menuSeqs);
-        this.code = "127426";
-        this.departmentName = DepartmentName.REAL_ESTATE;
+        this.noticeScrapInfo = new NoticeScrapInfo(REAL_ESTATE.getHostPrefix(), 1563);
+        this.departmentName = REAL_ESTATE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/AnimalResourcesFoodScienceBiotechnologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/AnimalResourcesFoodScienceBiotechnologyDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_biology;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ANIMAL_RESOURCES)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ANIMAL_RESOURCES;
+
+@RegisterDepartmentMap(key = ANIMAL_RESOURCES)
 public class AnimalResourcesFoodScienceBiotechnologyDept extends SanghuoBiologyCollege {
 
     public AnimalResourcesFoodScienceBiotechnologyDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class AnimalResourcesFoodScienceBiotechnologyDept extends SanghuoBiologyC
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15632573");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("202");
-        List<String> menuSeqs = List.of("1560");
-
+        List<String> professorForumIds = List.of("11016");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "FOODBIO", boardSeqs, menuSeqs);
-        this.code = "126909";
-        this.departmentName = DepartmentName.ANIMAL_RESOURCES;
+        this.noticeScrapInfo = new NoticeScrapInfo(ANIMAL_RESOURCES.getHostPrefix(), 923);
+        this.departmentName = ANIMAL_RESOURCES;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/AnimalScienceTechnologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/AnimalScienceTechnologyDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_biology;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ANIMAL_SCIENCE)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ANIMAL_SCIENCE;
+
+@RegisterDepartmentMap(key = ANIMAL_SCIENCE)
 public class AnimalScienceTechnologyDept extends SanghuoBiologyCollege {
 
     public AnimalScienceTechnologyDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class AnimalScienceTechnologyDept extends SanghuoBiologyCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("17673919");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("82");
-        List<String> menuSeqs = List.of("797");
-
+        List<String> professorForumIds = List.of("10902");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "ANIS", boardSeqs, menuSeqs);
-        this.code = "126907";
-        this.departmentName = DepartmentName.ANIMAL_SCIENCE;
+        this.noticeScrapInfo = new NoticeScrapInfo(ANIMAL_SCIENCE.getHostPrefix(), 914);
+        this.departmentName = ANIMAL_SCIENCE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/BiologicalSciencesDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/BiologicalSciencesDept.java
@@ -1,21 +1,21 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_biology;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
+
+import static com.kustacks.kuring.notice.domain.DepartmentName.BIO_SCIENCE;
 
 // 생명과학특성학과의 baseUrl = http://www.konkuk.ac.kr/cms/Common/MessageBoard/ArticleList.do
 // 생명과학특성학과는 게시글 링크를 비공개로 해놔서 파싱할 수가 없음. 그래서 forumIds를 주석처리해둠.
-@RegisterDepartmentMap(key = DepartmentName.BIO_SCIENCE)
+@RegisterDepartmentMap(key = BIO_SCIENCE)
 public class BiologicalSciencesDept extends SanghuoBiologyCollege {
 
     public BiologicalSciencesDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -25,14 +25,9 @@ public class BiologicalSciencesDept extends SanghuoBiologyCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("6182");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = Collections.emptyList();
-        List<String> menuSeqs = Collections.emptyList();
-
+        List<String> professorForumIds = List.of("10864");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "BIOSCIENCE", boardSeqs, menuSeqs);
-        this.code = "126906";
-        this.departmentName = DepartmentName.BIO_SCIENCE;
+        this.noticeScrapInfo = new NoticeScrapInfo(BIO_SCIENCE.getHostPrefix(), 909);
+        this.departmentName = BIO_SCIENCE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/CropScienceDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/CropScienceDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_biology;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.CROP_SCIENCE)
+import static com.kustacks.kuring.notice.domain.DepartmentName.CROP_SCIENCE;
+
+@RegisterDepartmentMap(key = CROP_SCIENCE)
 public class CropScienceDept extends SanghuoBiologyCollege {
 
     public CropScienceDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class CropScienceDept extends SanghuoBiologyCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15766997");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("190");
-        List<String> menuSeqs = List.of("1454");
-
+        List<String> professorForumIds = List.of("10939");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "CROPSCIENCE", boardSeqs, menuSeqs);
-        this.code = "126908";
-        this.departmentName = DepartmentName.CROP_SCIENCE;
+        this.noticeScrapInfo = new NoticeScrapInfo(CROP_SCIENCE.getHostPrefix(), 471);
+        this.departmentName = CROP_SCIENCE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/EnvironmentalHealthScienceDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/EnvironmentalHealthScienceDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_biology;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ENV_HEALTH_SCIENCE)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ENV_HEALTH_SCIENCE;
+
+@RegisterDepartmentMap(key = ENV_HEALTH_SCIENCE)
 public class EnvironmentalHealthScienceDept extends SanghuoBiologyCollege {
 
     public EnvironmentalHealthScienceDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class EnvironmentalHealthScienceDept extends SanghuoBiologyCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("13900359");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("267");
-        List<String> menuSeqs = List.of("2059");
-
+        List<String> professorForumIds = List.of("11062");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "HEALTHENV", boardSeqs, menuSeqs);
-        this.code = "126911";
-        this.departmentName = DepartmentName.ENV_HEALTH_SCIENCE;
+        this.noticeScrapInfo = new NoticeScrapInfo(ENV_HEALTH_SCIENCE.getHostPrefix(), 477);
+        this.departmentName = ENV_HEALTH_SCIENCE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/FoodMarketingSafetyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/FoodMarketingSafetyDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_biology;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.FOOD_MARKETING)
+import static com.kustacks.kuring.notice.domain.DepartmentName.FOOD_MARKETING;
+
+@RegisterDepartmentMap(key = FOOD_MARKETING)
 public class FoodMarketingSafetyDept extends SanghuoBiologyCollege {
 
     public FoodMarketingSafetyDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class FoodMarketingSafetyDept extends SanghuoBiologyCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15827578");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("262");
-        List<String> menuSeqs = List.of("2004");
-
+        List<String> professorForumIds = List.of("11029");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "KUFSM", boardSeqs, menuSeqs);
-        this.code = "126910";
-        this.departmentName = DepartmentName.FOOD_MARKETING;
+        this.noticeScrapInfo = new NoticeScrapInfo(FOOD_MARKETING.getHostPrefix(), 929);
+        this.departmentName = FOOD_MARKETING;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/ForestryLandscapeArchitectureDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/ForestryLandscapeArchitectureDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_biology;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.FORESTRY_LANDSCAPE_ARCH)
+import static com.kustacks.kuring.notice.domain.DepartmentName.FORESTRY_LANDSCAPE_ARCH;
+
+@RegisterDepartmentMap(key = FORESTRY_LANDSCAPE_ARCH)
 public class ForestryLandscapeArchitectureDept extends SanghuoBiologyCollege {
 
     public ForestryLandscapeArchitectureDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class ForestryLandscapeArchitectureDept extends SanghuoBiologyCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15766919");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("413");
-        List<String> menuSeqs = List.of("2729");
-
+        List<String> professorForumIds = List.of("11103");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "FLA", boardSeqs, menuSeqs);
-        this.code = "126912";
-        this.departmentName = DepartmentName.FORESTRY_LANDSCAPE_ARCH;
+        this.noticeScrapInfo = new NoticeScrapInfo(FORESTRY_LANDSCAPE_ARCH.getHostPrefix(), 479);
+        this.departmentName = FORESTRY_LANDSCAPE_ARCH;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_elective/ElectiveEducationCenterDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_elective/ElectiveEducationCenterDept.java
@@ -1,35 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_elective;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ELE_EDU_CENTER)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ELE_EDU_CENTER;
+
+@RegisterDepartmentMap(key = ELE_EDU_CENTER)
 public class ElectiveEducationCenterDept extends SanghuoCollege {
 
     public ElectiveEducationCenterDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                                       NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                                       NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("12886454");
-        List<String> forumIds = List.of("8281581");
-        List<String> boardSeqs = List.of("1564");
-        List<String> menuSeqs = List.of("13921");
-
+        List<String> professorForumIds = List.of("11471");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "SGEDU", boardSeqs, menuSeqs);
-        this.code = "126952";
-        this.departmentName = DepartmentName.ELE_EDU_CENTER;
+        this.noticeScrapInfo = new NoticeScrapInfo(ELE_EDU_CENTER.getHostPrefix(), 509);
+        this.departmentName = ELE_EDU_CENTER;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_elective/VolunteerCenterDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_elective/VolunteerCenterDept.java
@@ -1,20 +1,21 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_elective;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.Collections;
 import java.util.List;
 
+import static com.kustacks.kuring.notice.domain.DepartmentName.VOLUNTEER;
+
 // TODO: 교직원 스크랩 시 장애가 되지 않는지 확인 필요
-@RegisterDepartmentMap(key = DepartmentName.VOLUNTEER)
+@RegisterDepartmentMap(key = VOLUNTEER)
 public class VolunteerCenterDept extends SanghuoCollege {
 
     public VolunteerCenterDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -25,13 +26,8 @@ public class VolunteerCenterDept extends SanghuoCollege {
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
         List<String> professorForumIds = Collections.emptyList();
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("773");
-        List<String> menuSeqs = List.of("5528");
-
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "VOLUNTEER", boardSeqs, menuSeqs);
-        this.code = "127424";
-        this.departmentName = DepartmentName.VOLUNTEER;
+        this.noticeScrapInfo = new NoticeScrapInfo(VOLUNTEER.getHostPrefix(), 523);
+        this.departmentName = VOLUNTEER;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/science/ChemicalsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/science/ChemicalsDept.java
@@ -1,34 +1,30 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.CHEMICALS)
+import static com.kustacks.kuring.notice.domain.DepartmentName.CHEMICALS;
+
+@RegisterDepartmentMap(key = CHEMICALS)
 public class ChemicalsDept extends ScienceCollege {
     public ChemicalsDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                         NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                         NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("8900");
-        List<String> forumIds = List.of("8897");
-        List<String> boardSeqs = List.of("1525");
-        List<String> menuSeqs = List.of("11371");
-
+        List<String> professorForumIds = List.of("9794");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "CHEMI", boardSeqs, menuSeqs);
-        this.code = "121261";
-        this.departmentName = DepartmentName.CHEMICALS;
+        this.noticeScrapInfo = new NoticeScrapInfo(CHEMICALS.getHostPrefix(), 739);
+        this.departmentName = CHEMICALS;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/science/MathematicsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/science/MathematicsDept.java
@@ -1,35 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.MATH)
+import static com.kustacks.kuring.notice.domain.DepartmentName.MATH;
+
+@RegisterDepartmentMap(key = MATH)
 public class MathematicsDept extends ScienceCollege {
 
     public MathematicsDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                           NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                           NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("8663");
-        List<String> forumIds = List.of("8652");
-        List<String> boardSeqs = List.of("1496");
-        List<String> menuSeqs = List.of("11144");
-
+        List<String> professorForumIds = List.of("9733");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "MATH", boardSeqs, menuSeqs);
-        this.code = "121260";
-        this.departmentName = DepartmentName.MATH;
+        this.noticeScrapInfo = new NoticeScrapInfo(MATH.getHostPrefix(), 727);
+        this.departmentName = MATH;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/science/PhysicsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/science/PhysicsDept.java
@@ -1,34 +1,30 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.PHYSICS)
+import static com.kustacks.kuring.notice.domain.DepartmentName.PHYSICS;
+
+@RegisterDepartmentMap(key = PHYSICS)
 public class PhysicsDept extends ScienceCollege {
     public PhysicsDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                       NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                       NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("8747");
-        List<String> forumIds = List.of("8897");
-        List<String> boardSeqs = List.of("1505");
-        List<String> menuSeqs = List.of("11209");
-
+        List<String> professorForumIds = List.of("9765");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "PHYS", boardSeqs, menuSeqs);
-        this.code = "126783";
-        this.departmentName = DepartmentName.PHYSICS;
+        this.noticeScrapInfo = new NoticeScrapInfo(PHYSICS.getHostPrefix(), 393);
+        this.departmentName = PHYSICS;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/AppliedStatisticsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/AppliedStatisticsDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.social_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.STATISTICS)
+import static com.kustacks.kuring.notice.domain.DepartmentName.STATISTICS;
+
+@RegisterDepartmentMap(key = STATISTICS)
 public class AppliedStatisticsDept extends SocialSciencesCollege {
 
     public AppliedStatisticsDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class AppliedStatisticsDept extends SocialSciencesCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("5081");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("963");
-        List<String> menuSeqs = List.of("6642");
-
+        List<String> professorForumIds = List.of("10389");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "STAT", boardSeqs, menuSeqs);
-        this.code = "127124";
-        this.departmentName = DepartmentName.STATISTICS;
+        this.noticeScrapInfo = new NoticeScrapInfo(STATISTICS.getHostPrefix(), 431);
+        this.departmentName = STATISTICS;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/EconomicsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/EconomicsDept.java
@@ -1,36 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.social_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ECONOMICS)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ECONOMICS;
+
+@RegisterDepartmentMap(key = ECONOMICS)
 public class EconomicsDept extends SocialSciencesCollege {
 
     public EconomicsDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                         NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                         NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("9842");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("866");
-        List<String> menuSeqs = List.of("5981");
-
+        List<String> professorForumIds = List.of("10216");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "ECONOMIC", boardSeqs, menuSeqs);
-        this.code = "127121";
-        this.departmentName = DepartmentName.ECONOMICS;
+        this.noticeScrapInfo = new NoticeScrapInfo(ECONOMICS.getHostPrefix(), 423);
+        this.departmentName = ECONOMICS;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/GlobalBusinessDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/GlobalBusinessDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.social_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.GLOBAL_BUSI)
+import static com.kustacks.kuring.notice.domain.DepartmentName.GLOBAL_BUSI;
+
+@RegisterDepartmentMap(key = GLOBAL_BUSI)
 public class GlobalBusinessDept extends SocialSciencesCollege {
 
     public GlobalBusinessDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class GlobalBusinessDept extends SocialSciencesCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("7516");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1002");
-        List<String> menuSeqs = List.of("7026");
-
+        List<String> professorForumIds = List.of("10443");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "ITRADE", boardSeqs, menuSeqs);
-        this.code = "127126";
-        this.departmentName = DepartmentName.GLOBAL_BUSI;
+        this.noticeScrapInfo = new NoticeScrapInfo(GLOBAL_BUSI.getHostPrefix(), 435);
+        this.departmentName = GLOBAL_BUSI;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/InterDisciplinaryStudiesDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/InterDisciplinaryStudiesDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.social_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.DISCI_STUDIES)
+import static com.kustacks.kuring.notice.domain.DepartmentName.DISCI_STUDIES;
+
+@RegisterDepartmentMap(key = DISCI_STUDIES)
 public class InterDisciplinaryStudiesDept extends SocialSciencesCollege {
 
     public InterDisciplinaryStudiesDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class InterDisciplinaryStudiesDept extends SocialSciencesCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("3716919");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("175");
-        List<String> menuSeqs = List.of("1294");
-
+        List<String> professorForumIds = List.of("0");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "DOLA", boardSeqs, menuSeqs);
-        this.code = "127125";
-        this.departmentName = DepartmentName.DISCI_STUDIES;
+        this.noticeScrapInfo = new NoticeScrapInfo(DISCI_STUDIES.getHostPrefix(), 0);
+        this.departmentName = DISCI_STUDIES;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/InternationalTradeDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/InternationalTradeDept.java
@@ -1,35 +1,31 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.social_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.INT_TRADE)
+import static com.kustacks.kuring.notice.domain.DepartmentName.INT_TRADE;
+
+@RegisterDepartmentMap(key = INT_TRADE)
 public class InternationalTradeDept extends SocialSciencesCollege {
 
     public InternationalTradeDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
-                                  NoticeHtmlParserTemplate latestPageNoticeHtmlParserTwo, LatestPageNoticeProperties latestPageNoticeProperties) {
+                                  NoticeHtmlParserTemplate latestPageNoticeHtmlParser, LatestPageNoticeProperties latestPageNoticeProperties) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
-        this.htmlParser = latestPageNoticeHtmlParserTwo;
+        this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("15003249");
-        List<String> forumIds = List.of("9517");
-        List<String> boardSeqs = List.of("1600");
-        List<String> menuSeqs = List.of("11770");
-
+        List<String> professorForumIds = List.of("10371");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "INT_TRADE", boardSeqs, menuSeqs);
-        this.code = "127123";
-        this.departmentName = DepartmentName.INT_TRADE;
+        this.noticeScrapInfo = new NoticeScrapInfo(INT_TRADE.getHostPrefix(), 429);
+        this.departmentName = INT_TRADE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/PoliticalScienceDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/PoliticalScienceDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.social_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.POLITICS)
+import static com.kustacks.kuring.notice.domain.DepartmentName.POLITICS;
+
+@RegisterDepartmentMap(key = POLITICS)
 public class PoliticalScienceDept extends SocialSciencesCollege {
 
     public PoliticalScienceDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class PoliticalScienceDept extends SocialSciencesCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("6884", "14286274");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1138");
-        List<String> menuSeqs = List.of("7929");
-
+        List<String> professorForumIds = List.of("10199");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "POL", boardSeqs, menuSeqs);
-        this.code = "127120";
-        this.departmentName = DepartmentName.POLITICS;
+        this.noticeScrapInfo = new NoticeScrapInfo(POLITICS.getHostPrefix(), 803);
+        this.departmentName = POLITICS;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/PublicAdministrationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/PublicAdministrationDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.social_science;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.ADMINISTRATION)
+import static com.kustacks.kuring.notice.domain.DepartmentName.ADMINISTRATION;
+
+@RegisterDepartmentMap(key = ADMINISTRATION)
 public class PublicAdministrationDept extends SocialSciencesCollege {
 
     public PublicAdministrationDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class PublicAdministrationDept extends SocialSciencesCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("7245");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1145");
-        List<String> menuSeqs = List.of("7970");
-
+        List<String> professorForumIds = List.of("2507");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "KKUPA", boardSeqs, menuSeqs);
-        this.code = "127122";
-        this.departmentName = DepartmentName.ADMINISTRATION;
+        this.noticeScrapInfo = new NoticeScrapInfo(ADMINISTRATION.getHostPrefix(), 0);
+        this.departmentName = ADMINISTRATION;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/veterinary_medicine/VeterinaryMedicineDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/veterinary_medicine/VeterinaryMedicineDept.java
@@ -1,19 +1,19 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.veterinary_medicine;
 
-import com.kustacks.kuring.notice.domain.DepartmentName;
-import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.client.notice.NoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
 import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
 import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
-import com.kustacks.kuring.worker.dto.ScrapingResultDto;
 import com.kustacks.kuring.worker.scrap.parser.notice.NoticeHtmlParserTemplate;
 
-import java.util.Collections;
 import java.util.List;
 
-@RegisterDepartmentMap(key = DepartmentName.VET_MEDICINE)
+import static com.kustacks.kuring.notice.domain.DepartmentName.VET_MEDICINE;
+
+@RegisterDepartmentMap(key = VET_MEDICINE)
 public class VeterinaryMedicineDept extends VeterinaryMedicineCollege {
 
     public VeterinaryMedicineDept(NoticeApiClient<ScrapingResultDto, DeptInfo> latestPageNoticeApiClient,
@@ -23,14 +23,9 @@ public class VeterinaryMedicineDept extends VeterinaryMedicineCollege {
         this.htmlParser = latestPageNoticeHtmlParser;
         this.latestPageNoticeProperties = latestPageNoticeProperties;
 
-        List<String> professorForumIds = List.of("86647");
-        List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("475");
-        List<String> menuSeqs = List.of("3427");
-
+        List<String> professorForumIds = List.of("11135", "11136");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "VETERINARY", boardSeqs, menuSeqs);
-        this.code = "105101";
-        this.departmentName = DepartmentName.VET_MEDICINE;
+        this.noticeScrapInfo = new NoticeScrapInfo(VET_MEDICINE.getHostPrefix(), 948);
+        this.departmentName = VET_MEDICINE;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/parser/notice/LatestPageNoticeHtmlParser.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/parser/notice/LatestPageNoticeHtmlParser.java
@@ -17,25 +17,23 @@ public class LatestPageNoticeHtmlParser extends NoticeHtmlParserTemplate {
 
     @Override
     protected Elements selectImportantRows(Document document) {
-        return document.select("#noticeList > tr");
+        return document.select(".board-table > tbody > tr").select(".notice");
     }
 
     @Override
     protected Elements selectNormalRows(Document document) {
-        return document.select("#dispList > tr");
+        return document.select(".board-table > tbody > tr").not(".notice");
     }
 
     @Override
     protected String[] extractNoticeFromRow(Element row) {
-        String[] oneNoticeInfo = new String[3];
         Elements tds = row.getElementsByTag("td");
 
-        Element subjectAndIdElement = tds.get(1).getElementsByTag("a").get(0);
-        Element postedDateElement = tds.get(3);
+        // articleId, postedDate, subject
+        String number = tds.get(1).select("a").attr("onclick").replaceAll("[^0-9]", "").substring(3);
+        String date = tds.get(3).text();
+        String title = tds.get(1).select("strong").text();
 
-        oneNoticeInfo[0] = subjectAndIdElement.attr("data-itsp-view-link"); // articleId
-        oneNoticeInfo[1] = postedDateElement.ownText(); // postedDate
-        oneNoticeInfo[2] = subjectAndIdElement.ownText(); // subject
-        return oneNoticeInfo;
+        return new String[]{number, date, title};
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/parser/notice/NoticeHtmlParserTemplate.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/parser/notice/NoticeHtmlParserTemplate.java
@@ -9,6 +9,7 @@ import org.jsoup.select.Elements;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public abstract class NoticeHtmlParserTemplate {
 
@@ -33,7 +34,7 @@ public abstract class NoticeHtmlParserTemplate {
 
         return rows.stream()
                 .map(this::extractNoticeFromRow)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     protected abstract boolean support(DeptInfo deptInfo);

--- a/src/main/java/com/kustacks/kuring/worker/scrap/parser/notice/RowsDto.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/parser/notice/RowsDto.java
@@ -1,9 +1,10 @@
 package com.kustacks.kuring.worker.scrap.parser.notice;
 
 import com.kustacks.kuring.worker.update.notice.dto.response.CommonNoticeFormatDto;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class RowsDto {
 
@@ -16,26 +17,36 @@ public class RowsDto {
     }
 
     public List<CommonNoticeFormatDto> buildImportantRowList(String viewUrl) {
+        Collections.reverse(importantRowList);
         return importantRowList.stream()
                 .map(row -> CommonNoticeFormatDto
                         .builder()
                         .articleId(row[0])
                         .postedDate(row[1])
                         .subject(row[2])
-                        .fullUrl(viewUrl + row[0])
+                        .fullUrl(
+                                UriComponentsBuilder.fromUriString(viewUrl)
+                                        .buildAndExpand(row[0])
+                                        .toUriString()
+                        )
                         .important(true)
                         .build())
                 .toList();
     }
 
     public List<CommonNoticeFormatDto> buildNormalRowList(String viewUrl) {
+        Collections.reverse(normalRowList);
         return normalRowList.stream()
                 .map(row -> CommonNoticeFormatDto
                         .builder()
                         .articleId(row[0])
                         .postedDate(row[1])
                         .subject(row[2])
-                        .fullUrl(viewUrl + row[0])
+                        .fullUrl(
+                                UriComponentsBuilder.fromUriString(viewUrl)
+                                        .buildAndExpand(row[0])
+                                        .toUriString()
+                        )
                         .important(false)
                         .build())
                 .toList();

--- a/src/main/resources/constants.properties
+++ b/src/main/resources/constants.properties
@@ -2,8 +2,8 @@ notice.kuis.request-url=https://kuis.konkuk.ac.kr/CmmnOneStop/find.do
 notice.kuis.referer-url=https://kuis.konkuk.ac.kr/index.do
 notice.normal-base-url=https://old.konkuk.ac.kr/do/MessageBoard/ArticleRead.do
 notice.library-base-url=https://library.konkuk.ac.kr/library-guide/bulletins/notice
-notice.recent.list-url=http://{department}.konkuk.ac.kr/noticeList.do
-notice.recent.view-url=http://{department}.konkuk.ac.kr/noticeView.do
+notice.recent.list-url=https://{department}.konkuk.ac.kr/bbs/{department}/{siteId}/artclList.do
+notice.recent.view-url=https://{department}.konkuk.ac.kr/bbs/{department}/{siteId}/{noticeId}/artclView.do
 notice.real-estate.list-url=http://www.realestate.ac.kr/gb/bbs/board.php?bo_table=notice
 notice.real-estate.view-url=http://www.realestate.ac.kr/gb/bbs/board.php?bo_table=notice
 notice.library.request-url=https://library.konkuk.ac.kr/pyxis-api/1/bulletin-boards/1/bulletins

--- a/src/main/resources/db/migration/V240226__Truncate_department_notices.sql
+++ b/src/main/resources/db/migration/V240226__Truncate_department_notices.sql
@@ -1,0 +1,3 @@
+DELETE
+FROM notice
+WHERE dtype != 'Notice' AND department_name != 'REAL_ESTATE';

--- a/src/test/java/com/kustacks/kuring/worker/scrap/client/notice/LatestPageNoticeApiClientTest.java
+++ b/src/test/java/com/kustacks/kuring/worker/scrap/client/notice/LatestPageNoticeApiClientTest.java
@@ -1,0 +1,48 @@
+package com.kustacks.kuring.worker.scrap.client.notice;
+
+import com.kustacks.kuring.worker.scrap.client.JsoupClient;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LatestPageNoticeApiClientTest {
+
+    @Mock
+    private JsoupClient jsoupClient;
+
+    @DisplayName("공지의 총 개수를 가져온다.")
+    @Test
+    public void getTotalNoticeSize() throws IOException {
+        // given
+        Document doc = Jsoup.parse(loadHtmlFile("src/test/resources/notice/cse-notice-2024.html"));
+        when(jsoupClient.get(anyString(), anyInt())).thenReturn(doc);
+        String url = "https://cse.konkuk.ac.kr/cse/9962/subview.do";
+
+        // when
+        int totalNoticeSize = new LatestPageNoticeApiClient(jsoupClient).getTotalNoticeSize(url);
+
+        // then
+        assertThat(totalNoticeSize).isEqualTo(625);
+    }
+
+    private static String loadHtmlFile(String filePath) throws IOException {
+        Path path = Path.of(filePath);
+        byte[] fileBytes = Files.readAllBytes(path);
+        return new String(fileBytes, StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/com/kustacks/kuring/worker/scrap/parser/NoticeHtmlParserTemplateTest.java
+++ b/src/test/java/com/kustacks/kuring/worker/scrap/parser/NoticeHtmlParserTemplateTest.java
@@ -9,6 +9,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -17,25 +18,79 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class NoticeHtmlParserTemplateTest {
+
+    @DisplayName("View Url이 정상적으로 생석되는지 확인한다")
+    @Test
+    public void viewUrlCreate() {
+        // given
+        String urlTemplate = "https://{department}.konkuk.ac.kr/bbs/{department}/{siteId}/{noticeId}/artclView.do";
+
+        // when
+        String viewUrl = urlTemplate
+                .replaceAll("\\{department\\}", "cse")
+                .replace("{siteId}", "775");
+
+        String result = UriComponentsBuilder.fromUriString(viewUrl)
+                .buildAndExpand(5737)
+                .toUriString();
+
+        // then
+        assertThat(result).isEqualTo("https://cse.konkuk.ac.kr/bbs/cse/775/5737/artclView.do");
+    }
 
     @DisplayName("오래된 학과의 홈페이지 공지를 분석한다")
     @Test
     void LatestPageNoticeHtmlParser() throws IOException {
         // given
-        Document doc = Jsoup.parse(loadHtmlFile("src/test/resources/notice/cse.html"));
+        Document doc = Jsoup.parse(loadHtmlFile("src/test/resources/notice/cse-notice-2024.html"));
+        String viewUrl = "https://cse.konkuk.ac.kr/bbs/cse/775/{uniqueNoticeId}/artclView.do";
 
         // when
         RowsDto rowsDto = new LatestPageNoticeHtmlParser().parse(doc);
-        List<CommonNoticeFormatDto> important = rowsDto.buildImportantRowList("important");
-        List<CommonNoticeFormatDto> normal = rowsDto.buildNormalRowList("normal");
+        List<CommonNoticeFormatDto> important = rowsDto.buildImportantRowList(viewUrl);
+        List<CommonNoticeFormatDto> normal = rowsDto.buildNormalRowList(viewUrl);
 
         // then
         assertAll(
-                () -> assertThat(important).hasSize(12),
-                () -> assertThat(normal).hasSize(12)
+                () -> assertThat(important).hasSize(15),
+                () -> assertThat(important)
+                        .extracting("articleId", "subject", "postedDate", "fullUrl", "important")
+                        .containsExactlyInAnyOrder(
+                                tuple("5737", "[졸업] 2024학년도 제135회 학위수여식 관련 졸업가능여부 조회 및 행사 안내", "2024.02.16", "https://cse.konkuk.ac.kr/bbs/cse/775/5737/artclView.do", true),
+                                tuple("828684", "[졸업] 2024년 전기 학위복 대여 및 학위기 배부 장소 안내", "2024.02.05", "https://cse.konkuk.ac.kr/bbs/cse/775/828684/artclView.do", true),
+                                tuple("828683", "[학사] 2024년도 2월 미졸업자 수강신청학점(미졸코드) 변경 안내", "2024.02.02", "https://cse.konkuk.ac.kr/bbs/cse/775/828683/artclView.do", true),
+                                tuple("828681", "[학사] 2024학년도 건국대학교 학부 온라인 요람 발간 안내", "2024.01.31", "https://cse.konkuk.ac.kr/bbs/cse/775/828681/artclView.do", true),
+                                tuple("828680", "[교직] 교직이수예정자의 교직소양 영역 최저이수기준 안내", "2024.01.31", "https://cse.konkuk.ac.kr/bbs/cse/775/828680/artclView.do", true),
+                                tuple("828672", "[학사] 2024-1학기 수강바구니(수강신청) 일정 및 유의사항 안내", "2024.01.12", "https://cse.konkuk.ac.kr/bbs/cse/775/828672/artclView.do", true),
+                                tuple("828670", "[학사] 2024학년도 1학기 조기졸업 신청 안내", "2024.01.08", "https://cse.konkuk.ac.kr/bbs/cse/775/828670/artclView.do", true),
+                                tuple("828669", "[현장실습] 2024학년도 1학기 현장실습학기제 안내", "2024.01.08", "https://cse.konkuk.ac.kr/bbs/cse/775/828669/artclView.do", true),
+                                tuple("828665", "[학사] 2024-1학기 학사구조개편 관련 소속변경 안내", "2023.12.07", "https://cse.konkuk.ac.kr/bbs/cse/775/828665/artclView.do", true),
+                                tuple("828653", "[학사] 가사휴학 연한 제한 제도 시행 안내", "2023.11.03", "https://cse.konkuk.ac.kr/bbs/cse/775/828653/artclView.do", true),
+                                tuple("828351", "[졸업] 컴퓨터공학부 학과별 졸업요건 정리", "2022.02.08", "https://cse.konkuk.ac.kr/bbs/cse/775/828351/artclView.do", true),
+                                tuple("828243", "[졸업] 인턴십 의무이수제 졸업요건 안내", "2021.06.23", "https://cse.konkuk.ac.kr/bbs/cse/775/828243/artclView.do", true),
+                                tuple("828163", "[졸업] 교과목명 신구대비표", "2021.01.25", "https://cse.konkuk.ac.kr/bbs/cse/775/828163/artclView.do", true),
+                                tuple("828089", "[내규] 교환학생 전공학점인정 관련 내규 안내", "2020.07.28", "https://cse.konkuk.ac.kr/bbs/cse/775/828089/artclView.do", true),
+                                tuple("828034", "[내규] 현장실습 전공학점인정 관련 내규 안내", "2020.03.23", "https://cse.konkuk.ac.kr/bbs/cse/775/828034/artclView.do", true)
+                        ),
+                () -> assertThat(normal).hasSize(10),
+                () -> assertThat(normal)
+                        .extracting("articleId", "subject", "postedDate", "fullUrl", "important")
+                        .containsExactlyInAnyOrder(
+                                tuple("5744", "[WE人교육센터] 건국대 비교과 프로그램 홍보자료 홍보자료 배포", "2024.02.21", "https://cse.konkuk.ac.kr/bbs/cse/775/5744/artclView.do", false),
+                                tuple("5737", "[졸업] 2024학년도 제135회 학위수여식 관련 졸업가능여부 조회 및 행사 안내", "2024.02.16", "https://cse.konkuk.ac.kr/bbs/cse/775/5737/artclView.do", false),
+                                tuple("5736", "Adobe(어도비) 네임드 라이선스 회수 및 ETLA 라이선스 사용 안내", "2024.02.15", "https://cse.konkuk.ac.kr/bbs/cse/775/5736/artclView.do", false),
+                                tuple("5735", "2024-1학기 학부생 연구인턴 프로그램 시행 안내", "2024.02.14", "https://cse.konkuk.ac.kr/bbs/cse/775/5735/artclView.do", false),
+                                tuple("828684", "[졸업] 2024년 전기 학위복 대여 및 학위기 배부 장소 안내", "2024.02.05", "https://cse.konkuk.ac.kr/bbs/cse/775/828684/artclView.do", false),
+                                tuple("828683", "[학사] 2024년도 2월 미졸업자 수강신청학점(미졸코드) 변경 안내", "2024.02.02", "https://cse.konkuk.ac.kr/bbs/cse/775/828683/artclView.do", false),
+                                tuple("828682", "[학사] 2024-1학기 대학원 개설 교과목 선수강 신청 안내", "2024.01.31", "https://cse.konkuk.ac.kr/bbs/cse/775/828682/artclView.do", false),
+                                tuple("828681", "[학사] 2024학년도 건국대학교 학부 온라인 요람 발간 안내", "2024.01.31", "https://cse.konkuk.ac.kr/bbs/cse/775/828681/artclView.do", false),
+                                tuple("828680", "[교직] 교직이수예정자의 교직소양 영역 최저이수기준 안내", "2024.01.31", "https://cse.konkuk.ac.kr/bbs/cse/775/828680/artclView.do", false),
+                                tuple("828679", "[학사] 성적평점 백분위 환산점수표 관련 규정 개정 안내", "2024.01.30", "https://cse.konkuk.ac.kr/bbs/cse/775/828679/artclView.do", false)
+                        )
         );
     }
 

--- a/src/test/java/com/kustacks/kuring/worker/update/CategoryNoticeUpdaterTest.java
+++ b/src/test/java/com/kustacks/kuring/worker/update/CategoryNoticeUpdaterTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.TestPropertySource;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -67,7 +68,7 @@ class CategoryNoticeUpdaterTest {
     }
 
     private static List<CommonNoticeFormatDto> createLibraryFixture() {
-        return List.of(
+        return Arrays.asList(
                 CommonNoticeFormatDto.builder().articleId("1").updatedDate("2021-01-01").subject("library1")
                         .postedDate("2021-01-01").fullUrl("https://library.konkuk.ac.kr/library-guide/bulletins/notice/71921").important(false).build(),
                 CommonNoticeFormatDto.builder().articleId("2").updatedDate("2021-01-01").subject("library2")
@@ -86,7 +87,7 @@ class CategoryNoticeUpdaterTest {
     }
 
     private static List<CommonNoticeFormatDto> createNoticesFixture() {
-        return List.of(
+        return Arrays.asList(
                 CommonNoticeFormatDto.builder().articleId("1").updatedDate("2021-01-01").subject("library1")
                         .postedDate("2021-01-01").fullUrl("https://library.konkuk.ac.kr/library-guide/bulletins/notice/71921").important(false).build(),
                 CommonNoticeFormatDto.builder().articleId("2").updatedDate("2021-01-01").subject("library2")

--- a/src/test/resources/notice/cse-notice-2024.html
+++ b/src/test/resources/notice/cse-notice-2024.html
@@ -1,0 +1,2141 @@
+<!DOCTYPE HTML>
+<!--[if lt IE 7 ]><html dir="ltr" lang="ko" class="no-js ie ie6 lte7 lte8 lte9"><![endif]-->
+<!--[if IE 7 ]><html dir="ltr" lang="ko" class="no-js ie ie7 lte7 lte8 lte9"><![endif]--> 
+<!--[if IE 8 ]><html dir="ltr" lang="ko" class="no-js ie ie8 lte8 lte9"><![endif]-->
+<!--[if IE 9 ]><html dir="ltr" lang="ko" class="no-js ie ie9 lte9"><![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--><html dir="ltr" lang="ko" class="no-js"><!--<![endif]-->
+	<head>
+		<meta charset="UTF-8">
+		<title>
+			K2Web Wizard
+			
+		</title>
+		<meta property="og:url" content="http://www.k2web.co.kr/">
+		<meta property="og:type" content="website">
+		<meta property="og:title" content="K2WebWizard">
+		<meta property="og:description" content="누구나 인터넷으로부터 자유롭기를 희망하며">
+		<meta name="generator" content="K2Web Wizard"> 
+
+ 
+		
+		
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+	
+		
+	
+	
+
+
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta id="resResponsiveViewport" name="viewport" content="width=device-width, initial-scale=1, minimum-scale=0.5, maximum-scale=1, user-scalable=yes">
+	
+	
+	<meta name="apple-mobile-web-app-title" content="">
+	
+	<meta name="description" content="">
+	<meta name="keywords" content="">
+	<meta property="og:title" content="">
+	<meta property="og:site_name" content="">
+	<meta property="og:url" content="?page=1">
+	<meta property="og:image" content="">
+	<meta property="og:description" content="">
+	
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="">
+	<meta name="twitter:url" content="?page=1">
+	<meta name="twitter:image" content="">
+	<meta name="twitter:description" content="">
+
+<meta name="generator" content="K2Web Wizard"> 
+
+	<link rel="stylesheet" href="/Web-home/_UI/css/common/mCustomScrollbar.css">
+	<link rel="stylesheet" href="/Web-home/_UI/css/common/blockUI.css">
+	<link rel="stylesheet" href="/Web-home/_SITES/css/content/content.css">
+
+	
+
+	
+	
+	
+	
+		
+	
+	
+
+	
+	<link rel="stylesheet" href="/Web-home/_UI/css/guide/responsive.css">
+	
+		
+		
+		
+		
+			<!-- ONLY PC -->
+			<link href="/Web-home/_UI/css/guide/responsiveDesktop.css" rel="stylesheet">
+		
+	
+
+	
+	
+	
+		
+		
+		
+		
+			<!-- ONLY PC -->
+			<link href="/sites/cse/style/css/site_contents_Desktop.css" rel="stylesheet">
+		
+	
+	
+
+	<link rel="stylesheet" href="/Web-home/_SITES/css/fnct/fnct.css">
+	
+		
+		
+		
+		
+			<!-- ONLY PC -->
+			<link href="/Web-home/_SITES/css/fnct/fnctDesktop.css" rel="stylesheet">
+		
+	
+
+	<script src="/Web-home/js/jquery-1.9.1.min.js"></script>
+	<script src="/Web-home/js/jquery-ui-1.12.1.min.js"></script>
+	<script src="/Web-home/js/jquery-migrate-1.4.1.min.js"></script>
+	<script src="/Web-home/js/jquery-mCustomScrollbar.3.0.3.min.js"></script>
+	<script src="/Web-home/js/common.js"></script>
+	
+	<!-- [SITES:S] -->
+	<script>
+		var urlPattern = ".do";
+		var defaultTextSiteId = "cse";
+		var ctxPath = "";
+	</script>
+
+	<!-- Slider -->
+	<!--<script src="/sites/cse/style/js/vendor/slick.min.js?version=1"></script>-->
+	<script src="/Web-home/_UI/js/_lib/jquery.slickslider.js"></script>
+	
+	
+		
+		
+			<!-- sub,popup,etc -->
+			<!-- Table Scroll -->
+			<script src="/sites/cse/style/js/vendor/niceScroll.min.js?version=1"></script>
+			<!-- Favorite -->
+			
+		
+	
+
+	<!-- [M/S RESOURCE] -->
+	
+	<!-- [FNCT RESOURCE STYLE] -->
+	
+	<!-- [END] -->
+
+	
+		
+		
+			
+		
+	
+	
+	
+	<link href="/sites/cse/style_edit/css/style.css" rel="stylesheet">
+	
+	
+	
+	<script src="/sites/cse/style_edit/js/script.js"></script>
+	<!-- 다음 우편 api script start-->
+	<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+	<!-- 다음 우편 api script end-->
+	
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+
+<!--[if lt IE 9]>
+
+	<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+	<script src="//ie7-js.googlecode.com/svn/version/2.1(beta4)/IE9.js"></script>
+	<script src="//oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+
+<![endif]-->
+		
+		<style>
+		._fnctWrap{
+			overflow: hidden;
+			/*margin: 50px;*/
+		}
+		#divLoadBody {
+			display: none; 
+		}
+		</style>
+		
+
+
+<link rel="stylesheet" href="/Web-home/_UI/css/common/jquery-ui.css">
+<link rel="stylesheet" href="/Web-home/fnct/bbs/kon-board-normal1/css/style.css">
+
+
+    		<!--<script>
+    		/*function loaded(){  
+    			var element = document.getElementById('loading'); // 로딩 요소 
+    			element.parentNode.removeChild(element); // 요소 제거 
+   			} 
+   			// 로딩 이벤트에 등록 
+   			if(window.addEventListener){  
+   			      window.addEventListener('load', loaded, false);      
+   			    }else{
+   			      window.attachEvent('onload', loaded); 
+   			}
+   			 $(window).load(function(){
+   				  $('#loading').fadeOut(2000);
+			}); */
+			</script>
+			 <style>
+				#loading {
+					background: url("/Web-home/_UI/images/guide/loading.gif") no-repeat 50% 50% #fff;
+					position: fixed;
+					top: 0;
+					left: 0;
+					width: 100%;
+					height: 100%;
+					z-index: 9999;
+					text-indent: -5000px;
+				}
+			</style> -->
+ </head>
+<body class="_responsiveObj _langko">
+
+<!-- <div id="loading">
+L o a d i n g . . .    
+</div> -->
+
+	
+
+
+
+
+<div class="_fnctWrap">
+	
+
+	<form name="searchForm" method="post" action="/bbs/cse/775/artclList.do">
+		
+		<input type="hidden" id="mouseCtrl">
+		
+		<input type="hidden" name="layout" value="" />
+		<input type="hidden" id="bbsClSeq" name="bbsClSeq" value=""/>
+		<input type="hidden" id="bbsOpenWrdSeq" name="bbsOpenWrdSeq" value="" />
+		<input type="hidden" name="isViewMine" value="false">
+
+		
+
+		
+
+		
+
+		<!-- Search -->
+		<div class="board-search">
+			<div class="util-search">
+				
+					<a href="/bbs/cse/775/rssList.do?row=50" target="_blank">RSS 2.0</a>
+				
+				총 <strong>625</strong> 개의 게시물이 있습니다.
+			</div>
+
+			<div class="form-search">
+				<fieldset>
+					<legend>게시물 검색</legend>
+					<div class="tbl-search">
+						<div class="box-sel">
+							<select id="srchColumn" name="srchColumn">
+								
+									<option value="sj" >제목</option>
+								
+									<option value="writer" >작성자</option>
+								
+							</select>
+						</div>
+						<div class="box-search">
+							<input type="text" id="srchWrd" name="srchWrd" value="" onkeypress="if(event.keyCode == '13') jf_searchArtcl('srchWrd', this.value)">
+							<input type="submit" value="검색">
+						</div>
+					</div>
+				</fieldset>
+			</div>
+		</div>
+	</form>
+
+	<form name="viewForm" method="post">
+		<input type="hidden" name="layout" value="" />
+		<input type="hidden" name="page" value="1">
+		<input type="hidden" name="srchColumn" value="">
+		<input type="hidden" name="srchWrd" value="">
+		<input type="hidden" name="bbsClSeq" value=""/>
+		<input type="hidden" name="bbsOpenWrdSeq" value="" />
+		<input type="hidden" name="rgsBgndeStr" value="">
+		<input type="hidden" name="rgsEnddeStr" value="">
+		<input type="hidden" name="isViewMine" value="false" />
+		<input type="hidden" name="password">
+
+		<h2 class="hidden">게시글 리스트</h2>
+
+		<!-- List Table -->
+		<div class="scroll-table">
+			<table class="board-table horizon1">
+				<caption>학과공지 - 번호, 제목, 작성자, 작성일, 조회수, 첨부파일</caption>
+				<colgroup>
+						
+						<col class="col-num">
+						<col class="col-subject">
+						<col class="col-write">
+						
+						<col class="col-date">
+						
+						
+						<col class="col-acess">
+						
+						<col class="col-file">
+						
+						
+							
+						
+							
+						
+				</colgroup>
+				<thead>
+					<tr>
+						
+						<th class="th-num">번호</th>
+						<th class="th-subject">제목</th>
+						<th class="th-write">작성자</th>
+						
+						<th class="th-date">작성일</th>
+						
+						
+						<th class="th-acess">조회수</th>
+						
+							<th class="th-file">첨부파일</th>
+						
+						
+							
+						
+							
+						
+					</tr>
+				</thead>
+				<tbody>
+					
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/5737/artclView.do" onclick="jf_viewArtcl('cse', '775', '5737')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[졸업] 2024학년도 제135회 학위수여식 관련 졸업가능여부 조회 및 행사 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											computer
+										
+									
+								</td>
+								
+								<td class="td-date">2024.02.16</td>
+								
+								
+								<td class="td-access">48</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>1</span></p>
+											
+										
+										<!-- 1 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828684/artclView.do" onclick="jf_viewArtcl('cse', '775', '828684')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[졸업] 2024년 전기 학위복 대여 및 학위기 배부 장소 안내 </strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2024.02.05</td>
+								
+								
+								<td class="td-access">39</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>1</span></p>
+											
+										
+										<!-- 1 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828683/artclView.do" onclick="jf_viewArtcl('cse', '775', '828683')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[학사] 2024년도 2월 미졸업자 수강신청학점(미졸코드) 변경 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2024.02.02</td>
+								
+								
+								<td class="td-access">57</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>2</span></p>
+											
+										
+										<!-- 2 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828681/artclView.do" onclick="jf_viewArtcl('cse', '775', '828681')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[학사] 2024학년도 건국대학교 학부 온라인 요람 발간 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2024.01.31</td>
+								
+								
+								<td class="td-access">81</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>1</span></p>
+											
+										
+										<!-- 1 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828680/artclView.do" onclick="jf_viewArtcl('cse', '775', '828680')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[교직] 교직이수예정자의 교직소양 영역 최저이수기준 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2024.01.31</td>
+								
+								
+								<td class="td-access">25</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>1</span></p>
+											
+										
+										<!-- 1 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828672/artclView.do" onclick="jf_viewArtcl('cse', '775', '828672')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[학사] 2024-1학기 수강바구니(수강신청) 일정 및 유의사항 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2024.01.12</td>
+								
+								
+								<td class="td-access">179</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>4</span></p>
+											
+										
+										<!-- 4 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828670/artclView.do" onclick="jf_viewArtcl('cse', '775', '828670')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[학사] 2024학년도 1학기 조기졸업 신청 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2024.01.08</td>
+								
+								
+								<td class="td-access">61</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>1</span></p>
+											
+										
+										<!-- 1 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828669/artclView.do" onclick="jf_viewArtcl('cse', '775', '828669')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[현장실습] 2024학년도 1학기 현장실습학기제 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2024.01.08</td>
+								
+								
+								<td class="td-access">99</td>
+								
+									<td class="td-file ">
+										
+											
+												<p class="file-n"><span>0</span></p>
+											
+											
+										
+										<!-- 0 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828665/artclView.do" onclick="jf_viewArtcl('cse', '775', '828665')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[학사] 2024-1학기 학사구조개편 관련 소속변경 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2023.12.07</td>
+								
+								
+								<td class="td-access">222</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>2</span></p>
+											
+										
+										<!-- 2 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828653/artclView.do" onclick="jf_viewArtcl('cse', '775', '828653')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[학사] 가사휴학 연한 제한 제도 시행 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2023.11.03</td>
+								
+								
+								<td class="td-access">82</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>1</span></p>
+											
+										
+										<!-- 1 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828351/artclView.do" onclick="jf_viewArtcl('cse', '775', '828351')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[졸업] 컴퓨터공학부 학과별 졸업요건 정리</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2022.02.08</td>
+								
+								
+								<td class="td-access">3889</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>1</span></p>
+											
+										
+										<!-- 1 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828243/artclView.do" onclick="jf_viewArtcl('cse', '775', '828243')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[졸업] 인턴십 의무이수제 졸업요건 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2021.06.23</td>
+								
+								
+								<td class="td-access">1576</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>1</span></p>
+											
+										
+										<!-- 1 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828163/artclView.do" onclick="jf_viewArtcl('cse', '775', '828163')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[졸업] 교과목명 신구대비표</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2021.01.25</td>
+								
+								
+								<td class="td-access">1441</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>1</span></p>
+											
+										
+										<!-- 1 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828089/artclView.do" onclick="jf_viewArtcl('cse', '775', '828089')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[내규] 교환학생 전공학점인정 관련 내규 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2020.07.28</td>
+								
+								
+								<td class="td-access">699</td>
+								
+									<td class="td-file file">
+										
+											
+											
+												<p class="file-y"><span>1</span></p>
+											
+										
+										<!-- 1 -->
+									</td>
+								
+							</tr>
+						
+							<tr class="notice ">
+								
+								<td class="td-num">
+									
+										
+										
+											<span>일반공지</span>
+										
+									
+								</td>
+								<td class="td-subject">
+									<a href="/bbs/cse/775/828034/artclView.do" onclick="jf_viewArtcl('cse', '775', '828034')">
+										[
+										
+											
+											
+												일반공지
+											
+										
+										]
+										<strong>[내규] 현장실습 전공학점인정 관련 내규 안내</strong>
+									</a>
+								</td>
+								<td class="td-write">
+									
+										
+										
+										
+											컴퓨터공학부
+										
+									
+								</td>
+								
+								<td class="td-date">2020.03.23</td>
+								
+								
+								<td class="td-access">1731</td>
+								
+									<td class="td-file ">
+										
+											
+												<p class="file-n"><span>0</span></p>
+											
+											
+										
+										<!-- 0 -->
+									</td>
+								
+							</tr>
+						
+					
+					
+						
+							
+								
+									
+									
+									
+									
+										
+										<tr class="">
+									
+								
+									
+									<td class="td-num">625</td>
+									<td class="td-subject">
+										
+											
+											
+											
+											
+												<a href="/bbs/cse/775/5744/artclView.do" onclick="jf_viewArtcl('cse', '775', '5744')">
+											
+										
+										
+										
+											
+											
+											
+											
+												
+												<strong>[WE人교육센터] 건국대 비교과 프로그램 홍보자료 홍보자료 배포</strong>
+												
+													<span class="new">새글</span>
+												
+											
+										
+										
+											
+											
+											
+											
+												</a>
+											
+										
+									</td>
+									<td class="td-write">
+										
+											
+											
+											
+											
+												
+													
+													
+													
+														computer
+													
+												
+											
+										
+									</td>
+                  
+									<td class="td-date">2024.02.21</td>
+									
+									
+									<td class="td-access">
+										
+											
+											
+											
+											
+												35
+											
+										
+									</td>
+									
+                    <td class="td-file ">
+                      
+                        
+                        
+                        
+                        
+                          
+                            
+                              <p class="file-n"><span>0</span></p>
+                            
+                            
+                          
+                        
+                      
+                    </td>
+                  
+									
+										
+									
+										
+									
+								</tr>
+							
+								
+									
+									
+									
+									
+										
+										<tr class="">
+									
+								
+									
+									<td class="td-num">624</td>
+									<td class="td-subject">
+										
+											
+											
+											
+											
+												<a href="/bbs/cse/775/5737/artclView.do" onclick="jf_viewArtcl('cse', '775', '5737')">
+											
+										
+										
+										
+											
+											
+											
+											
+												
+												<strong>[졸업] 2024학년도 제135회 학위수여식 관련 졸업가능여부 조회 및 행사 안내</strong>
+												
+											
+										
+										
+											
+											
+											
+											
+												</a>
+											
+										
+									</td>
+									<td class="td-write">
+										
+											
+											
+											
+											
+												
+													
+													
+													
+														computer
+													
+												
+											
+										
+									</td>
+                  
+									<td class="td-date">2024.02.16</td>
+									
+									
+									<td class="td-access">
+										
+											
+											
+											
+											
+												48
+											
+										
+									</td>
+									
+                    <td class="td-file file">
+                      
+                        
+                        
+                        
+                        
+                          
+                            
+                            
+                              <p class="file-y"><span>1</span></p>
+                            
+                          
+                        
+                      
+                    </td>
+                  
+									
+										
+									
+										
+									
+								</tr>
+							
+								
+									
+									
+									
+									
+										
+										<tr class="">
+									
+								
+									
+									<td class="td-num">623</td>
+									<td class="td-subject">
+										
+											
+											
+											
+											
+												<a href="/bbs/cse/775/5736/artclView.do" onclick="jf_viewArtcl('cse', '775', '5736')">
+											
+										
+										
+										
+											
+											
+											
+											
+												
+												<strong>Adobe(어도비) 네임드 라이선스 회수 및 ETLA 라이선스 사용 안내</strong>
+												
+											
+										
+										
+											
+											
+											
+											
+												</a>
+											
+										
+									</td>
+									<td class="td-write">
+										
+											
+											
+											
+											
+												
+													
+													
+													
+														computer
+													
+												
+											
+										
+									</td>
+                  
+									<td class="td-date">2024.02.15</td>
+									
+									
+									<td class="td-access">
+										
+											
+											
+											
+											
+												44
+											
+										
+									</td>
+									
+                    <td class="td-file file">
+                      
+                        
+                        
+                        
+                        
+                          
+                            
+                            
+                              <p class="file-y"><span>1</span></p>
+                            
+                          
+                        
+                      
+                    </td>
+                  
+									
+										
+									
+										
+									
+								</tr>
+							
+								
+									
+									
+									
+									
+										
+										<tr class="">
+									
+								
+									
+									<td class="td-num">622</td>
+									<td class="td-subject">
+										
+											
+											
+											
+											
+												<a href="/bbs/cse/775/5735/artclView.do" onclick="jf_viewArtcl('cse', '775', '5735')">
+											
+										
+										
+										
+											
+											
+											
+											
+												
+												<strong>2024-1학기 학부생 연구인턴 프로그램 시행 안내</strong>
+												
+											
+										
+										
+											
+											
+											
+											
+												</a>
+											
+										
+									</td>
+									<td class="td-write">
+										
+											
+											
+											
+											
+												
+													
+													
+													
+														computer
+													
+												
+											
+										
+									</td>
+                  
+									<td class="td-date">2024.02.14</td>
+									
+									
+									<td class="td-access">
+										
+											
+											
+											
+											
+												66
+											
+										
+									</td>
+									
+                    <td class="td-file file">
+                      
+                        
+                        
+                        
+                        
+                          
+                            
+                            
+                              <p class="file-y"><span>4</span></p>
+                            
+                          
+                        
+                      
+                    </td>
+                  
+									
+										
+									
+										
+									
+								</tr>
+							
+								
+									
+									
+									
+									
+										
+										<tr class="">
+									
+								
+									
+									<td class="td-num">621</td>
+									<td class="td-subject">
+										
+											
+											
+											
+											
+												<a href="/bbs/cse/775/828684/artclView.do" onclick="jf_viewArtcl('cse', '775', '828684')">
+											
+										
+										
+										
+											
+											
+											
+											
+												
+												<strong>[졸업] 2024년 전기 학위복 대여 및 학위기 배부 장소 안내 </strong>
+												
+											
+										
+										
+											
+											
+											
+											
+												</a>
+											
+										
+									</td>
+									<td class="td-write">
+										
+											
+											
+											
+											
+												
+													
+													
+													
+														컴퓨터공학부
+													
+												
+											
+										
+									</td>
+                  
+									<td class="td-date">2024.02.05</td>
+									
+									
+									<td class="td-access">
+										
+											
+											
+											
+											
+												39
+											
+										
+									</td>
+									
+                    <td class="td-file file">
+                      
+                        
+                        
+                        
+                        
+                          
+                            
+                            
+                              <p class="file-y"><span>1</span></p>
+                            
+                          
+                        
+                      
+                    </td>
+                  
+									
+										
+									
+										
+									
+								</tr>
+							
+								
+									
+									
+									
+									
+										
+										<tr class="">
+									
+								
+									
+									<td class="td-num">620</td>
+									<td class="td-subject">
+										
+											
+											
+											
+											
+												<a href="/bbs/cse/775/828683/artclView.do" onclick="jf_viewArtcl('cse', '775', '828683')">
+											
+										
+										
+										
+											
+											
+											
+											
+												
+												<strong>[학사] 2024년도 2월 미졸업자 수강신청학점(미졸코드) 변경 안내</strong>
+												
+											
+										
+										
+											
+											
+											
+											
+												</a>
+											
+										
+									</td>
+									<td class="td-write">
+										
+											
+											
+											
+											
+												
+													
+													
+													
+														컴퓨터공학부
+													
+												
+											
+										
+									</td>
+                  
+									<td class="td-date">2024.02.02</td>
+									
+									
+									<td class="td-access">
+										
+											
+											
+											
+											
+												57
+											
+										
+									</td>
+									
+                    <td class="td-file file">
+                      
+                        
+                        
+                        
+                        
+                          
+                            
+                            
+                              <p class="file-y"><span>2</span></p>
+                            
+                          
+                        
+                      
+                    </td>
+                  
+									
+										
+									
+										
+									
+								</tr>
+							
+								
+									
+									
+									
+									
+										
+										<tr class="">
+									
+								
+									
+									<td class="td-num">619</td>
+									<td class="td-subject">
+										
+											
+											
+											
+											
+												<a href="/bbs/cse/775/828682/artclView.do" onclick="jf_viewArtcl('cse', '775', '828682')">
+											
+										
+										
+										
+											
+											
+											
+											
+												
+												<strong>[학사] 2024-1학기 대학원 개설 교과목 선수강 신청 안내</strong>
+												
+											
+										
+										
+											
+											
+											
+											
+												</a>
+											
+										
+									</td>
+									<td class="td-write">
+										
+											
+											
+											
+											
+												
+													
+													
+													
+														컴퓨터공학부
+													
+												
+											
+										
+									</td>
+                  
+									<td class="td-date">2024.01.31</td>
+									
+									
+									<td class="td-access">
+										
+											
+											
+											
+											
+												47
+											
+										
+									</td>
+									
+                    <td class="td-file file">
+                      
+                        
+                        
+                        
+                        
+                          
+                            
+                            
+                              <p class="file-y"><span>1</span></p>
+                            
+                          
+                        
+                      
+                    </td>
+                  
+									
+										
+									
+										
+									
+								</tr>
+							
+								
+									
+									
+									
+									
+										
+										<tr class="">
+									
+								
+									
+									<td class="td-num">618</td>
+									<td class="td-subject">
+										
+											
+											
+											
+											
+												<a href="/bbs/cse/775/828681/artclView.do" onclick="jf_viewArtcl('cse', '775', '828681')">
+											
+										
+										
+										
+											
+											
+											
+											
+												
+												<strong>[학사] 2024학년도 건국대학교 학부 온라인 요람 발간 안내</strong>
+												
+											
+										
+										
+											
+											
+											
+											
+												</a>
+											
+										
+									</td>
+									<td class="td-write">
+										
+											
+											
+											
+											
+												
+													
+													
+													
+														컴퓨터공학부
+													
+												
+											
+										
+									</td>
+                  
+									<td class="td-date">2024.01.31</td>
+									
+									
+									<td class="td-access">
+										
+											
+											
+											
+											
+												81
+											
+										
+									</td>
+									
+                    <td class="td-file file">
+                      
+                        
+                        
+                        
+                        
+                          
+                            
+                            
+                              <p class="file-y"><span>1</span></p>
+                            
+                          
+                        
+                      
+                    </td>
+                  
+									
+										
+									
+										
+									
+								</tr>
+							
+								
+									
+									
+									
+									
+										
+										<tr class="">
+									
+								
+									
+									<td class="td-num">617</td>
+									<td class="td-subject">
+										
+											
+											
+											
+											
+												<a href="/bbs/cse/775/828680/artclView.do" onclick="jf_viewArtcl('cse', '775', '828680')">
+											
+										
+										
+										
+											
+											
+											
+											
+												
+												<strong>[교직] 교직이수예정자의 교직소양 영역 최저이수기준 안내</strong>
+												
+											
+										
+										
+											
+											
+											
+											
+												</a>
+											
+										
+									</td>
+									<td class="td-write">
+										
+											
+											
+											
+											
+												
+													
+													
+													
+														컴퓨터공학부
+													
+												
+											
+										
+									</td>
+                  
+									<td class="td-date">2024.01.31</td>
+									
+									
+									<td class="td-access">
+										
+											
+											
+											
+											
+												25
+											
+										
+									</td>
+									
+                    <td class="td-file file">
+                      
+                        
+                        
+                        
+                        
+                          
+                            
+                            
+                              <p class="file-y"><span>1</span></p>
+                            
+                          
+                        
+                      
+                    </td>
+                  
+									
+										
+									
+										
+									
+								</tr>
+							
+								
+									
+									
+									
+									
+										
+										<tr class="">
+									
+								
+									
+									<td class="td-num">616</td>
+									<td class="td-subject">
+										
+											
+											
+											
+											
+												<a href="/bbs/cse/775/828679/artclView.do" onclick="jf_viewArtcl('cse', '775', '828679')">
+											
+										
+										
+										
+											
+											
+											
+											
+												
+												<strong>[학사] 성적평점 백분위 환산점수표 관련 규정 개정 안내</strong>
+												
+											
+										
+										
+											
+											
+											
+											
+												</a>
+											
+										
+									</td>
+									<td class="td-write">
+										
+											
+											
+											
+											
+												
+													
+													
+													
+														컴퓨터공학부
+													
+												
+											
+										
+									</td>
+                  
+									<td class="td-date">2024.01.30</td>
+									
+									
+									<td class="td-access">
+										
+											
+											
+											
+											
+												26
+											
+										
+									</td>
+									
+                    <td class="td-file file">
+                      
+                        
+                        
+                        
+                        
+                          
+                            
+                            
+                              <p class="file-y"><span>1</span></p>
+                            
+                          
+                        
+                      
+                    </td>
+                  
+									
+										
+									
+										
+									
+								</tr>
+							
+						
+						
+						
+					</tbody>
+			</table>
+		</div>
+	</form>
+
+	<form name="pageForm" method="post" action="/bbs/cse/775/artclList.do">
+		<input type="hidden" name="layout" value="" />
+		<input type="hidden" id="page" name="page" value="1">
+		<input type="hidden" name="srchColumn" value="">
+		<input type="hidden" name="srchWrd" value="">
+		<input type="hidden" name="bbsClSeq" value=""/>
+		<input type="hidden" name="bbsOpenWrdSeq" value="" />
+		<input type="hidden" name="rgsBgndeStr" value="">
+		<input type="hidden" name="rgsEnddeStr" value="">
+		<input type="hidden" name="isViewMine" value="false" />
+		<div class="_paging">
+	<div class="_inner">
+		<a href="javascript:page_link('1')" class="_first" title="처음 목록으로 이동">처음</a>
+<p class="_pageState"><span class="_curPage">1</span><span class="_totPage">63</span></p><ul>
+<li><strong title="현재 페이지">1</strong></li>
+<li><a href="javascript:page_link('2')" title="2페이지">2</a></li>
+<li><a href="javascript:page_link('3')" title="3페이지">3</a></li>
+<li><a href="javascript:page_link('4')" title="4페이지">4</a></li>
+<li><a href="javascript:page_link('5')" title="5페이지">5</a></li>
+<li><a href="javascript:page_link('6')" title="6페이지">6</a></li>
+<li><a href="javascript:page_link('7')" title="7페이지">7</a></li>
+<li><a href="javascript:page_link('8')" title="8페이지">8</a></li>
+<li><a href="javascript:page_link('9')" title="9페이지">9</a></li>
+<li><a href="javascript:page_link('10')" title="10페이지">10</a></li>
+</ul>
+<a href="javascript:page_link('2')" class="_listNext" title="다음 페이지">다음 페이지</a>
+<a href="javascript:page_link('11')" class="_next" title="다음 목록으로 이동">다음</a>
+<a href="javascript:page_link('63')" class="_last" title="마지막 목록으로 이동">끝</a>
+	</div>
+</div>
+
+	</form>
+
+	<!-- Button -->
+	<div class="board-button">
+		<div class="btn-mine">
+			
+		</div>
+		<div class="btn-control">
+			
+		</div>
+	</div>
+</div>
+
+
+
+
+<script defer src="/Web-home/fnct/bbs/kon-board-normal1/js/artclList.js"></script>
+
+
+
+
+
+</body>
+</html>
+
+


### PR DESCRIPTION
* test: getTotalNoticeSize 메서드 단위 테스트

* feat: 학과별 정보 수정

* feat: 학과별 공지 스크랩 로직 수정

* fix(DeptInfo#createViewUrl): 정상적으로 view Url을 만들지 못하던 문제 해결

* refactor(CategoryNoticeUpdater): updateKuisNoticeAsync에서 reverse로직 추가

* refactor: 시간 측정 로직 변경

* feat: 기존 학과별 공지 삭제 DDL문 작성

* test: 테스트에서 변경 가능한 리스트를 반환하도록 수정