### PR TITLE
[Fix] heroku 배포 에러 해결

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -35,6 +35,10 @@ jobs:
           git add .
           git commit -m "Build Ready"
 
+      - name: Install Heroku CLI
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh 
+
       - name: Deploy to Heroku
         # You may pin to the exact commit or the version.
         # uses: AkhileshNS/heroku-deploy@79ef2ae4ff9b897010907016b268fd0f88561820


### PR DESCRIPTION
### [문제 상황](https://github.com/ku-ring/ku-ring-backend-web/actions/runs/13427807727/job/37514447516)

위 문제 해결하기 위해서 찾아본 결과 아래 링크참고하여 조치합니다.

> Please Note: ubuntu-latest which as of the time of updating this documentation is 24.04 no longer supports the heroku-cli by default. So if you must use the latest version of ubuntu-latest, be sure to install heroku-cli (instructions [here](https://devcenter.heroku.com/articles/heroku-cli#install-the-heroku-cli)) before running the plugin.

### [참고 링크](https://github.com/AkhileshNS/heroku-deploy/issues/188)

