### PR TITLE
Feat : 회원탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -39,6 +39,7 @@ public enum ResponseCodeAndMessages {
     USER_SIGNUP(HttpStatus.CREATED.value(), "사용자 계정 생성에 성공했습니다."),
     USER_LOGIN(HttpStatus.OK.value(), "로그인에 성공했습니다."),
     USER_LOGOUT(HttpStatus.OK.value(), "로그아웃에 성공했습니다."),
+    USER_WITHDRAW(HttpStatus.OK.value(), "회원탈퇴 되었습니다"),
 
     /* Alert */
     ALERT_SEARCH_SUCCESS(HttpStatus.OK.value(), "예약 알림 조회에 성공하였습니다"),

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -39,7 +39,7 @@ public enum ResponseCodeAndMessages {
     USER_SIGNUP(HttpStatus.CREATED.value(), "사용자 계정 생성에 성공했습니다."),
     USER_LOGIN(HttpStatus.OK.value(), "로그인에 성공했습니다."),
     USER_LOGOUT(HttpStatus.OK.value(), "로그아웃에 성공했습니다."),
-    USER_WITHDRAW(HttpStatus.OK.value(), "회원탈퇴 되었습니다"),
+    USER_WITHDRAW(HttpStatus.NO_CONTENT.value(), "회원탈퇴 되었습니다"),
 
     /* Alert */
     ALERT_SEARCH_SUCCESS(HttpStatus.OK.value(), "예약 알림 조회에 성공하였습니다"),

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/RootUserRepository.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/RootUserRepository.java
@@ -12,6 +12,9 @@ interface RootUserRepository extends JpaRepository<RootUser, Long> {
     Optional<RootUser> findByEmail(String email);
     Optional<RootUser> findByNickname(String nickname);
 
+    @Query(value = "SELECT * FROM root_user WHERE email = :email AND deleted = true", nativeQuery = true)
+    Optional<RootUser> findDeletedRootUserByEmail(@Param("email") String email);
+
     @Modifying(clearAutomatically = true)
     @Query("UPDATE RootUser ru SET ru.questionCount = :monthlyQuestionCount")
     void resetAllRootUserQuestionCount(@Param("monthlyQuestionCount") int monthlyQuestionCount);

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -93,4 +93,9 @@ public class UserPersistenceAdapter implements UserCommandPort, UserQueryPort, A
     public void resetAllRootUserQuestionCount() {
         rootUserRepository.resetAllRootUserQuestionCount(ROOT_USER_MONTHLY_QUESTION_COUNT);
     }
+
+    @Override
+    public void deleteRootUser(RootUser rootUser) {
+        rootUserRepository.delete(rootUser);
+    }
 }

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -75,6 +75,11 @@ public class UserPersistenceAdapter implements UserCommandPort, UserQueryPort, A
     }
 
     @Override
+    public List<User> findByLoggedInUserId(Long id) {
+        return userRepository.findByLoginUserId(id);
+    }
+
+    @Override
     public boolean existRootUserByEmail(String email) {
         return rootUserRepository.findByEmail(email).isPresent();
     }

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -45,6 +45,11 @@ public class UserPersistenceAdapter implements UserCommandPort, UserQueryPort, A
     }
 
     @Override
+    public Optional<RootUser> findDeletedRootUserByEmail(String email) {
+        return rootUserRepository.findDeletedRootUserByEmail(email);
+    }
+
+    @Override
     public List<User> findAll() {
         return userRepository.findAll();
     }

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserRepository.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserRepository.java
@@ -12,4 +12,6 @@ interface UserRepository extends JpaRepository<User, Long>, UserQueryRepository 
 
     @Query("SELECT u.fcmToken FROM User u")
     List<String> findAllFcmTokens();
+
+    List<User> findByLoginUserId(Long loginUserId);
 }

