### PR TITLE
version 2.9.0

### DIFF
--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -31,6 +31,7 @@ public enum ResponseCodeAndMessages {
     BOOKMARK_LOOKUP_SUCCESS(HttpStatus.OK.value(), "북마크 조회에 성공하였습니다"),
     FEEDBACK_SAVE_SUCCESS(HttpStatus.OK.value(), "피드백 저장에 성공하였습니다"),
     FEEDBACK_SEARCH_SUCCESS(HttpStatus.OK.value(), "피드백 조회에 성공하였습니다"),
+    ASK_COUNT_LOOKUP_SUCCESS(HttpStatus.OK.value(), "질문 가능 횟수 조회에 성공하였습니다"),
 
     /* Alert */
     ALERT_SEARCH_SUCCESS(HttpStatus.OK.value(), "예약 알림 조회에 성공하였습니다"),

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserQueryApiV2.java
@@ -2,10 +2,12 @@ package com.kustacks.kuring.user.adapter.in.web;
 
 import com.kustacks.kuring.common.annotation.RestWebAdapter;
 import com.kustacks.kuring.common.dto.BaseResponse;
+import com.kustacks.kuring.user.adapter.in.web.dto.UserAIAskCountResponse;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserBookmarkResponse;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserCategoryNameResponse;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserDepartmentNameResponse;
 import com.kustacks.kuring.user.application.port.in.UserQueryUseCase;
+import com.kustacks.kuring.user.application.port.in.dto.UserAIAskCountResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -71,5 +73,16 @@ class UserQueryApiV2 {
                 .toList();
 
         return ResponseEntity.ok().body(new BaseResponse<>(BOOKMARK_LOOKUP_SUCCESS, responses));
+    }
+
+    @Operation(summary = "사용자 질문 가능횟수 조회", description = "사용자의 남은 질문횟수와 가능한 질문 횟수를 조회합니다")
+    @SecurityRequirement(name = USER_TOKEN_HEADER_KEY)
+    @GetMapping("/ask-counts")
+    public ResponseEntity<BaseResponse<UserAIAskCountResponse>> lookupUserAIAskCount(
+            @RequestHeader(USER_TOKEN_HEADER_KEY) String userToken
+    ) {
+        UserAIAskCountResult result = userQueryUseCase.lookupUserAIAskCount(userToken);
+        UserAIAskCountResponse response = UserAIAskCountResponse.from(result);
+        return ResponseEntity.ok().body(new BaseResponse<>(ASK_COUNT_LOOKUP_SUCCESS, response));
     }
 }

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserAIAskCountResponse.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserAIAskCountResponse.java
@@ -1,0 +1,12 @@
+package com.kustacks.kuring.user.adapter.in.web.dto;
+
+import com.kustacks.kuring.user.application.port.in.dto.UserAIAskCountResult;
+
+public record UserAIAskCountResponse(
+        int leftAskCount,
+        int maxAskCount
+) {
+    public static UserAIAskCountResponse from(UserAIAskCountResult result) {
+        return new UserAIAskCountResponse(result.leftAskCount(), result.maxAskCount());
+    }
+}

--- a/src/main/java/com/kustacks/kuring/user/application/port/in/UserQueryUseCase.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/in/UserQueryUseCase.java
@@ -1,5 +1,6 @@
 package com.kustacks.kuring.user.application.port.in;
 
+import com.kustacks.kuring.user.application.port.in.dto.UserAIAskCountResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserBookmarkResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserCategoryNameResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserDepartmentNameResult;
@@ -10,4 +11,6 @@ public interface UserQueryUseCase {
     List<UserCategoryNameResult> lookupSubscribeCategories(String userToken);
     List<UserDepartmentNameResult> lookupSubscribeDepartments(String userToken);
     List<UserBookmarkResult> lookupUserBookmarkedNotices(String userToken);
+
+    UserAIAskCountResult lookupUserAIAskCount(String userToken);
 }

