### PR TITLE
version 2.7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter:1.19.8'
     testImplementation 'org.testcontainers:mariadb:1.19.8'
     testImplementation 'org.testcontainers:chromadb:1.19.8'
+    testImplementation 'io.projectreactor:reactor-test'
 }
 
 dependencyManagement {

--- a/src/main/java/com/kustacks/kuring/ai/adapter/out/model/InMemoryQueryAiModelAdapter.java
+++ b/src/main/java/com/kustacks/kuring/ai/adapter/out/model/InMemoryQueryAiModelAdapter.java
@@ -1,8 +1,6 @@
 package com.kustacks.kuring.ai.adapter.out.model;
 
 import com.kustacks.kuring.ai.application.port.out.QueryAiModelPort;
-import com.kustacks.kuring.common.exception.InvalidStateException;
-import com.kustacks.kuring.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -26,10 +24,6 @@ public class InMemoryQueryAiModelAdapter implements QueryAiModelPort {
                     "는", " ", "0", "2", "-", "4", "5", "0", "-", "3", "9", "6", "7", "로", " ", "하", "시",
                     "면", " ", "됩", "니", "다", "."
             );
-        }
-
-        if (prompt.getContents().contains("잘못된 질문")) {
-            throw new InvalidStateException(ErrorCode.AI_SIMILAR_DOCUMENTS_NOT_FOUND);
         }
 
         return Flux.just("미", "리", " ", "준", "비", "된", " ",

--- a/src/main/java/com/kustacks/kuring/ai/adapter/out/persistence/InMemoryVectorStoreAdapter.java
+++ b/src/main/java/com/kustacks/kuring/ai/adapter/out/persistence/InMemoryVectorStoreAdapter.java
@@ -10,6 +10,7 @@ import org.springframework.ai.document.Document;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Stream;
@@ -22,6 +23,8 @@ public class InMemoryVectorStoreAdapter implements QueryVectorStorePort, Command
 
     @Override
     public List<String> findSimilarityContents(String question) {
+        if(question.equals("잘못된 질문")) return Collections.emptyList();
+
         HashMap<String, Object> metadata = createMetaData();
 
         Document document = createDocument(metadata);

--- a/src/main/java/com/kustacks/kuring/ai/application/service/RAGQueryService.java
+++ b/src/main/java/com/kustacks/kuring/ai/application/service/RAGQueryService.java
@@ -33,9 +33,14 @@ public class RAGQueryService implements RAGQueryUseCase {
 
     @Override
     public Flux<String> askAiModel(String question, String id) {
-        ragEventPort.userDecreaseQuestionCountEvent(id);
-        Prompt completePrompt = buildCompletePrompt(question);
-        return ragChatModel.call(completePrompt);
+        try {
+            ragEventPort.userDecreaseQuestionCountEvent(id);
+            Prompt completePrompt = buildCompletePrompt(question);
+            return ragChatModel.call(completePrompt);
+        } catch (InvalidStateException e) {
+            final String separator = "";
+            return Flux.fromArray(e.getErrorCode().getMessage().split(separator));
+        }
     }
 
     @PostConstruct

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -38,12 +38,12 @@ spring:
       api-key: ${AI_API_KEY}
       chat:
         options:
-          model: gpt-3.5-turbo
+          model: ${AI_CHAT_MODEL}
           temperature: 0.0
           maxTokens: 1000
       embedding:
         options:
-          model: text-embedding-3-small
+          model: ${AI_EMBEDDING_MODEL}
     vectorstore:
       chroma:
         client:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -42,12 +42,12 @@ spring:
       api-key: ${AI_API_KEY}
       chat:
         options:
-          model: gpt-3.5-turbo
+          model: ${AI_CHAT_MODEL}
           temperature: 0.0
           maxTokens: 1000
       embedding:
         options:
-          model: text-embedding-3-small
+          model: ${AI_EMBEDDING_MODEL}
     vectorstore:
       chroma:
         client:

--- a/src/test/java/com/kustacks/kuring/acceptance/AiAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/AiAcceptanceTest.java
@@ -1,16 +1,25 @@
 package com.kustacks.kuring.acceptance;
 
 import com.kustacks.kuring.support.IntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import static com.kustacks.kuring.acceptance.AiStep.*;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.kustacks.kuring.acceptance.AiStep.모델_응답_확인;
+import static com.kustacks.kuring.acceptance.AiStep.사용자_질문_요청;
 
 @DisplayName("인수 : 인공지능")
 class AiAcceptanceTest extends IntegrationTestSupport {
+
+    WebTestClient client;
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        client = WebTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
+    }
 
     /**
      * Given : 쿠링앱이 실행중이다
@@ -21,14 +30,18 @@ class AiAcceptanceTest extends IntegrationTestSupport {
     @Test
     void ask_to_open_ai() {
         // given
-        WebTestClient client = WebTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
         String question = "교내,외 장학금 및 학자금 대출 관련 전화번호들을 안내를 해줘";
 
         // when
         var 모델_응답 = 사용자_질문_요청(client, question, USER_FCM_TOKEN);
 
         // then
-        모델_응답_검증(모델_응답, HttpStatus.OK.value());
+        모델_응답_확인(모델_응답, "학", "생", "복", "지", "처", "장", "학", "복", "지", "팀", "의",
+                "전", "화", "번", "호", "는", "0", "2", "-", "4", "5", "0", "-", "3", "2", "1",
+                "1", "~", "2", "이", "며", ",", "건", "국", "사", "랑", "/", "장", "학", "사", "정",
+                "관", "장", "학", "/", "기", "금", "장", "학", "과", "관", "련", "된", "문", "의",
+                "는", "0", "2", "-", "4", "5", "0", "-", "3", "9", "6", "7", "로", "하", "시",
+                "면", "됩", "니", "다", ".");
     }
 
     /**
@@ -41,15 +54,14 @@ class AiAcceptanceTest extends IntegrationTestSupport {
     void ask_to_open_ai_overflow_count() {
         // given
         String question = "교내,외 장학금 및 학자금 대출 관련 전화번호들을 안내를 해줘";
-        사용자_질문_요청_REST(question, USER_FCM_TOKEN);
-        사용자_질문_요청_REST(question, USER_FCM_TOKEN);
-        사용자_질문_요청_REST(question, USER_FCM_TOKEN);
+        사용자_질문_요청(client, question, USER_FCM_TOKEN);
+        사용자_질문_요청(client, question, USER_FCM_TOKEN);
 
         // when
-        var 모델_응답 = 사용자_질문_요청_REST(question, USER_FCM_TOKEN);
+        var 모델_응답 = 사용자_질문_요청(client, question, USER_FCM_TOKEN);
 
         // then
-        assertThat(모델_응답.statusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+        모델_응답_확인(모델_응답, "남", "은", "질", "문", "횟", "수", "가", "부", "족", "합", "니", "다", ".");
     }
 
     /**
@@ -64,10 +76,11 @@ class AiAcceptanceTest extends IntegrationTestSupport {
         String question = "잘못된 질문";
 
         // when
-        var 모델_응답 = 사용자_질문_요청_REST(question, USER_FCM_TOKEN);
+        var 모델_응답 = 사용자_질문_요청(client, question, USER_FCM_TOKEN);
 
         // then
-        assertThat(모델_응답.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        모델_응답_확인(모델_응답, "죄", "송", "합", "니", "다", ",", "관", "련", "된", "내",
+                "용", "에", "대", "하", "여", "알", "지", "못", "합", "니", "다", ".");
     }
 }
 


### PR DESCRIPTION
* setting: reactor-test 의존성 추가

* test(AiAcceptanceTest): 질문하는 인수테스트 StepVerifier를 사용하도록 변경

* feat(RAGQueryService): RAGQueryService 내부에서 직접 예외처리 구현

기존에는 ExceptionHandler 로 처리하였지만, 이는 JSON 응답에 적합하지 Flux<String>을 반환하기에 적합하지 않는것 같다. 따라서 직접적으로 Service 에서 예외를 처리하여 반환한다.

* setting: ai model 과 embedding model 을 외부 환경변수로 분리