--- a/src/main/java/com/kustacks/kuring/user/application/port/in/UserCommandUseCase.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/in/UserCommandUseCase.java
@@ -11,4 +11,5 @@ public interface UserCommandUseCase {
     void signupUser(UserSignupCommand userSignupCommand);
     void logout(UserLogoutCommand userLogoutCommand);
     UserLoginResult login(UserLoginCommand userLoginCommand);
+    void withdraw(UserWithdrawCommand userWithdrawCommand);
 }

--- a/src/main/java/com/kustacks/kuring/user/application/port/in/dto/UserWithdrawCommand.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/in/dto/UserWithdrawCommand.java
@@ -1,0 +1,6 @@
+package com.kustacks.kuring.user.application.port.in.dto;
+
+public record UserWithdrawCommand(
+        String email
+) {
+}

--- a/src/main/java/com/kustacks/kuring/user/application/port/out/RootUserCommandPort.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/out/RootUserCommandPort.java
@@ -6,4 +6,5 @@ public interface RootUserCommandPort {
     RootUser saveRootUser(RootUser rootUser);
 
     void resetAllRootUserQuestionCount();
+    void deleteRootUser(RootUser rootUser);
 }

--- a/src/main/java/com/kustacks/kuring/user/application/port/out/RootUserQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/out/RootUserQueryPort.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 public interface RootUserQueryPort {
     Optional<RootUser> findRootUserByEmail(String email);
+    Optional<RootUser> findDeletedRootUserByEmail(String email);
 
     boolean existRootUserByEmail(String email);
 }

