### PR TITLE
[Fix] 경영학과 HostPrefix 수정

### DIFF
--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/business/BusinessAdministrationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/business/BusinessAdministrationDept.java
@@ -26,7 +26,7 @@ public class BusinessAdministrationDept extends BusinessCollege {
 
         List<String> professorForumIds = List.of("10499");
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
-        this.noticeScrapInfo = new NoticeScrapInfo(BUIS_ADMIN.getKorName(), 437);
+        this.noticeScrapInfo = new NoticeScrapInfo("kbs", 437);
         this.departmentName = BUIS_ADMIN;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/update/notice/DepartmentNoticeUpdater.java
+++ b/src/main/java/com/kustacks/kuring/worker/update/notice/DepartmentNoticeUpdater.java
@@ -43,9 +43,14 @@ public class DepartmentNoticeUpdater {
 
         for (DeptInfo deptInfo : deptInfoList) {
             CompletableFuture
-                    .supplyAsync(() -> updateDepartmentAsync(deptInfo, DeptInfo::scrapLatestPageHtml), noticeUpdaterThreadTaskExecutor)
-                    .thenApply(scrapResults -> compareLatestAndUpdateDB(scrapResults, deptInfo.getDeptName()))
-                    .thenAccept(notificationService::sendNotificationList);
+                    .supplyAsync(
+                            () -> updateDepartmentAsync(deptInfo, DeptInfo::scrapLatestPageHtml),
+                            noticeUpdaterThreadTaskExecutor
+                    ).thenApply(
+                            scrapResults -> compareLatestAndUpdateDB(scrapResults, deptInfo.getDeptName())
+                    ).thenAccept(
+                            notificationService::sendNotificationList
+                    );
         }
     }
 

--- a/src/main/java/com/kustacks/kuring/worker/update/notice/KuisHomepageNoticeUpdater.java
+++ b/src/main/java/com/kustacks/kuring/worker/update/notice/KuisHomepageNoticeUpdater.java
@@ -53,7 +53,9 @@ public class KuisHomepageNoticeUpdater {
                             noticeUpdaterThreadTaskExecutor
                     ).thenApply(
                             scrapResults -> compareLatestAndUpdateDB(scrapResults, kuisNoticeInfo.getCategoryName())
-                    ).thenAccept(notificationService::sendNotificationList);
+                    ).thenAccept(
+                            notificationService::sendNotificationList
+                    );
         }
     }
 


### PR DESCRIPTION
경영학과의 경우 기존 hostPrefix가 아닌 KBS라는 신규 키워드를 사용하고 있었다.
따라서 공지 스크랩이 정상적으로 이루어지고 있지 않아 별도로 처리한다.