### PR TITLE
Feat : 직위 추가 ddl 수정, 교직원 스크랩 로직 및 주기 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ out/
 ### API docs ###
 **/src/main/resources/static/docs/*
 
-**/ku-stack-firebase-adminsdk-87nwq-5ba04dfc12.json
+**/ku-stack-firebase-adminsdk-87nwq-ae6a2df931.json
+**/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ configurations.all {
     }
 }
 
-test.onlyIf { System.getenv('DEPLOY_ENV') == 'dev' }
+//test.onlyIf { System.getenv('DEPLOY_ENV') == 'dev' }
 
 test {
     jacoco {

--- a/src/main/java/com/kustacks/kuring/staff/adapter/out/persistence/StaffRepository.java
+++ b/src/main/java/com/kustacks/kuring/staff/adapter/out/persistence/StaffRepository.java
@@ -3,9 +3,6 @@ package com.kustacks.kuring.staff.adapter.out.persistence;
 import com.kustacks.kuring.staff.domain.Staff;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface StaffRepository extends JpaRepository<Staff, Long>, StaffQueryRepository {
 
-    List<Staff> findByDeptContaining(String deptName);
 }

--- a/src/main/java/com/kustacks/kuring/worker/update/staff/StaffDataSynchronizer.java
+++ b/src/main/java/com/kustacks/kuring/worker/update/staff/StaffDataSynchronizer.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -29,20 +28,19 @@ public class StaffDataSynchronizer {
     }
 
     private StaffCompareResults compare(StaffScrapResults scrapResults) {
-        Map<String, Staff> originStaffStorage = findByDeptContainingMap(scrapResults.successDepartmentNames());
+        Map<String, Staff> originStaffStorage = findAllOriginStaffs();
         return staffCompareSupport.compareAllDepartmentsAndUpdateExistStaff(scrapResults.kuStaffDTOMap(), originStaffStorage);
     }
 
     private void synchronizationWithDb(StaffCompareResults compareResults) {
+        System.out.println(compareResults.toString());
         staffRepository.deleteAll(compareResults.deleteStaffs());
         staffRepository.saveAll(compareResults.newStaffs());
     }
 
-    private Map<String, Staff> findByDeptContainingMap(List<String> scrapSuccessDepartmentNames) {
-        return scrapSuccessDepartmentNames.stream()
-                .flatMap(
-                        deptName -> staffRepository.findByDeptContaining(deptName).stream()
-                ).collect(
+    private Map<String, Staff> findAllOriginStaffs() {
+        return staffRepository.findAll().stream()
+                .collect(
                         Collectors.toMap(
                                 Staff::identifier,
                                 Function.identity(),

--- a/src/main/java/com/kustacks/kuring/worker/update/staff/StaffDataSynchronizer.java
+++ b/src/main/java/com/kustacks/kuring/worker/update/staff/StaffDataSynchronizer.java
@@ -33,7 +33,6 @@ public class StaffDataSynchronizer {
     }
 
     private void synchronizationWithDb(StaffCompareResults compareResults) {
-        System.out.println(compareResults.toString());
         staffRepository.deleteAll(compareResults.deleteStaffs());
         staffRepository.saveAll(compareResults.newStaffs());
     }

--- a/src/main/java/com/kustacks/kuring/worker/update/staff/StaffUpdater.java
+++ b/src/main/java/com/kustacks/kuring/worker/update/staff/StaffUpdater.java
@@ -11,7 +11,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -26,7 +25,7 @@ public class StaffUpdater {
     private final StaffScraper staffScraper;
     private final List<DeptInfo> deptInfos;
     
-    @Scheduled(fixedRate = 1, timeUnit = TimeUnit.DAYS)
+    @Scheduled(fixedRate = 30, timeUnit = TimeUnit.DAYS)
     public void update() {
         log.info("========== 교직원 업데이트 시작 ==========");
 
@@ -38,19 +37,17 @@ public class StaffUpdater {
 
     private StaffScrapResults scrapAllDepartmentsStaffs() {
         Map<String, StaffDto> kuStaffDtoMap = new HashMap<>();
-        List<String> successDepartmentNames = new LinkedList<>();
 
         deptInfos.stream()
                 .filter(DeptInfo::isSupportStaffScrap)
-                .forEach(deptInfo -> scrapSingleDepartmentsStaffs(kuStaffDtoMap, successDepartmentNames, deptInfo));
-        return new StaffScrapResults(kuStaffDtoMap, successDepartmentNames);
+                .forEach(deptInfo -> scrapSingleDepartmentsStaffs(kuStaffDtoMap, deptInfo));
+        return new StaffScrapResults(kuStaffDtoMap);
     }
 
-    private void scrapSingleDepartmentsStaffs(Map<String, StaffDto> kuStaffDtoMap, List<String> successDepartmentNames, DeptInfo deptInfo) {
+    private void scrapSingleDepartmentsStaffs(Map<String, StaffDto> kuStaffDtoMap, DeptInfo deptInfo) {
         try {
             Map<String, StaffDto> staffScrapResultMap = scrapStaffByDepartment(deptInfo);
             mergeForMultipleDepartmentsStaff(kuStaffDtoMap, staffScrapResultMap);
-            successDepartmentNames.add(deptInfo.getDeptName());
         } catch (InternalLogicException e) {
             log.error("[StaffScraperException] {}학과 교직원 스크래핑 문제 발생.", deptInfo.getDeptName());
         }

--- a/src/main/java/com/kustacks/kuring/worker/update/staff/dto/StaffScrapResults.java
+++ b/src/main/java/com/kustacks/kuring/worker/update/staff/dto/StaffScrapResults.java
@@ -4,11 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 public record StaffScrapResults(
-        Map<String, StaffDto> kuStaffDTOMap,
-        List<String> successDepartmentNames
+        Map<String, StaffDto> kuStaffDTOMap
 ) {
 
-    public List<StaffDto> getStaffDtos() {
-        return kuStaffDTOMap.values().stream().toList();
-    }
 }

--- a/src/main/resources/db/migration/V241130__Add_position_to_staff.sql
+++ b/src/main/resources/db/migration/V241130__Add_position_to_staff.sql
@@ -1,2 +1,2 @@
 ALTER TABLE staff
-    ADD column position varchar(64) default false;
+    ADD column position varchar(64);

--- a/src/test/java/com/kustacks/kuring/worker/update/staff/StaffUpdaterTest.java
+++ b/src/test/java/com/kustacks/kuring/worker/update/staff/StaffUpdaterTest.java
@@ -86,8 +86,7 @@ class StaffUpdaterTest extends IntegrationTestSupport {
         kuStaffDtoMap.put(dto1.identifier(), dto1);
         kuStaffDtoMap.put(dto2.identifier(), dto2);
 
-        List<String> successDepartmentNames = List.of("컴퓨터공학과", "생명과학부");
-        StaffScrapResults staffScrapResults = new StaffScrapResults(kuStaffDtoMap, successDepartmentNames);
+        StaffScrapResults staffScrapResults = new StaffScrapResults(kuStaffDtoMap);
 
         // when
         staffDataSynchronizer.compareAndUpdateDb(staffScrapResults);


### PR DESCRIPTION
## 관련 이슈
#149 

## 📝작업 내용

### 1. ddl default 값 수정
이전 PR에서 default 값이 잘못 들어가서 "0"으로 들어가는 현상을 수정하기 위해 ddl수정했습니닷.
PR머지 전 dev 서버DB에서 flyway 기록 삭제, 만들어져있는 position column 삭제하려고 합니당

### 2. 이전까진 학과 이름이 변경된 경우 DB에서 조회 되지 않아 스크랩한 내용과 비교가 불가능해 삭제되지 않는 현상
이를 위해 DB에 있는 전체학과를 조회하여 비교하도록 구현했습니다. 로컬에서 정상적으로 비교, 삭제되는것 확인했습니다!

### 3. 교직원 스크랩 주기를 배포를 위해 30일로 다시 변경했습니닷