--- a/src/main/java/com/kustacks/kuring/user/application/port/out/UserQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/out/UserQueryPort.java
@@ -12,7 +12,8 @@ public interface UserQueryPort {
 
     List<User> findAll();
     List<User> findByPageRequest(Pageable pageable);
-
+    List<User> findByLoggedInUserId(Long id);
+    
     Long countUser();
 
     boolean existByNickname(String nickname);

--- a/src/main/java/com/kustacks/kuring/user/application/service/UserCommandService.java
+++ b/src/main/java/com/kustacks/kuring/user/application/service/UserCommandService.java
@@ -141,7 +141,7 @@ class UserCommandService implements UserCommandUseCase {
     }
 
     private void logoutAllLoginedUser(RootUser rootUser) {
-        userQueryPort.findByLoginedUserId(rootUser.getId())
+        userQueryPort.findByLoggedInUserId(rootUser.getId())
                 .forEach(User::logout);
     }
 

--- a/src/main/java/com/kustacks/kuring/user/domain/RootUser.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/RootUser.java
@@ -57,4 +57,10 @@ public class RootUser implements Serializable {
     public void updateQuestionCount(int questionCount) {
         this.questionCount = questionCount;
     }
+
+    public void reactive(String password) {
+        this.password = password;
+        this.deleted = Boolean.FALSE;
+        this.questionCount = ROOT_USER_MONTHLY_QUESTION_COUNT;
+    }
 }

--- a/src/main/java/com/kustacks/kuring/user/domain/RootUser.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/RootUser.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.io.Serializable;
 
@@ -15,6 +17,8 @@ import static com.kustacks.kuring.user.domain.User.FCM_USER_MONTHLY_QUESTION_COU
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "update root_user set deleted = true where id = ?")
+@SQLRestriction("deleted = false")
 public class RootUser implements Serializable {
     public static final int ROOT_USER_EXTRA_QUESTION_COUNT = 3;
     public static final int ROOT_USER_MONTHLY_QUESTION_COUNT = FCM_USER_MONTHLY_QUESTION_COUNT + ROOT_USER_EXTRA_QUESTION_COUNT;
@@ -39,6 +43,9 @@ public class RootUser implements Serializable {
     @Getter(AccessLevel.PUBLIC)
     @Column(columnDefinition = "integer default 0")
     private Integer questionCount;
+
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted = Boolean.FALSE;
 
     public RootUser(String email, String password, String nickname) {
         this.email = email;

--- a/src/main/resources/db/migration/V250318__Add_deleted_to_root_user.sql
+++ b/src/main/resources/db/migration/V250318__Add_deleted_to_root_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE root_user
+    ADD column deleted boolean default false;

--- a/src/main/resources/db/migration/V250319__Drop_unique_key_from_email.sql
+++ b/src/main/resources/db/migration/V250319__Drop_unique_key_from_email.sql
@@ -1,2 +1,0 @@
-ALTER TABLE root_user
-    DROP KEY email;

--- a/src/main/resources/db/migration/V250319__Drop_unique_key_from_email.sql
+++ b/src/main/resources/db/migration/V250319__Drop_unique_key_from_email.sql
@@ -1,0 +1,2 @@
+ALTER TABLE root_user
+    DROP KEY email;

--- a/src/test/java/com/kustacks/kuring/acceptance/EmailAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/EmailAcceptanceTest.java
@@ -52,7 +52,7 @@ class EmailAcceptanceTest extends IntegrationTestSupport {
     @Test
     void duplicate_email_fail() {
         //given
-        회원가입_요청(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+        사용자_회원가입_요청(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
 
         // when - 이미 가입된 이메일로 인증코드 요청
         var 인증_이메일_전송_응답 = 인증_이메일_전송_요청(USER_EMAIL);

--- a/src/test/java/com/kustacks/kuring/acceptance/EmailAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/EmailAcceptanceTest.java
@@ -10,7 +10,7 @@ import static com.kustacks.kuring.acceptance.EmailStep.인증_이메일_전송_�
 import static com.kustacks.kuring.acceptance.EmailStep.인증_이메일_전송_응답_확인;
 import static com.kustacks.kuring.acceptance.EmailStep.인증코드_인증_요청;
 import static com.kustacks.kuring.acceptance.EmailStep.인증코드_인증_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.회원가입_요청;
+import static com.kustacks.kuring.acceptance.UserStep.사용자_회원가입_요청;
 
 @DisplayName("인수 : 이메일")
 class EmailAcceptanceTest extends IntegrationTestSupport {

--- a/src/test/java/com/kustacks/kuring/acceptance/NoticeAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/NoticeAcceptanceTest.java
@@ -344,7 +344,7 @@ class NoticeAcceptanceTest extends IntegrationTestSupport {
                 .getLong("data.comments[0].comment.id");
 
         //given 새로운 사용자 로그인
-        UserStep.회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, "123456");
+        UserStep.사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, "123456");
         String accessToken2 = 사용자_로그인_되어_있음(USER_FCM_TOKEN, NEW_EMAIL, "123456");
 
 

--- a/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
@@ -24,6 +24,7 @@ import static com.kustacks.kuring.acceptance.UserStep.북마크_생성_요청;
 import static com.kustacks.kuring.acceptance.UserStep.북마크_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.북마크_조회_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.북마크한_공지_조회_요청;
+import static com.kustacks.kuring.acceptance.UserStep.사용자_로그인_되어_있음;
 import static com.kustacks.kuring.acceptance.UserStep.사용자_카테고리_구독_목록_조회_요청;
 import static com.kustacks.kuring.acceptance.UserStep.사용자_학과_조회_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.질문_횟수_응답_검증;
@@ -35,7 +36,9 @@ import static com.kustacks.kuring.acceptance.UserStep.피드백_요청_응답_�
 import static com.kustacks.kuring.acceptance.UserStep.학과_구독_요청;
 import static com.kustacks.kuring.acceptance.UserStep.학과_구독_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.회원_가입_요청;
-import static com.kustacks.kuring.acceptance.UserStep.회원가입_요청;
+import static com.kustacks.kuring.acceptance.UserStep.회원_탈퇴_요청;
+import static com.kustacks.kuring.acceptance.UserStep.회원_탈퇴_응답_확인;
+import static com.kustacks.kuring.acceptance.UserStep.사용자_회원가입_요청;
 import static com.kustacks.kuring.acceptance.UserStep.회원가입_응답_확인;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -252,7 +255,7 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         인증_이메일_전송_요청(NEW_EMAIL);
         인증코드_인증_요청(NEW_EMAIL, "123456");
 
-        회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+        사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
 
         var 로그인_응답 = 로그인_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
         String jwtToken = 로그인_응답.jsonPath().getString("data.accessToken");
@@ -272,7 +275,7 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         doNothing().when(firebaseSubscribeService).validationToken(anyString());
 
         // when
-        var 회원가입_응답 = 회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+        var 회원가입_응답 = 사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
 
         // then
         회원가입_응답_확인(회원가입_응답);
@@ -284,7 +287,7 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         // given
         doNothing().when(firebaseSubscribeService).validationToken(anyString());
 
-        회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+        사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
 
         // when
         var 로그인_응답 = 로그인_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
@@ -299,7 +302,7 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         // given
         doNothing().when(firebaseSubscribeService).validationToken(anyString());
 
-        회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+        사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
 
         var 로그인_응답 = 로그인_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
         String jwtToken = 로그인_응답.jsonPath().getString("data.accessToken");
@@ -317,7 +320,7 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         // given
         doNothing().when(firebaseSubscribeService).validationToken(anyString());
 
-        회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+        사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
 
         // when
         var 로그인_응답 = 로그인_요청(USER_FCM_TOKEN, NEW_EMAIL, "wrong_password");
@@ -346,12 +349,70 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         doNothing().when(firebaseSubscribeService).validationToken(anyString());
 
         // 첫번째 회원가입
-        회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+        사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
 
         // when 같은 이메일로 회원가입 요청
-        var 중복_회원가입_응답 = 회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+        var 중복_회원가입_응답 = 사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
 
         // then
         실패_응답_확인(중복_회원가입_응답, HttpStatus.BAD_REQUEST);
+    }
+    @DisplayName("[v2] 사용자는 회원 탈퇴를 할 수 있다")
+    @Test
+    void withdraw_user() {
+        // given
+        doNothing().when(firebaseSubscribeService).validationToken(anyString());
+        사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+        String jwtToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+
+        // when
+        var 회원_탈퇴_응답 = 회원_탈퇴_요청(USER_FCM_TOKEN, jwtToken);
+
+        // then
+        회원_탈퇴_응답_확인(회원_탈퇴_응답);
+
+        // 탈퇴 후 로그인 시도 시 실패 확인
+        var 로그인_응답 = 로그인_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+        실패_응답_확인(로그인_응답, HttpStatus.NOT_FOUND);
+    }
+
+    @DisplayName("[v2] 여러 기기에 로그인한 사용자는 회원 탈퇴 시 모든 기기에서 로그아웃한다.")
+    @Test
+    void withdraw_user_and_logout_all_device() {
+        // given
+        doNothing().when(firebaseSubscribeService).validationToken(anyString());
+
+        회원_가입_요청("token1");
+        회원_가입_요청("token2");
+        회원_가입_요청("token3");
+        String jwtToken1 = 사용자_로그인_되어_있음("token1", USER_EMAIL, USER_PASSWORD);
+        String jwtToken2 = 사용자_로그인_되어_있음("token2", USER_EMAIL, USER_PASSWORD);
+        String jwtToken3 = 사용자_로그인_되어_있음("token3", USER_EMAIL, USER_PASSWORD);
+
+        //when
+        회원_탈퇴_요청(USER_FCM_TOKEN, jwtToken1);
+
+        //then
+        var 로그아웃_응답1 = 로그아웃_요청("token1", jwtToken1);
+        var 로그아웃_응답2 = 로그아웃_요청("token2", jwtToken2);
+        var 로그아웃_응답3 = 로그아웃_요청("token3", jwtToken3);
+        실패_응답_확인(로그아웃_응답1, HttpStatus.NOT_FOUND);
+        실패_응답_확인(로그아웃_응답2, HttpStatus.NOT_FOUND);
+        실패_응답_확인(로그아웃_응답3, HttpStatus.NOT_FOUND);
+    }
+
+
+    @DisplayName("[v2] 유효하지 않은 JWT 토큰으로 회원 탈퇴 시 실패한다")
+    @Test
+    void withdraw_user_with_invalid_token() {
+        // given
+        doNothing().when(firebaseSubscribeService).validationToken(anyString());
+        사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);
+
+        // when
+        var 회원_탈퇴_응답 = 회원_탈퇴_요청(USER_FCM_TOKEN, "invalid_token");
+
+        // then
+        실패_응답_확인(회원_탈퇴_응답, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
@@ -281,6 +281,26 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         회원가입_응답_확인(회원가입_응답);
     }
 
+    @DisplayName("[v2] 탈퇴한 사용자는 같은 이메일로 재가입할 수 있다")
+    @Test
+    void reactivate_withdrawn_user() {
+        // given
+        doNothing().when(firebaseSubscribeService).validationToken(anyString());
+
+        String jwtToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+        var 회원_탈퇴_응답 = 회원_탈퇴_요청(USER_FCM_TOKEN, jwtToken);
+
+        // when
+        var 재가입_응답 = 사용자_회원가입_요청(USER_FCM_TOKEN, USER_EMAIL, "new_password");
+
+        // then
+        회원가입_응답_확인(재가입_응답);
+
+        // 재가입 후 로그인도 가능한지 확인
+        var 로그인_응답 = 로그인_요청(USER_FCM_TOKEN, USER_EMAIL, "new_password");
+        로그인_응답_확인(로그인_응답);
+    }
+
     @DisplayName("[v2] 사용자는 로그인을 할 수 있다")
     @Test
     void login_success() {
@@ -357,6 +377,7 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         // then
         실패_응답_확인(중복_회원가입_응답, HttpStatus.BAD_REQUEST);
     }
+
     @DisplayName("[v2] 사용자는 회원 탈퇴를 할 수 있다")
     @Test
     void withdraw_user() {

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -260,7 +260,7 @@ public class UserStep {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
-                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("로그아웃에 성공했습니다.")  // 컨트롤러에서 USER_LOGOUT 메시지 사용
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("회원탈퇴 되었습니다")
         );
     }
 

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -259,7 +259,7 @@ public class UserStep {
     public static void 회원_탈퇴_응답_확인(ExtractableResponse<Response> response) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
+                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(204),
                 () -> assertThat(response.jsonPath().getString("message")).isEqualTo("회원탈퇴 되었습니다")
         );
     }

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -191,11 +191,10 @@ public class UserStep {
         );
     }
 
-    public static ExtractableResponse<Response> 회원가입_요청(String token, String email, String password) {
+    public static ExtractableResponse<Response> 사용자_회원가입_요청(String token, String email, String password) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("User-Token", token)
-
                 .body(new UserSignupRequest(email, password))
                 .when().post("/api/v2/users/signup")
                 .then().log().all()
@@ -246,6 +245,25 @@ public class UserStep {
                 () -> assertThat(response.jsonPath().getString("message")).isEqualTo("로그아웃에 성공했습니다.")
         );
     }
+
+    public static ExtractableResponse<Response> 회원_탈퇴_요청(String fcmToken, String jwtToken) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("User-Token", fcmToken)
+                .header("Authorization", "Bearer " + jwtToken)
+                .when().delete("/api/v2/users/withdraw")
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 회원_탈퇴_응답_확인(ExtractableResponse<Response> response) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("로그아웃에 성공했습니다.")  // 컨트롤러에서 USER_LOGOUT 메시지 사용
+        );
+    }
+
 
     public static String 사용자_로그인_되어_있음(String userToken, String loginId, String password) {
         ExtractableResponse<Response> response = 로그인_요청(userToken, loginId, password);


### PR DESCRIPTION
### 로직 구현
- RootUser 회원 탈퇴 기능이 추가되었습니다.
- 회원 탈퇴 시 RootUser로 로그인 되어있는 User를 로그아웃합니다.
- SoftDelete 방식으로 구현됐습니다.

### DB 변경사항
-  root_user에 deleted 컬럼이 추가됐습니다.
- root_user 테이블의 email의 unique 속성을 삭제했습니다.(재가입 가능)

> 여러개 작업하다가 PR 쪼개려다보니 커밋이 살짝 요상합니다 😢 