### PR TITLE
Feat : 비밀번호 변경(초기화) API 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -39,6 +39,7 @@ public enum ResponseCodeAndMessages {
     USER_SIGNUP(HttpStatus.CREATED.value(), "사용자 계정 생성에 성공했습니다."),
     USER_LOGIN(HttpStatus.OK.value(), "로그인에 성공했습니다."),
     USER_LOGOUT(HttpStatus.OK.value(), "로그아웃에 성공했습니다."),
+    USER_PASSWORD_MODIFY(HttpStatus.OK.value(), "비밀번호 변경에 성공했습니다."),
 
     /* Alert */
     ALERT_SEARCH_SUCCESS(HttpStatus.OK.value(), "예약 알림 조회에 성공하였습니다"),

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserCommandApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserCommandApiV2.java
@@ -13,6 +13,7 @@ import com.kustacks.kuring.user.adapter.in.web.dto.UserDepartmentsSubscribeReque
 import com.kustacks.kuring.user.adapter.in.web.dto.UserFeedbackRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserLoginRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserLoginResponse;
+import com.kustacks.kuring.user.adapter.in.web.dto.UserPasswordModifyRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserSignupRequest;
 import com.kustacks.kuring.user.application.port.in.UserCommandUseCase;
 import com.kustacks.kuring.user.application.port.in.dto.UserBookmarkCommand;
@@ -22,6 +23,7 @@ import com.kustacks.kuring.user.application.port.in.dto.UserFeedbackCommand;
 import com.kustacks.kuring.user.application.port.in.dto.UserLoginCommand;
 import com.kustacks.kuring.user.application.port.in.dto.UserLoginResult;
 import com.kustacks.kuring.user.application.port.in.dto.UserLogoutCommand;
+import com.kustacks.kuring.user.application.port.in.dto.UserPasswordModifyCommand;
 import com.kustacks.kuring.user.application.port.in.dto.UserSignupCommand;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -33,6 +35,7 @@ import org.apache.logging.log4j.util.Strings;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -133,6 +136,24 @@ class UserCommandApiV2 {
 
         userCommandUseCase.logout(new UserLogoutCommand(id, email));
         return ResponseEntity.ok().body(new BaseResponse<>(USER_LOGOUT, null));
+    }
+
+    @Operation(summary = "사용자 비밀번호 변경", description = "사용자가 비밀번호 변경합니다.")
+    @SecurityRequirement(name = JWT_TOKEN_HEADER_KEY)
+    @PatchMapping(value = "/password")
+    public ResponseEntity<BaseResponse<Void>> modifyPassword(
+                @RequestBody UserPasswordModifyRequest request,
+                @RequestHeader (value = AuthorizationExtractor.AUTHORIZATION, required = false) String bearerToken
+    ) {
+        if (bearerToken == null) {
+            userCommandUseCase.changePassword(new UserPasswordModifyCommand(request.email(), request.password()));
+        }else{
+            String jwtToken = extract(bearerToken, AuthorizationType.BEARER);
+            String email = validateJwtAndGetEmail(jwtToken);
+            userCommandUseCase.changePassword(new UserPasswordModifyCommand(email, request.password()));
+        }
+
+        return ResponseEntity.ok().body(new BaseResponse<>(USER_PASSWORD_MODIFY, null));
     }
 
     private String validateJwtAndGetEmail(String jwtToken) {

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserPasswordModifyRequest.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserPasswordModifyRequest.java
@@ -1,6 +1,6 @@
 package com.kustacks.kuring.user.adapter.in.web.dto;
 
-public record UserPasswordResetRequest(
+public record UserPasswordModifyRequest(
         String email,
         String password
 ) {

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserPasswordResetRequest.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserPasswordResetRequest.java
@@ -1,0 +1,7 @@
+package com.kustacks.kuring.user.adapter.in.web.dto;
+
+public record UserPasswordResetRequest(
+        String email,
+        String password
+) {
+}

--- a/src/main/java/com/kustacks/kuring/user/application/port/in/UserCommandUseCase.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/in/UserCommandUseCase.java
@@ -11,4 +11,5 @@ public interface UserCommandUseCase {
     void signupUser(UserSignupCommand userSignupCommand);
     void logout(UserLogoutCommand userLogoutCommand);
     UserLoginResult login(UserLoginCommand userLoginCommand);
+    void changePassword(UserPasswordModifyCommand userPasswordModifyCommand);
 }

--- a/src/main/java/com/kustacks/kuring/user/application/port/in/dto/UserPasswordModifyCommand.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/in/dto/UserPasswordModifyCommand.java
@@ -1,0 +1,7 @@
+package com.kustacks.kuring.user.application.port.in.dto;
+
+public record UserPasswordModifyCommand(
+        String email,
+        String password
+) {
+}

--- a/src/main/java/com/kustacks/kuring/user/application/service/UserCommandService.java
+++ b/src/main/java/com/kustacks/kuring/user/application/service/UserCommandService.java
@@ -11,6 +11,7 @@ import com.kustacks.kuring.message.application.service.exception.FirebaseSubscri
 import com.kustacks.kuring.message.application.service.exception.FirebaseUnSubscribeException;
 import com.kustacks.kuring.notice.domain.CategoryName;
 import com.kustacks.kuring.notice.domain.DepartmentName;
+import com.kustacks.kuring.user.application.port.in.dto.UserPasswordModifyCommand;
 import com.kustacks.kuring.user.application.port.in.UserCommandUseCase;
 import com.kustacks.kuring.user.application.port.in.dto.UserBookmarkCommand;
 import com.kustacks.kuring.user.application.port.in.dto.UserCategoriesSubscribeCommand;
@@ -127,6 +128,13 @@ class UserCommandService implements UserCommandUseCase {
 
         String token = jwtTokenProvider.createUserToken(userLoginCommand.email());
         return new UserLoginResult(token);
+    }
+
+
+    @Override
+    public void changePassword(UserPasswordModifyCommand userPasswordModifyCommand) {
+        RootUser rootUser = findRootUserByEmailOrThrow(userPasswordModifyCommand.email());
+        rootUser.modifyPassword(passwordEncoder.encode(userPasswordModifyCommand.password()));
     }
 
     private void checkUserIsNotLoggedIn(User user) {

--- a/src/main/java/com/kustacks/kuring/user/domain/RootUser.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/RootUser.java
@@ -50,4 +50,8 @@ public class RootUser implements Serializable {
     public void updateQuestionCount(int questionCount) {
         this.questionCount = questionCount;
     }
+
+    public void modifyPassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
@@ -24,6 +24,8 @@ import static com.kustacks.kuring.acceptance.UserStep.북마크_생성_요청;
 import static com.kustacks.kuring.acceptance.UserStep.북마크_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.북마크_조회_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.북마크한_공지_조회_요청;
+import static com.kustacks.kuring.acceptance.UserStep.비밀번호_변경_요청;
+import static com.kustacks.kuring.acceptance.UserStep.비밀번호_변경_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.사용자_카테고리_구독_목록_조회_요청;
 import static com.kustacks.kuring.acceptance.UserStep.사용자_학과_조회_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.질문_횟수_응답_검증;
@@ -353,5 +355,34 @@ class UserAcceptanceTest extends IntegrationTestSupport {
 
         // then
         실패_응답_확인(중복_회원가입_응답, HttpStatus.BAD_REQUEST);
+    }
+    @DisplayName("[v2] 사용자는 비밀번호를 변경하고 새로운 비밀번호로 로그인할 수 있다.")
+    @Test
+    void modify_password() {
+        // given
+        doNothing().when(firebaseSubscribeService).validationToken(anyString());
+
+        // when
+        var 비밀번호_초기화_응답 = 비밀번호_변경_요청(USER_EMAIL, "new_password");
+
+        // then
+        비밀번호_변경_응답_확인(비밀번호_초기화_응답);
+
+        // 변경된 비밀번호로 로그인이 가능한지 확인
+        var 로그인_응답 = 로그인_요청(USER_FCM_TOKEN, USER_EMAIL, "new_password");
+        로그인_응답_확인(로그인_응답);
+    }
+
+    @DisplayName("[v2] 존재하지 않는 이메일로 비밀번호 변경 시도시 실패한다")
+    @Test
+    void modify_password_with_wrong_email() {
+        // given
+        doNothing().when(firebaseSubscribeService).validationToken(anyString());
+
+        // when
+        var 비밀번호_초기화_응답 = 비밀번호_변경_요청("wrong-email@konkuk.ac.kr", "new_password");
+
+        // then
+        실패_응답_확인(비밀번호_초기화_응답, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
@@ -26,8 +26,10 @@ import static com.kustacks.kuring.acceptance.UserStep.북마크_조회_응답_�
 import static com.kustacks.kuring.acceptance.UserStep.북마크한_공지_조회_요청;
 import static com.kustacks.kuring.acceptance.UserStep.비밀번호_변경_요청;
 import static com.kustacks.kuring.acceptance.UserStep.비밀번호_변경_응답_확인;
+import static com.kustacks.kuring.acceptance.UserStep.사용자_로그인_되어_있음;
 import static com.kustacks.kuring.acceptance.UserStep.사용자_카테고리_구독_목록_조회_요청;
 import static com.kustacks.kuring.acceptance.UserStep.사용자_학과_조회_응답_확인;
+import static com.kustacks.kuring.acceptance.UserStep.액세스_토큰으로_비밀번호_변경_요청;
 import static com.kustacks.kuring.acceptance.UserStep.질문_횟수_응답_검증;
 import static com.kustacks.kuring.acceptance.UserStep.카테고리_구독_목록_조회_요청_응답_확인;
 import static com.kustacks.kuring.acceptance.UserStep.카테고리_구독_요청;
@@ -356,6 +358,7 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         // then
         실패_응답_확인(중복_회원가입_응답, HttpStatus.BAD_REQUEST);
     }
+
     @DisplayName("[v2] 사용자는 비밀번호를 변경하고 새로운 비밀번호로 로그인할 수 있다.")
     @Test
     void modify_password() {
@@ -369,6 +372,25 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         비밀번호_변경_응답_확인(비밀번호_초기화_응답);
 
         // 변경된 비밀번호로 로그인이 가능한지 확인
+        var 로그인_응답 = 로그인_요청(USER_FCM_TOKEN, USER_EMAIL, "new_password");
+        로그인_응답_확인(로그인_응답);
+    }
+
+    @DisplayName("[v2] 사용자는 비밀번호를 변경하고 새로운 비밀번호로 로그인할 수 있다.")
+    @Test
+    void modify_password_with_access_token() {
+        // given
+        doNothing().when(firebaseSubscribeService).validationToken(anyString());
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        // when
+        var 비밀번호_변경_응답 = 액세스_토큰으로_비밀번호_변경_요청(accessToken,"new_password");
+
+        // then
+        비밀번호_변경_응답_확인(비밀번호_변경_응답);
+
+        // 변경된 비밀번호로 재로그인이 가능한지 확인
+        로그아웃_요청(USER_FCM_TOKEN, accessToken);
         var 로그인_응답 = 로그인_요청(USER_FCM_TOKEN, USER_EMAIL, "new_password");
         로그인_응답_확인(로그인_응답);
     }

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -258,6 +258,17 @@ public class UserStep {
                 .extract();
     }
 
+
+    public static ExtractableResponse<Response> 액세스_토큰으로_비밀번호_변경_요청(String jwtToken, String newPassword) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + jwtToken)
+                .body(new UserPasswordModifyRequest(null, newPassword))
+                .when().patch("/api/v2/users/password")
+                .then().log().all()
+                .extract();
+    }
+
     public static void 비밀번호_변경_응답_확인(ExtractableResponse<Response> response) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -6,6 +6,7 @@ import com.kustacks.kuring.user.adapter.in.web.dto.UserCategoriesSubscribeReques
 import com.kustacks.kuring.user.adapter.in.web.dto.UserDepartmentsSubscribeRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserFeedbackRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserLoginRequest;
+import com.kustacks.kuring.user.adapter.in.web.dto.UserPasswordModifyRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserSignupRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -240,6 +241,24 @@ public class UserStep {
     }
 
     public static void 로그아웃_응답_확인(ExtractableResponse<Response> response) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("로그아웃에 성공했습니다.")
+        );
+    }
+
+
+    public static ExtractableResponse<Response> 비밀번호_변경_요청(String email, String newPassword) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new UserPasswordModifyRequest(email, newPassword))
+                .when().patch("/api/v2/users/passwords")
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 비밀번호_변경_응답_확인(ExtractableResponse<Response> response) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -253,7 +253,7 @@ public class UserStep {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new UserPasswordModifyRequest(email, newPassword))
-                .when().patch("/api/v2/users/passwords")
+                .when().patch("/api/v2/users/password")
                 .then().log().all()
                 .extract();
     }
@@ -262,7 +262,7 @@ public class UserStep {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
-                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("로그아웃에 성공했습니다.")
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("비밀번호 변경에 성공했습니다.")
         );
     }
 


### PR DESCRIPTION
### 구현
- 비밀번호 변경 로직 추가했습니다.
- Access-Token 유무에 따라 변경이나 초기화가 가능합니다.



1. 초기화 시

`Request Body`
```json
{
       "email" : "client@konkuk.ac.kr",
       "password" : "newPassword"
}

````

3. 변경 시

`Request Header`
Authorization : Bearer {access-token}

`Request Body`
```json
{
       "password" : "newPassword"
}



