### PR TITLE
Feat : 유저 정보 조회 API 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/auth/authentication/AuthorizationExtractor.java
+++ b/src/main/java/com/kustacks/kuring/auth/authentication/AuthorizationExtractor.java
@@ -33,7 +33,7 @@ public class AuthorizationExtractor {
         return Strings.EMPTY;
     }
 
-    public static String extract(String value, AuthorizationType type) {
+    public static String extractAuthorizationValue(String value, AuthorizationType type) {
         String typeToLowerCase = type.toLowerCase();
         int typeLength = typeToLowerCase.length();
 

--- a/src/main/java/com/kustacks/kuring/auth/authentication/AuthorizationExtractor.java
+++ b/src/main/java/com/kustacks/kuring/auth/authentication/AuthorizationExtractor.java
@@ -32,4 +32,20 @@ public class AuthorizationExtractor {
 
         return Strings.EMPTY;
     }
+
+    public static String extract(String value, AuthorizationType type) {
+        String typeToLowerCase = type.toLowerCase();
+        int typeLength = typeToLowerCase.length();
+
+        if ((value.toLowerCase().startsWith(typeToLowerCase))) {
+            String authHeaderValue = value.substring(typeLength).trim();
+            int commaIndex = authHeaderValue.indexOf(',');
+            if (commaIndex > 0) {
+                authHeaderValue = authHeaderValue.substring(0, commaIndex);
+            }
+            return authHeaderValue;
+        }
+
+        return Strings.EMPTY;
+    }
 }

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -28,7 +28,7 @@ public enum ResponseCodeAndMessages {
     /* User */
     USER_REGISTER_SUCCESS(HttpStatus.OK.value(), "회원가입에 성공하였습니다"),
     USER_REGISTER_FAIL(HttpStatus.BAD_REQUEST.value(), "회원가입에 실패하였습니다"),
-    BOOKMAKR_SAVE_SUCCESS(HttpStatus.OK.value(), "북마크 저장에 성공하였습니다"),
+    BOOKMARK_SAVE_SUCCESS(HttpStatus.OK.value(), "북마크 저장에 성공하였습니다"),
     BOOKMARK_LOOKUP_SUCCESS(HttpStatus.OK.value(), "북마크 조회에 성공하였습니다"),
     FEEDBACK_SAVE_SUCCESS(HttpStatus.OK.value(), "피드백 저장에 성공하였습니다"),
     FEEDBACK_SEARCH_SUCCESS(HttpStatus.OK.value(), "피드백 조회에 성공하였습니다"),

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -39,6 +39,7 @@ public enum ResponseCodeAndMessages {
     USER_SIGNUP(HttpStatus.CREATED.value(), "사용자 계정 생성에 성공했습니다."),
     USER_LOGIN(HttpStatus.OK.value(), "로그인에 성공했습니다."),
     USER_LOGOUT(HttpStatus.OK.value(), "로그아웃에 성공했습니다."),
+    USER_INFO_LOOKUP_SUCCESS(HttpStatus.OK.value(), "회원정보 조회에 성공했습니다."),
 
     /* Alert */
     ALERT_SEARCH_SUCCESS(HttpStatus.OK.value(), "예약 알림 조회에 성공하였습니다"),

--- a/src/main/java/com/kustacks/kuring/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/kustacks/kuring/common/exception/code/ErrorCode.java
@@ -84,7 +84,7 @@ public enum ErrorCode {
     USER_MISMATCH_DEVICE(HttpStatus.BAD_REQUEST, "로그인한 사용자가 아닙니다."),
     USER_ALREADY_LOGIN(HttpStatus.BAD_REQUEST, "이미 로그인된 사용자입니다."),
 
-    JWT_INVALID_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 Access Token입니다."),
+    JWT_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 Access Token입니다."),
 
     EMAIL_NO_SUCH_ALGORITHM(HttpStatus.INTERNAL_SERVER_ERROR, "랜덤 숫자 생성 간 알고리즘을 찾을 수 없습니다."),
     EMAIL_INVALID_SUFFIX(HttpStatus.BAD_REQUEST, "건국대학교 이메일 도메인이 아닙니다."),

--- a/src/main/java/com/kustacks/kuring/notice/adapter/in/web/NoticeCommandApiV2.java
+++ b/src/main/java/com/kustacks/kuring/notice/adapter/in/web/NoticeCommandApiV2.java
@@ -21,11 +21,15 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.apache.logging.log4j.util.Strings;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
+import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extract;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.NOTICE_COMMENT_EDIT_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.NOTICE_COMMENT_SAVE_SUCCESS;
 
@@ -117,21 +121,5 @@ public class NoticeCommandApiV2 {
             throw new InvalidStateException(ErrorCode.JWT_INVALID_TOKEN);
         }
         return jwtTokenProvider.getPrincipal(jwtToken);
-    }
-
-    private String extract(String value, AuthorizationType type) {
-        String typeToLowerCase = type.toLowerCase();
-        int typeLength = typeToLowerCase.length();
-
-        if ((value.toLowerCase().startsWith(typeToLowerCase))) {
-            String authHeaderValue = value.substring(typeLength).trim();
-            int commaIndex = authHeaderValue.indexOf(',');
-            if (commaIndex > 0) {
-                authHeaderValue = authHeaderValue.substring(0, commaIndex);
-            }
-            return authHeaderValue;
-        }
-
-        return Strings.EMPTY;
     }
 }

--- a/src/main/java/com/kustacks/kuring/notice/adapter/in/web/NoticeCommandApiV2.java
+++ b/src/main/java/com/kustacks/kuring/notice/adapter/in/web/NoticeCommandApiV2.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extract;
+import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extractAuthorizationValue;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.NOTICE_COMMENT_EDIT_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.NOTICE_COMMENT_SAVE_SUCCESS;
 
@@ -54,7 +54,7 @@ public class NoticeCommandApiV2 {
             @RequestHeader (AuthorizationExtractor.AUTHORIZATION) String bearerToken,
             @RequestBody NoticeCommentCreateRequest request
     ) {
-        String jwtToken = extract(bearerToken, AuthorizationType.BEARER);
+        String jwtToken = extractAuthorizationValue(bearerToken, AuthorizationType.BEARER);
         String email = validateJwtAndGetEmail(jwtToken);
 
         if (request.parentId() == null) {
@@ -88,7 +88,7 @@ public class NoticeCommandApiV2 {
             @RequestHeader (AuthorizationExtractor.AUTHORIZATION) String bearerToken,
             @RequestBody NoticeCommentEditRequest request
     ) {
-        String jwtToken = extract(bearerToken, AuthorizationType.BEARER);
+        String jwtToken = extractAuthorizationValue(bearerToken, AuthorizationType.BEARER);
         String email = validateJwtAndGetEmail(jwtToken);
 
         var command = new EditCommentCommand(email, id, commentId, request.content());
@@ -106,7 +106,7 @@ public class NoticeCommandApiV2 {
             @Parameter(description = "댓글 ID") @PathVariable("commentId") Long commentId,
             @RequestHeader (AuthorizationExtractor.AUTHORIZATION) String bearerToken
     ) {
-        String jwtToken = extract(bearerToken, AuthorizationType.BEARER);
+        String jwtToken = extractAuthorizationValue(bearerToken, AuthorizationType.BEARER);
         String email = validateJwtAndGetEmail(jwtToken);
 
         var command = new DeleteCommentCommand(email, id, commentId);

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserCommandApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserCommandApiV2.java
@@ -93,7 +93,7 @@ class UserCommandApiV2 {
             @RequestHeader(FCM_TOKEN_HEADER_KEY) String id
     ) {
         userCommandUseCase.saveBookmark(new UserBookmarkCommand(id, request.articleId()));
-        return ResponseEntity.ok().body(new BaseResponse<>(BOOKMAKR_SAVE_SUCCESS, null));
+        return ResponseEntity.ok().body(new BaseResponse<>(BOOKMARK_SAVE_SUCCESS, null));
     }
 
     @Operation(summary = "사용자 회원가입", description = "사용자가 회원가입합니다.")

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserCommandApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserCommandApiV2.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extract;
+import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extractAuthorizationValue;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.BOOKMARK_SAVE_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CATEGORY_SUBSCRIBE_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.DEPARTMENTS_SUBSCRIBE_SUCCESS;
@@ -134,7 +134,7 @@ class UserCommandApiV2 {
             @RequestHeader(FCM_TOKEN_HEADER_KEY) String id,
             @RequestHeader (AuthorizationExtractor.AUTHORIZATION) String bearerToken
     ) {
-        String jwtToken = extract(bearerToken, AuthorizationType.BEARER);
+        String jwtToken = extractAuthorizationValue(bearerToken, AuthorizationType.BEARER);
         String email = validateJwtAndGetEmail(jwtToken);
 
         userCommandUseCase.logout(new UserLogoutCommand(id, email));

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserCommandApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserCommandApiV2.java
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.logging.log4j.util.Strings;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -37,7 +36,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.*;
+import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extract;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.BOOKMARK_SAVE_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CATEGORY_SUBSCRIBE_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.DEPARTMENTS_SUBSCRIBE_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.FEEDBACK_SAVE_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.USER_LOGIN;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.USER_LOGOUT;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.USER_SIGNUP;
 
 @Tag(name = "User-Command", description = "사용자가 주체가 되는 정보 수정")
 @Slf4j
@@ -140,21 +146,5 @@ class UserCommandApiV2 {
             throw new InvalidStateException(ErrorCode.JWT_INVALID_TOKEN);
         }
         return jwtTokenProvider.getPrincipal(jwtToken);
-    }
-
-    private static String extract(String value, AuthorizationType type) {
-        String typeToLowerCase = type.toLowerCase();
-        int typeLength = typeToLowerCase.length();
-
-        if ((value.toLowerCase().startsWith(typeToLowerCase))) {
-            String authHeaderValue = value.substring(typeLength).trim();
-            int commaIndex = authHeaderValue.indexOf(',');
-            if (commaIndex > 0) {
-                authHeaderValue = authHeaderValue.substring(0, commaIndex);
-            }
-            return authHeaderValue;
-        }
-
-        return Strings.EMPTY;
     }
 }

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserQueryApiV2.java
@@ -19,7 +19,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.logging.log4j.util.Strings;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,6 +28,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extract;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.ASK_COUNT_LOOKUP_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.BOOKMARK_LOOKUP_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CATEGORY_USER_SUBSCRIBES_LOOKUP_SUCCESS;
@@ -136,21 +136,5 @@ class UserQueryApiV2 {
             throw new InvalidStateException(ErrorCode.JWT_INVALID_TOKEN);
         }
         return jwtTokenProvider.getPrincipal(jwtToken);
-    }
-
-    private String extract(String value, AuthorizationType type) {
-        String typeToLowerCase = type.toLowerCase();
-        int typeLength = typeToLowerCase.length();
-
-        if ((value.toLowerCase().startsWith(typeToLowerCase))) {
-            String authHeaderValue = value.substring(typeLength).trim();
-            int commaIndex = authHeaderValue.indexOf(',');
-            if (commaIndex > 0) {
-                authHeaderValue = authHeaderValue.substring(0, commaIndex);
-            }
-            return authHeaderValue;
-        }
-
-        return Strings.EMPTY;
     }
 }

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserQueryApiV2.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extract;
+import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extractAuthorizationValue;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.ASK_COUNT_LOOKUP_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.BOOKMARK_LOOKUP_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CATEGORY_USER_SUBSCRIBES_LOOKUP_SUCCESS;
@@ -111,7 +111,7 @@ class UserQueryApiV2 {
     public ResponseEntity<BaseResponse<UserInfoResponse>> lookupUserInfo(
                         @RequestHeader (AuthorizationExtractor.AUTHORIZATION) String bearerToken
     ) {
-        String jwtToken = extract(bearerToken, AuthorizationType.BEARER);
+        String jwtToken = extractAuthorizationValue(bearerToken, AuthorizationType.BEARER);
         String email = validateJwtAndGetEmail(jwtToken);
 
         return lookupAndConvertResponse(

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserQueryApiV2.java
@@ -1,18 +1,26 @@
 package com.kustacks.kuring.user.adapter.in.web;
 
+import com.kustacks.kuring.auth.authentication.AuthorizationExtractor;
+import com.kustacks.kuring.auth.authentication.AuthorizationType;
+import com.kustacks.kuring.auth.token.JwtTokenProvider;
 import com.kustacks.kuring.common.annotation.RestWebAdapter;
 import com.kustacks.kuring.common.dto.BaseResponse;
+import com.kustacks.kuring.common.exception.InvalidStateException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserAIAskCountResponse;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserBookmarkResponse;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserCategoryNameResponse;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserDepartmentNameResponse;
+import com.kustacks.kuring.user.adapter.in.web.dto.UserInfoResponse;
 import com.kustacks.kuring.user.application.port.in.UserQueryUseCase;
 import com.kustacks.kuring.user.application.port.in.dto.UserAIAskCountResult;
+import com.kustacks.kuring.user.application.port.in.dto.UserInfoResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +28,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.List;
 
-import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.*;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.ASK_COUNT_LOOKUP_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.BOOKMARK_LOOKUP_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CATEGORY_USER_SUBSCRIBES_LOOKUP_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.DEPARTMENTS_USER_SUBSCRIBES_LOOKUP_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.USER_INFO_LOOKUP_SUCCESS;
 
 @Tag(name = "User-Query", description = "사용자가 주체가 되는 정보 조회")
 @Slf4j
@@ -30,8 +42,10 @@ import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.*;
 class UserQueryApiV2 {
 
     private static final String FCM_TOKEN_HEADER_KEY = "User-Token";
+    private static final String JWT_TOKEN_HEADER_KEY = "JWT";
 
     private final UserQueryUseCase userQueryUseCase;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Operation(summary = "사용자 카테고리 조회", description = "사용자가 구독한 카테고리 목록을 조회합니다")
     @SecurityRequirement(name = FCM_TOKEN_HEADER_KEY)
@@ -84,5 +98,42 @@ class UserQueryApiV2 {
         UserAIAskCountResult result = userQueryUseCase.lookupUserAIAskCount(userToken);
         UserAIAskCountResponse response = UserAIAskCountResponse.from(result);
         return ResponseEntity.ok().body(new BaseResponse<>(ASK_COUNT_LOOKUP_SUCCESS, response));
+    }
+
+    @Operation(summary = "사용자 정보 조회", description = "사용자 정보를 조회합니다.")
+    @SecurityRequirement(name = JWT_TOKEN_HEADER_KEY)
+    @GetMapping("/user-me")
+    public ResponseEntity<BaseResponse<UserInfoResponse>> lookupUserInfo(
+                        @RequestHeader (AuthorizationExtractor.AUTHORIZATION) String bearerToken
+    ) {
+        String jwtToken = extract(bearerToken, AuthorizationType.BEARER);
+        String email = validateJwtAndGetEmail(jwtToken);
+
+        UserInfoResult result = userQueryUseCase.lookupUserInfo(email);
+        UserInfoResponse response = UserInfoResponse.from(result);
+        return ResponseEntity.ok().body(new BaseResponse<>(USER_INFO_LOOKUP_SUCCESS, response));
+    }
+
+    private String validateJwtAndGetEmail(String jwtToken) {
+        if (!jwtTokenProvider.validateToken(jwtToken)) {
+            throw new InvalidStateException(ErrorCode.JWT_INVALID_TOKEN);
+        }
+        return jwtTokenProvider.getPrincipal(jwtToken);
+    }
+
+    private String extract(String value, AuthorizationType type) {
+        String typeToLowerCase = type.toLowerCase();
+        int typeLength = typeToLowerCase.length();
+
+        if ((value.toLowerCase().startsWith(typeToLowerCase))) {
+            String authHeaderValue = value.substring(typeLength).trim();
+            int commaIndex = authHeaderValue.indexOf(',');
+            if (commaIndex > 0) {
+                authHeaderValue = authHeaderValue.substring(0, commaIndex);
+            }
+            return authHeaderValue;
+        }
+
+        return Strings.EMPTY;
     }
 }

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserInfoResponse.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserInfoResponse.java
@@ -1,0 +1,15 @@
+package com.kustacks.kuring.user.adapter.in.web.dto;
+
+import com.kustacks.kuring.user.application.port.in.dto.UserInfoResult;
+
+public record UserInfoResponse(
+        String email,
+        String nickname
+) {
+    public static UserInfoResponse from(UserInfoResult userInfoResult) {
+        return new UserInfoResponse(
+                userInfoResult.email(),
+                userInfoResult.nickname()
+        );
+    }
+}

--- a/src/main/java/com/kustacks/kuring/user/application/port/in/UserQueryUseCase.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/in/UserQueryUseCase.java
@@ -4,6 +4,7 @@ import com.kustacks.kuring.user.application.port.in.dto.UserAIAskCountResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserBookmarkResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserCategoryNameResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserDepartmentNameResult;
+import com.kustacks.kuring.user.application.port.in.dto.UserInfoResult;
 
 import java.util.List;
 
@@ -13,4 +14,5 @@ public interface UserQueryUseCase {
     List<UserBookmarkResult> lookupUserBookmarkedNotices(String userToken);
 
     UserAIAskCountResult lookupUserAIAskCount(String userToken);
+    UserInfoResult lookupUserInfo(String email);
 }

--- a/src/main/java/com/kustacks/kuring/user/application/port/in/dto/UserInfoResult.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/in/dto/UserInfoResult.java
@@ -1,0 +1,7 @@
+package com.kustacks.kuring.user.application.port.in.dto;
+
+public record UserInfoResult(
+        String nickname,
+        String email
+) {
+}

--- a/src/main/java/com/kustacks/kuring/user/application/service/UserQueryService.java
+++ b/src/main/java/com/kustacks/kuring/user/application/service/UserQueryService.java
@@ -12,9 +12,12 @@ import com.kustacks.kuring.user.application.port.in.dto.UserAIAskCountResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserBookmarkResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserCategoryNameResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserDepartmentNameResult;
+import com.kustacks.kuring.user.application.port.in.dto.UserInfoResult;
+import com.kustacks.kuring.user.application.port.out.RootUserQueryPort;
 import com.kustacks.kuring.user.application.port.out.UserCommandPort;
 import com.kustacks.kuring.user.application.port.out.UserEventPort;
 import com.kustacks.kuring.user.application.port.out.UserQueryPort;
+import com.kustacks.kuring.user.domain.RootUser;
 import com.kustacks.kuring.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +36,7 @@ class UserQueryService implements UserQueryUseCase {
 
     private final UserCommandPort userCommandPort;
     private final UserQueryPort userQueryPort;
+    private final RootUserQueryPort rootUserQueryPort;
     private final NoticeQueryPort noticeQueryPort;
     private final UserEventPort userEventPort;
     private final ServerProperties serverProperties;
@@ -62,6 +66,13 @@ class UserQueryService implements UserQueryUseCase {
         return new UserAIAskCountResult(user.getQuestionCount(), User.FCM_USER_MONTHLY_QUESTION_COUNT);
     }
 
+    @Override
+    public UserInfoResult lookupUserInfo(String email) {
+        RootUser rootUser = findRootUserByEmailOrThrow(email);
+        return new UserInfoResult(rootUser.getNickname(), rootUser.getEmail());
+    }
+
+
     private List<UserBookmarkResult> lookupAllBookmarkByIds(List<String> bookmarkIds) {
         return noticeQueryPort.findAllByBookmarkIds(bookmarkIds)
                 .stream()
@@ -82,6 +93,11 @@ class UserQueryService implements UserQueryUseCase {
         }
 
         return optionalUser.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private RootUser findRootUserByEmailOrThrow(String email) {
+        return rootUserQueryPort.findRootUserByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.ROOT_USER_NOT_FOUND));
     }
 
     private List<UserCategoryNameResult> convertCategoryNameDtoList(List<CategoryName> categoryNamesList) {

--- a/src/main/java/com/kustacks/kuring/user/domain/RootUser.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/RootUser.java
@@ -33,6 +33,7 @@ public class RootUser implements Serializable {
     @Column(nullable = true, length = 256)
     private String password;
 
+    @Getter(AccessLevel.PUBLIC)
     @Column(unique = true, length = 256)
     private String nickname;
 

--- a/src/test/java/com/kustacks/kuring/acceptance/NoticeAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/NoticeAcceptanceTest.java
@@ -181,7 +181,7 @@ class NoticeAcceptanceTest extends IntegrationTestSupport {
         var response = 공지에_댓글_추가(id, "INVALID_ACCESS_TOKEN", "this is comment");
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
     /**

--- a/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
@@ -24,6 +24,9 @@ import static com.kustacks.kuring.acceptance.UserStep.북마크_생성_요청;
 import static com.kustacks.kuring.acceptance.UserStep.북마크_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.북마크_조회_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.북마크한_공지_조회_요청;
+import static com.kustacks.kuring.acceptance.UserStep.사용자_로그인_되어_있음;
+import static com.kustacks.kuring.acceptance.UserStep.사용자_정보_조회_요청;
+import static com.kustacks.kuring.acceptance.UserStep.사용자_정보_조회_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.사용자_카테고리_구독_목록_조회_요청;
 import static com.kustacks.kuring.acceptance.UserStep.사용자_학과_조회_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.질문_횟수_응답_검증;
@@ -353,5 +356,34 @@ class UserAcceptanceTest extends IntegrationTestSupport {
 
         // then
         실패_응답_확인(중복_회원가입_응답, HttpStatus.BAD_REQUEST);
+    }
+
+
+    @DisplayName("[v2] 사용자는 본인의 정보를 조회할 수 있다")
+    @Test
+    void lookup_user_info() {
+        // given
+        doNothing().when(firebaseSubscribeService).validationToken(anyString());
+
+        String jwtToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        // when
+        var 사용자_정보_조회_응답 = 사용자_정보_조회_요청(USER_FCM_TOKEN, jwtToken);
+
+        // then
+        사용자_정보_조회_응답_확인(사용자_정보_조회_응답, USER_EMAIL);
+    }
+
+    @DisplayName("[v2] 유효하지 않은 JWT 토큰으로 사용자 정보 조회 시 실패한다")
+    @Test
+    void lookup_user_info_with_invalid_jwt_token() {
+        // given
+        doNothing().when(firebaseSubscribeService).validationToken(anyString());
+
+        // when
+        var 사용자_정보_조회_응답 = 사용자_정보_조회_요청(USER_FCM_TOKEN, "wrong_token");
+
+        // then
+        실패_응답_확인(사용자_정보_조회_응답, HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -247,9 +247,27 @@ public class UserStep {
         );
     }
 
+    public static ExtractableResponse<Response> 사용자_정보_조회_요청(String fcmToken, String jwtToken) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("User-Token", fcmToken)
+                .header("Authorization", "Bearer " + jwtToken)
+                .when().get("/api/v2/users/user-me")
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 사용자_정보_조회_응답_확인(ExtractableResponse<Response> response, String email) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("회원정보 조회에 성공했습니다."),
+                () -> assertThat(response.jsonPath().getString("data.email")).isEqualTo(email)
+        );
+    }
+
     public static String 사용자_로그인_되어_있음(String userToken, String loginId, String password) {
         ExtractableResponse<Response> response = 로그인_요청(userToken, loginId, password);
         return response.jsonPath().getString("data.accessToken");
     }
-
 }


### PR DESCRIPTION
### 구현 
- Jwt Access-Token 기반으로 유저 기본 정보 조회 API 추가했습니다.
- 토큰이 유효하지 않을 시 응답코드를 400 -> 401로 변경했습니다.
클라이언트 측에서 400이면 오류 이유를 알기 어렵다고 생각해서 수정했습니다.