--- a/src/main/java/com/kustacks/kuring/user/application/port/in/dto/UserAIAskCountResult.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/in/dto/UserAIAskCountResult.java
@@ -1,0 +1,7 @@
+package com.kustacks.kuring.user.application.port.in.dto;
+
+public record UserAIAskCountResult(
+        int leftAskCount,
+        int maxAskCount
+) {
+}

--- a/src/main/java/com/kustacks/kuring/user/application/service/UserQueryService.java
+++ b/src/main/java/com/kustacks/kuring/user/application/service/UserQueryService.java
@@ -8,6 +8,7 @@ import com.kustacks.kuring.notice.application.port.out.NoticeQueryPort;
 import com.kustacks.kuring.notice.domain.CategoryName;
 import com.kustacks.kuring.notice.domain.DepartmentName;
 import com.kustacks.kuring.user.application.port.in.UserQueryUseCase;
+import com.kustacks.kuring.user.application.port.in.dto.UserAIAskCountResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserBookmarkResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserCategoryNameResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserDepartmentNameResult;
@@ -53,6 +54,12 @@ class UserQueryService implements UserQueryUseCase {
         User user = findUserByToken(userToken);
         List<String> bookmarkIds = user.lookupAllBookmarkIds();
         return lookupAllBookmarkByIds(bookmarkIds);
+    }
+
+    @Override
+    public UserAIAskCountResult lookupUserAIAskCount(String userToken) {
+        User user = findUserByToken(userToken);
+        return new UserAIAskCountResult(user.getQuestionCount(), User.MONTHLY_QUESTION_COUNT);
     }
 
     private List<UserBookmarkResult> lookupAllBookmarkByIds(List<String> bookmarkIds) {

--- a/src/main/java/com/kustacks/kuring/user/domain/User.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/User.java
@@ -47,6 +47,7 @@ public class User implements Serializable {
     @Column(name = "deleted", nullable = false)
     private boolean deleted = Boolean.FALSE;
 
+    @Getter(AccessLevel.PUBLIC)
     @Column(columnDefinition = "integer default 0")
     private Integer questionCount;
 

--- a/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
@@ -199,4 +199,22 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         // then
         북마크_조회_응답_확인(북마크_조회_응답);
     }
+
+    /**
+     * Given : 사용자가 AI 질문을 한적이 있다
+     * When : 남은 질문 가능 횟수를 조회한다
+     * Then : 성공적으로 질문 가능횟수와 가능한 최대 질문 횟수를 반환한다
+     */
+    @DisplayName("[v2] 사용자는 자신의 남은 질문 가능 횟수를 조회할 수 있다")
+    @Test
+    void lookup_ask_count() {
+        // given
+        doNothing().when(firebaseSubscribeService).validationToken(anyString());
+
+        // when
+        var 질문_횟수_조회_응답 = 남은_질문_횟수_조회(USER_FCM_TOKEN);
+
+        // then
+        질문_횟수_응답_검증(질문_횟수_조회_응답);
+    }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -167,4 +167,23 @@ public class UserStep {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 남은_질문_횟수_조회(String userToken) {
+        return RestAssured
+                .given().log().all()
+                .header("User-Token", userToken)
+                .when().get("/api/v2/users/ask-counts")
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 질문_횟수_응답_검증(ExtractableResponse<Response> 질문_횟수_조회_응답) {
+        assertAll(
+                () -> assertThat(질문_횟수_조회_응답.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(질문_횟수_조회_응답.jsonPath().getInt("code")).isEqualTo(200),
+                () -> assertThat(질문_횟수_조회_응답.jsonPath().getString("message")).isEqualTo("질문 가능 횟수 조회에 성공하였습니다"),
+                () -> assertThat(질문_횟수_조회_응답.jsonPath().getInt("data.leftAskCount")).isEqualTo(2),
+                () -> assertThat(질문_횟수_조회_응답.jsonPath().getInt("data.maxAskCount")).isEqualTo(2)
+        );
+    }
 }


### PR DESCRIPTION
사용자의 질문 횟수를 조회하는 API 기능 추가
* test(UserAcceptanceTest): 사용자의 질문 가능 횟수를 조회하는 인수테스트 작성
* feat(UserQueryApiV2): 사용자 질문 횟수 조회 API 구현 완료