### PR TITLE
Feat: 비밀번호 초기화 시 인증코드 전송 로직 분리#247

### DIFF
--- a/src/main/java/com/kustacks/kuring/common/utils/generator/NicknameGenerator.java
+++ b/src/main/java/com/kustacks/kuring/common/utils/generator/NicknameGenerator.java
@@ -13,7 +13,7 @@ public class NicknameGenerator {
     }
 
     private static String pickRandomNicknamePrefix() {
-        int index = RandomGenerator.generatePositiveNumber(NICKNAME_PREFIXES.length);
+        int index = RandomGenerator.generateRandomSingleNumber(NICKNAME_PREFIXES.length);
         return NICKNAME_PREFIXES[index];
     }
 }

--- a/src/main/java/com/kustacks/kuring/common/utils/generator/NicknameGenerator.java
+++ b/src/main/java/com/kustacks/kuring/common/utils/generator/NicknameGenerator.java
@@ -1,0 +1,19 @@
+package com.kustacks.kuring.common.utils.generator;
+
+public class NicknameGenerator {
+    private static final int NICKNAME_NUMBER_LENGTH = 6;
+    private static final String[] NICKNAME_PREFIXES = {"쿠링이", "건덕이", "건구스"};
+
+    public static String generateNickname() {
+        // 접두사(쿠링이, 건덕이, 건구스 중 하나) + 6자리 숫자
+        String prefix = pickRandomNicknamePrefix();
+        String suffix = RandomGenerator.generateRandomNumber(NICKNAME_NUMBER_LENGTH);
+
+        return prefix + suffix;
+    }
+
+    private static String pickRandomNicknamePrefix() {
+        int index = RandomGenerator.generatePositiveNumber(NICKNAME_PREFIXES.length);
+        return NICKNAME_PREFIXES[index];
+    }
+}

--- a/src/main/java/com/kustacks/kuring/common/utils/generator/RandomGenerator.java
+++ b/src/main/java/com/kustacks/kuring/common/utils/generator/RandomGenerator.java
@@ -6,7 +6,6 @@ import java.util.Random;
 
 public class RandomGenerator {
     private static Random random;
-    private static final String[] NICKNAME_PREFIXES = {"쿠링이", "건덕이", "건구스"};
 
     public static String generateRandomNumber(int length) {
         try {
@@ -21,23 +20,21 @@ public class RandomGenerator {
         }
     }
 
-    public static String generateRandomNickname(int length) {
+    public static int generatePositiveNumber(int bound) {
         try {
             setSecureRandomInstance();
-            return pickRandomNicknamePrefix() + generateRandomNumber(length);
+            if (bound == 1) {
+                return 1;
+            }
+            return generateRandomSingleNumber(bound - 1) + 1;
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
     }
 
+
     private static void setSecureRandomInstance() throws NoSuchAlgorithmException {
         random = SecureRandom.getInstanceStrong();
-    }
-
-
-    private static String pickRandomNicknamePrefix() {
-        int i = generateRandomSingleNumber(NICKNAME_PREFIXES.length);
-        return NICKNAME_PREFIXES[i];
     }
 
     private static int generateRandomSingleNumber(int bound) {

--- a/src/main/java/com/kustacks/kuring/common/utils/generator/RandomGenerator.java
+++ b/src/main/java/com/kustacks/kuring/common/utils/generator/RandomGenerator.java
@@ -8,36 +8,24 @@ public class RandomGenerator {
     private static Random random;
 
     public static String generateRandomNumber(int length) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            sb.append(generateRandomSingleNumber(10));
+        }
+        return sb.toString();
+    }
+
+    public static int generateRandomSingleNumber(int bound) {
         try {
-            StringBuilder sb = new StringBuilder();
             setSecureRandomInstance();
-            for (int i = 0; i < length; i++) {
-                sb.append(generateRandomSingleNumber(10));
-            }
-            return sb.toString();
+            return random.nextInt(bound);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
     }
-
-    public static int generatePositiveNumber(int bound) {
-        try {
-            setSecureRandomInstance();
-            if (bound == 1) {
-                return 1;
-            }
-            return generateRandomSingleNumber(bound - 1) + 1;
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
 
     private static void setSecureRandomInstance() throws NoSuchAlgorithmException {
         random = SecureRandom.getInstanceStrong();
     }
 
-    private static int generateRandomSingleNumber(int bound) {
-        return random.nextInt(bound);
-    }
 }

--- a/src/main/java/com/kustacks/kuring/common/utils/generator/VerificationCodeGenerator.java
+++ b/src/main/java/com/kustacks/kuring/common/utils/generator/VerificationCodeGenerator.java
@@ -1,0 +1,16 @@
+package com.kustacks.kuring.common.utils.generator;
+
+import com.kustacks.kuring.common.exception.code.ErrorCode;
+import com.kustacks.kuring.email.application.service.exception.EmailBusinessException;
+
+public class VerificationCodeGenerator {
+    private static final int CODE_LENGTH = 6;
+
+    public static String generateVerificationCode() {
+        try {
+            return RandomGenerator.generateRandomNumber(CODE_LENGTH);
+        } catch (RuntimeException e) {
+            throw new EmailBusinessException(ErrorCode.EMAIL_NO_SUCH_ALGORITHM);
+        }
+    }
+}

--- a/src/main/java/com/kustacks/kuring/email/adapter/in/web/EmailCommandApiV2.java
+++ b/src/main/java/com/kustacks/kuring/email/adapter/in/web/EmailCommandApiV2.java
@@ -1,29 +1,62 @@
 package com.kustacks.kuring.email.adapter.in.web;
 
+import com.kustacks.kuring.auth.authentication.AuthorizationExtractor;
+import com.kustacks.kuring.auth.authentication.AuthorizationType;
+import com.kustacks.kuring.auth.token.JwtTokenProvider;
 import com.kustacks.kuring.common.annotation.RestWebAdapter;
 import com.kustacks.kuring.common.dto.BaseResponse;
 import com.kustacks.kuring.common.dto.ResponseCodeAndMessages;
+import com.kustacks.kuring.common.exception.InvalidStateException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
 import com.kustacks.kuring.email.adapter.in.web.dto.EmailVerificationRequest;
 import com.kustacks.kuring.email.application.port.in.EmailCommandUseCase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extractAuthorizationValue;
 
 @Slf4j
 @Tag(name = "Email-Query", description = "Email Send")
 @RestWebAdapter(path = "/api/v2/verification-code")
 @RequiredArgsConstructor
 public class EmailCommandApiV2 {
-    private final EmailCommandUseCase emailCommandUseCase;
 
-    @Operation(summary = "이메일로 인증번호 보내기", description = "사용자 회원가입 시 이메일로 인증번호를 보냅니다.")
-    @PostMapping
+    private static final String JWT_TOKEN_HEADER_KEY = "JWT";
+
+    private final EmailCommandUseCase emailCommandUseCase;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "이메일로 인증번호 보내기(회원가입 시)", description = "사용자 회원가입 시 이메일로 인증번호를 보냅니다.")
+    @PostMapping("/signup")
     public ResponseEntity<BaseResponse<Void>> sendVerificationCode(@RequestBody EmailVerificationRequest request) {
-        emailCommandUseCase.sendVerificationEmail(request.email());
+        emailCommandUseCase.sendSignupVerificationEmail(request.email());
         return ResponseEntity.ok().body(new BaseResponse<>(ResponseCodeAndMessages.EMAIL_SEND_SUCCESS, null));
+    }
+
+    @Operation(summary = "이메일로 인증번호 보내기(비밀번호 초기화 시)", description = "사용자 비밀번호 초기화 시 이메일로 인증번호를 보냅니다.")
+    @SecurityRequirement(name = JWT_TOKEN_HEADER_KEY)
+    @PostMapping("/password-reset")
+    public ResponseEntity<BaseResponse<Void>> sendPasswordResetVerificationCode(
+            @RequestHeader(AuthorizationExtractor.AUTHORIZATION) String bearerToken
+    ) {
+        String jwtToken = extractAuthorizationValue(bearerToken, AuthorizationType.BEARER);
+        String email = validateJwtAndGetEmail(jwtToken);
+
+        emailCommandUseCase.sendPasswordResetVerificationEmail(email);
+        return ResponseEntity.ok().body(new BaseResponse<>(ResponseCodeAndMessages.EMAIL_SEND_SUCCESS, null));
+    }
+
+    private String validateJwtAndGetEmail(String jwtToken) {
+        if (!jwtTokenProvider.validateToken(jwtToken)) {
+            throw new InvalidStateException(ErrorCode.JWT_INVALID_TOKEN);
+        }
+        return jwtTokenProvider.getPrincipal(jwtToken);
     }
 }

--- a/src/main/java/com/kustacks/kuring/email/application/port/in/EmailCommandUseCase.java
+++ b/src/main/java/com/kustacks/kuring/email/application/port/in/EmailCommandUseCase.java
@@ -1,5 +1,7 @@
 package com.kustacks.kuring.email.application.port.in;
 
 public interface EmailCommandUseCase {
-    void sendVerificationEmail(String email);
+    void sendSignupVerificationEmail(String email);
+
+    void sendPasswordResetVerificationEmail(String email);
 }

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/RootUserQueryRepository.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/RootUserQueryRepository.java
@@ -1,0 +1,7 @@
+package com.kustacks.kuring.user.adapter.out.persistence;
+
+import java.util.List;
+
+public interface RootUserQueryRepository {
+    List<String> findExistNicknamesIn(List<String> candidateNicknames);
+}

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/RootUserQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/RootUserQueryRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.kustacks.kuring.user.adapter.out.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.kustacks.kuring.user.domain.QRootUser.rootUser;
+
+@RequiredArgsConstructor
+class RootUserQueryRepositoryImpl implements RootUserQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<String> findExistNicknamesIn(List<String> candidateNicknames) {
+        return queryFactory.select(rootUser.nickname)
+                .from(rootUser)
+                .where(rootUser.nickname.in(candidateNicknames))
+                .fetch();
+    }
+}

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/RootUserRepository.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/RootUserRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-interface RootUserRepository extends JpaRepository<RootUser, Long> {
+interface RootUserRepository extends JpaRepository<RootUser, Long>, RootUserQueryRepository {
     Optional<RootUser> findByEmail(String email);
     Optional<RootUser> findByNickname(String nickname);
 

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -80,6 +80,11 @@ public class UserPersistenceAdapter implements UserCommandPort, UserQueryPort, A
     }
 
     @Override
+    public List<String> findUsingNicknamesIn(List<String> candidateNicknames) {
+        return rootUserRepository.findExistNicknamesIn(candidateNicknames);
+    }
+
+    @Override
     public List<User> findByLoggedInUserId(Long id) {
         return userRepository.findByLoginUserId(id);
     }

--- a/src/main/java/com/kustacks/kuring/user/application/port/out/RootUserQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/out/RootUserQueryPort.java
@@ -2,6 +2,7 @@ package com.kustacks.kuring.user.application.port.out;
 
 import com.kustacks.kuring.user.domain.RootUser;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RootUserQueryPort {
@@ -9,4 +10,6 @@ public interface RootUserQueryPort {
     Optional<RootUser> findDeletedRootUserByEmail(String email);
 
     boolean existRootUserByEmail(String email);
+
+    List<String> findUsingNicknamesIn(List<String> candidateNicknames);
 }

--- a/src/main/java/com/kustacks/kuring/user/application/service/UserCommandService.java
+++ b/src/main/java/com/kustacks/kuring/user/application/service/UserCommandService.java
@@ -6,7 +6,7 @@ import com.kustacks.kuring.common.exception.InvalidStateException;
 import com.kustacks.kuring.common.exception.NotFoundException;
 import com.kustacks.kuring.common.exception.code.ErrorCode;
 import com.kustacks.kuring.common.properties.ServerProperties;
-import com.kustacks.kuring.common.utils.generator.RandomGenerator;
+import com.kustacks.kuring.common.utils.generator.NicknameGenerator;
 import com.kustacks.kuring.message.application.service.exception.FirebaseSubscribeException;
 import com.kustacks.kuring.message.application.service.exception.FirebaseUnSubscribeException;
 import com.kustacks.kuring.notice.domain.CategoryName;
@@ -227,7 +227,7 @@ class UserCommandService implements UserCommandUseCase {
     private String createNickname() {
         String nickname = "";
         do {
-            nickname = RandomGenerator.generateRandomNickname(6);
+            nickname = NicknameGenerator.generateNickname();
         } while (userQueryPort.existByNickname(nickname));
         return nickname;
     }

--- a/src/main/java/com/kustacks/kuring/user/application/service/UserCommandService.java
+++ b/src/main/java/com/kustacks/kuring/user/application/service/UserCommandService.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,7 +97,7 @@ class UserCommandService implements UserCommandUseCase {
     @Override
     public void decreaseQuestionCount(UserDecreaseQuestionCountCommand command) {
         User findUser = findUserByToken(command.userId());
-        
+
         try {
             checkUserLoginIdAndDecreaseCount(findUser, command.email());
         } catch (IllegalStateException e) {
@@ -225,11 +226,28 @@ class UserCommandService implements UserCommandUseCase {
     }
 
     private String createNickname() {
-        String nickname = "";
-        do {
-            nickname = NicknameGenerator.generateNickname();
-        } while (userQueryPort.existByNickname(nickname));
-        return nickname;
+        final int BATCH_SIZE = 5;
+
+        while (true) {
+            List<String> candidateNicknames = new ArrayList<>();
+            for (int i = 0; i < BATCH_SIZE; i++) {
+                candidateNicknames.add(NicknameGenerator.generateNickname());
+            }
+
+            List<String> usingNicknames = rootUserQueryPort.findUsingNicknamesIn(candidateNicknames);
+            List<String> availableNicknames = selectAvailableNicknames(candidateNicknames, usingNicknames);
+
+            // 사용 가능한 닉네임이 있으면 랜덤으로 하나 선택
+            if (!availableNicknames.isEmpty()) {
+                return availableNicknames.get(0);
+            }
+        }
+    }
+
+    private List<String> selectAvailableNicknames(List<String> candidateNicknames, List<String> usingNicknames) {
+        return candidateNicknames.stream()
+                .filter(candidateNickname -> !usingNicknames.contains(candidateNickname))
+                .toList();
     }
 
     private UserSubscribeCompareResult<CategoryName> editSubscribeCategoryList(

--- a/src/test/java/com/kustacks/kuring/acceptance/EmailAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/EmailAcceptanceTest.java
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import static com.kustacks.kuring.acceptance.CommonStep.실패_응답_확인;
-import static com.kustacks.kuring.acceptance.EmailStep.인증_이메일_전송_요청;
+import static com.kustacks.kuring.acceptance.EmailStep.비밀번호초기화_인증코드_이메일_전송_요청;
 import static com.kustacks.kuring.acceptance.EmailStep.인증_이메일_전송_응답_확인;
 import static com.kustacks.kuring.acceptance.EmailStep.인증코드_인증_요청;
 import static com.kustacks.kuring.acceptance.EmailStep.인증코드_인증_응답_확인;
+import static com.kustacks.kuring.acceptance.EmailStep.회원가입_인증코드_이메일_전송_요청;
+import static com.kustacks.kuring.acceptance.UserStep.사용자_로그인_되어_있음;
 import static com.kustacks.kuring.acceptance.UserStep.사용자_회원가입_요청;
 
 @DisplayName("인수 : 이메일")
@@ -17,17 +19,17 @@ class EmailAcceptanceTest extends IntegrationTestSupport {
 
     public static final String NEW_EMAIL = "new-client@konkuk.ac.kr";
 
-    @DisplayName("인증코드 이메일을 성공적으로 발송한다.")
+    @DisplayName("회원가입 이메일 인증코드를 성공적으로 발송한다.")
     @Test
-    void send_verification_code_email() {
+    void send_email_verification_code_for_signup() {
         // when
-        var 인증_이메일_전송_응답 = 인증_이메일_전송_요청(NEW_EMAIL);
+        var 인증_이메일_전송_응답 = 회원가입_인증코드_이메일_전송_요청(NEW_EMAIL);
 
         // then
         인증_이메일_전송_응답_확인((인증_이메일_전송_응답));
     }
 
-    @DisplayName("인증코드를 성공적으로 인증한다.")
+    @DisplayName("회원가입 이메일 인증코드를 성공적으로 인증한다.")
     @Test
     void verify_verification_code() {
         // when
@@ -35,6 +37,19 @@ class EmailAcceptanceTest extends IntegrationTestSupport {
 
         // then
         인증코드_인증_응답_확인(인증코드_인증_응답, HttpStatus.OK);
+    }
+
+    @DisplayName("비밀번호 초기화 이메일 인증코드를 성공적으로 발송한다.")
+    @Test
+    void send_email_verification_code_for_password_reset() {
+        //given
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        // when
+        var 인증_이메일_전송_응답 = 비밀번호초기화_인증코드_이메일_전송_요청(NEW_EMAIL, accessToken);
+
+        // then
+        인증_이메일_전송_응답_확인((인증_이메일_전송_응답));
     }
 
     @DisplayName("잘못된 인증코드로 인증을 시도한다.")
@@ -48,14 +63,14 @@ class EmailAcceptanceTest extends IntegrationTestSupport {
     }
 
 
-    @DisplayName("이미 가입된 이메일로 인증코드 요청을 보냄.")
+    @DisplayName("이미 가입된 이메일로 회원가입 이메일 인증코드 요청을 보냄.")
     @Test
     void duplicate_email_fail() {
         //given
         사용자_회원가입_요청(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
 
         // when - 이미 가입된 이메일로 인증코드 요청
-        var 인증_이메일_전송_응답 = 인증_이메일_전송_요청(USER_EMAIL);
+        var 인증_이메일_전송_응답 = 회원가입_인증코드_이메일_전송_요청(USER_EMAIL);
 
         // then
         실패_응답_확인(인증_이메일_전송_응답, HttpStatus.BAD_REQUEST);

--- a/src/test/java/com/kustacks/kuring/acceptance/EmailStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/EmailStep.java
@@ -13,16 +13,26 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class EmailStep {
 
-    public static ExtractableResponse<Response> 인증_이메일_전송_요청(String email) {
+    public static ExtractableResponse<Response> 회원가입_인증코드_이메일_전송_요청(String email) {
         return RestAssured
                 .given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new EmailVerificationRequest(email))
-                .when().post("/api/v2/verification-code")
+                .when().post("/api/v2/verification-code/signup")
                 .then().log().all()
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 비밀번호초기화_인증코드_이메일_전송_요청(String email, String accessToken) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + accessToken)
+                .body(new EmailVerificationRequest(email))
+                .when().post("/api/v2/verification-code/password-reset")
+                .then().log().all()
+                .extract();
+    }
 
     public static void 인증_이메일_전송_응답_확인(ExtractableResponse<Response> response) {
         assertAll(

--- a/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
@@ -12,8 +12,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.kustacks.kuring.acceptance.CommonStep.실패_응답_확인;
-import static com.kustacks.kuring.acceptance.EmailStep.인증_이메일_전송_요청;
 import static com.kustacks.kuring.acceptance.EmailStep.인증코드_인증_요청;
+import static com.kustacks.kuring.acceptance.EmailStep.회원가입_인증코드_이메일_전송_요청;
 import static com.kustacks.kuring.acceptance.UserStep.구독한_학과_목록_조회_요청;
 import static com.kustacks.kuring.acceptance.UserStep.남은_질문_횟수_조회;
 import static com.kustacks.kuring.acceptance.UserStep.로그아웃_요청;
@@ -272,7 +272,7 @@ class UserAcceptanceTest extends IntegrationTestSupport {
     void verify_email_and_signup() {
         // given
         doNothing().when(firebaseSubscribeService).validationToken(anyString());
-        인증_이메일_전송_요청(NEW_EMAIL);
+        회원가입_인증코드_이메일_전송_요청(NEW_EMAIL);
         인증코드_인증_요청(NEW_EMAIL, "123456");
 
         사용자_회원가입_요청(USER_FCM_TOKEN, NEW_EMAIL, USER_PASSWORD);

--- a/src/test/java/com/kustacks/kuring/common/utils/generator/NicknameGeneratorTest.java
+++ b/src/test/java/com/kustacks/kuring/common/utils/generator/NicknameGeneratorTest.java
@@ -1,0 +1,59 @@
+package com.kustacks.kuring.common.utils.generator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+@ExtendWith(MockitoExtension.class)
+class NicknameGeneratorTest {
+    String[] prefixes = {"쿠링이", "건덕이", "건구스"};
+
+    @Test
+    @DisplayName("generateNickname 메서드는 닉네임을 생성한다")
+    void generateNickname_ShouldGenerateNickname() {
+        // when
+        String nickname = NicknameGenerator.generateNickname();
+
+        // then
+        assertThat(nickname).isNotNull();
+        assertThat(nickname).isNotEmpty();
+
+        boolean isMatch = false;
+        // 닉네임 형식 검증: 접두사 + 6자리 숫자
+        for (String prefix : prefixes) {
+            String regex = prefix + "\\d{6}";
+            if (nickname.matches(regex)) {
+                isMatch = true;
+                break;
+            }
+        }
+        assertThat(isMatch).isTrue();
+    }
+
+    @Test
+    @DisplayName("generateNickname 메서드는 RandomGenerator를 사용하여 닉네임을 생성한다")
+    void generateNickname_ShouldUseRandomGenerator() {
+        try (MockedStatic<RandomGenerator> mockedRandomGenerator = mockStatic(RandomGenerator.class)) {
+            // given
+            mockedRandomGenerator.when(() -> RandomGenerator.generatePositiveNumber(3))
+                    .thenReturn(1); // "건덕이" 선택
+            mockedRandomGenerator.when(() -> RandomGenerator.generateRandomNumber(6))
+                    .thenReturn("123456");
+
+            // when
+            String nickname = NicknameGenerator.generateNickname();
+
+            // then
+            assertThat(nickname).isEqualTo("건덕이123456");
+
+            // 메서드 호출 검증
+            mockedRandomGenerator.verify(() -> RandomGenerator.generatePositiveNumber(3));
+            mockedRandomGenerator.verify(() -> RandomGenerator.generateRandomNumber(6));
+        }
+    }
+}

--- a/src/test/java/com/kustacks/kuring/common/utils/generator/NicknameGeneratorTest.java
+++ b/src/test/java/com/kustacks/kuring/common/utils/generator/NicknameGeneratorTest.java
@@ -3,11 +3,9 @@ package com.kustacks.kuring.common.utils.generator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
 class NicknameGeneratorTest {
@@ -33,27 +31,5 @@ class NicknameGeneratorTest {
             }
         }
         assertThat(isMatch).isTrue();
-    }
-
-    @Test
-    @DisplayName("generateNickname 메서드는 RandomGenerator를 사용하여 닉네임을 생성한다")
-    void generateNickname_ShouldUseRandomGenerator() {
-        try (MockedStatic<RandomGenerator> mockedRandomGenerator = mockStatic(RandomGenerator.class)) {
-            // given
-            mockedRandomGenerator.when(() -> RandomGenerator.generatePositiveNumber(3))
-                    .thenReturn(1); // "건덕이" 선택
-            mockedRandomGenerator.when(() -> RandomGenerator.generateRandomNumber(6))
-                    .thenReturn("123456");
-
-            // when
-            String nickname = NicknameGenerator.generateNickname();
-
-            // then
-            assertThat(nickname).isEqualTo("건덕이123456");
-
-            // 메서드 호출 검증
-            mockedRandomGenerator.verify(() -> RandomGenerator.generatePositiveNumber(3));
-            mockedRandomGenerator.verify(() -> RandomGenerator.generateRandomNumber(6));
-        }
     }
 }

--- a/src/test/java/com/kustacks/kuring/common/utils/generator/NicknameGeneratorTest.java
+++ b/src/test/java/com/kustacks/kuring/common/utils/generator/NicknameGeneratorTest.java
@@ -2,14 +2,12 @@ package com.kustacks.kuring.common.utils.generator;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(MockitoExtension.class)
 class NicknameGeneratorTest {
-    String[] prefixes = {"쿠링이", "건덕이", "건구스"};
+    private final String[] nicknamePrefixes = {"쿠링이", "건덕이", "건구스"};
+    private final String nicknameRegexFormat = "^(%s)\\d{6}$";
 
     @Test
     @DisplayName("generateNickname 메서드는 닉네임을 생성한다")
@@ -21,15 +19,9 @@ class NicknameGeneratorTest {
         assertThat(nickname).isNotNull();
         assertThat(nickname).isNotEmpty();
 
-        boolean isMatch = false;
-        // 닉네임 형식 검증: 접두사 + 6자리 숫자
-        for (String prefix : prefixes) {
-            String regex = prefix + "\\d{6}";
-            if (nickname.matches(regex)) {
-                isMatch = true;
-                break;
-            }
-        }
-        assertThat(isMatch).isTrue();
+        String prefixRegex = String.join("|", nicknamePrefixes);
+        String fullRegex = String.format(nicknameRegexFormat, prefixRegex);
+
+        assertThat(nickname.matches(fullRegex)).isTrue();
     }
 }

--- a/src/test/java/com/kustacks/kuring/common/utils/generator/RandomGeneratorTest.java
+++ b/src/test/java/com/kustacks/kuring/common/utils/generator/RandomGeneratorTest.java
@@ -1,0 +1,80 @@
+package com.kustacks.kuring.common.utils.generator;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RandomGeneratorTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 3, 6, 10})
+    @DisplayName("generateRandomNumber 메서드는 지정된 길이의 숫자 문자열을 생성한다")
+    void generateRandomNumber_ShouldReturnStringWithSpecifiedLength(int length) {
+        // when
+        String result = RandomGenerator.generateRandomNumber(length);
+
+        // then
+        assertThat(result).hasSize(length);
+        assertThat(result).matches("\\d{" + length + "}");
+    }
+
+    @Test
+    @DisplayName("generateRandomNumber 메서드는 길이가 0인 경우 빈 문자열을 반환한다")
+    void generateRandomNumber_ShouldReturnEmptyString_WhenLengthIsZero() {
+        // when
+        String result = RandomGenerator.generateRandomNumber(0);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("generateRandomNumber 메서드는 길이가 음수인 경우 빈 문자열을 반환한다")
+    void generateRandomNumber_ShouldReturnEmptyString_WhenLengthIsNegative() {
+        // when
+        String result = RandomGenerator.generateRandomNumber(-5);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @RepeatedTest(100)
+    @DisplayName("generatePositiveNumber 메서드는 1 이상 bound 미만의 양수를 생성한다")
+    void generatePositiveNumber_ShouldReturnPositiveNumberLessThanMaxValue() {
+        // given
+        int bound = 10;
+
+        // when
+        int result = RandomGenerator.generatePositiveNumber(bound);
+
+        // then
+        assertThat(result).isGreaterThanOrEqualTo(1);
+        assertThat(result).isLessThan(bound);
+    }
+
+    @Test
+    @DisplayName("generatePositiveNumber 메서드는 bound가 0이하인 경우 IllegalArgumentException 예외가 발생한다.")
+    void generatePositiveNumber_ShouldThrowsException_WhenMaxValueIsLessThanTwo() {
+        // given
+        int bound = 0;
+
+        // when
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> RandomGenerator.generatePositiveNumber(bound));
+    }
+
+    @Test
+    @DisplayName("generatePositiveNumber 메서드는 bound가 1인 경우 1응 응답한다.")
+    void generatePositiveNumber_ShouldReturnOne_WhenMaxValueIsLessThanTwo() {
+        // given
+        int bound = 1;
+
+        // when
+        assertThat(RandomGenerator.generatePositiveNumber(bound)).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/kustacks/kuring/common/utils/generator/RandomGeneratorTest.java
+++ b/src/test/java/com/kustacks/kuring/common/utils/generator/RandomGeneratorTest.java
@@ -1,8 +1,6 @@
 package com.kustacks.kuring.common.utils.generator;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -41,40 +39,5 @@ class RandomGeneratorTest {
 
         // then
         assertThat(result).isEmpty();
-    }
-
-    @RepeatedTest(100)
-    @DisplayName("generatePositiveNumber 메서드는 1 이상 bound 미만의 양수를 생성한다")
-    void generatePositiveNumber_ShouldReturnPositiveNumberLessThanMaxValue() {
-        // given
-        int bound = 10;
-
-        // when
-        int result = RandomGenerator.generatePositiveNumber(bound);
-
-        // then
-        assertThat(result).isGreaterThanOrEqualTo(1);
-        assertThat(result).isLessThan(bound);
-    }
-
-    @Test
-    @DisplayName("generatePositiveNumber 메서드는 bound가 0이하인 경우 IllegalArgumentException 예외가 발생한다.")
-    void generatePositiveNumber_ShouldThrowsException_WhenMaxValueIsLessThanTwo() {
-        // given
-        int bound = 0;
-
-        // when
-        Assertions.assertThrows(IllegalArgumentException.class,
-                () -> RandomGenerator.generatePositiveNumber(bound));
-    }
-
-    @Test
-    @DisplayName("generatePositiveNumber 메서드는 bound가 1인 경우 1응 응답한다.")
-    void generatePositiveNumber_ShouldReturnOne_WhenMaxValueIsLessThanTwo() {
-        // given
-        int bound = 1;
-
-        // when
-        assertThat(RandomGenerator.generatePositiveNumber(bound)).isEqualTo(1);
     }
 }

--- a/src/test/java/com/kustacks/kuring/common/utils/generator/VerificationCodeGeneratorTest.java
+++ b/src/test/java/com/kustacks/kuring/common/utils/generator/VerificationCodeGeneratorTest.java
@@ -1,0 +1,45 @@
+package com.kustacks.kuring.common.utils.generator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+@ExtendWith(MockitoExtension.class)
+class VerificationCodeGeneratorTest {
+
+    @Test
+    @DisplayName("generateVerificationCode 메서드는 6자리 인증 코드를 생성한다")
+    void generateVerificationCode_ShouldGenerateSixDigitCode() {
+        // when
+        String code = VerificationCodeGenerator.generateVerificationCode();
+
+        // then
+        assertThat(code).isNotNull();
+        assertThat(code).hasSize(6);
+        assertThat(code).matches("\\d{6}");
+    }
+
+    @Test
+    @DisplayName("generateVerificationCode 메서드는 RandomGenerator를 사용하여 코드를 생성한다")
+    void generateVerificationCode_ShouldUseRandomGenerator() {
+        try (MockedStatic<RandomGenerator> mockedRandomGenerator = mockStatic(RandomGenerator.class)) {
+            // given
+            mockedRandomGenerator.when(() -> RandomGenerator.generateRandomNumber(6))
+                    .thenReturn("987654");
+
+            // when
+            String code = VerificationCodeGenerator.generateVerificationCode();
+
+            // then
+            assertThat(code).isEqualTo("987654");
+
+            // 메서드 호출 검증
+            mockedRandomGenerator.verify(() -> RandomGenerator.generateRandomNumber(6));
+        }
+    }
+}

--- a/src/test/java/com/kustacks/kuring/email/application/service/EmailCommandUseCaseTest.java
+++ b/src/test/java/com/kustacks/kuring/email/application/service/EmailCommandUseCaseTest.java
@@ -45,7 +45,7 @@ class EmailCommandUseCaseTest {
         Mockito.when(rootUserQueryPort.existRootUserByEmail(Mockito.anyString())).thenReturn(false);
 
         //when
-        emailCommandService.sendVerificationEmail(email);
+        emailCommandService.sendSignupVerificationEmail(email);
 
         //then
         Mockito.verify(templateEnginePort, Mockito.times(1))

--- a/src/test/java/com/kustacks/kuring/support/IntegrationTestSupport.java
+++ b/src/test/java/com/kustacks/kuring/support/IntegrationTestSupport.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.testcontainers.chromadb.ChromaDBContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
@@ -28,6 +29,7 @@ public class IntegrationTestSupport {
 
     static {
         chroma = new ChromaDBContainer(DockerImageName.parse("chromadb/chroma:latest"))
+                .waitingFor(Wait.forHttp("/api/v2/heartbeat"))
                 .withExposedPorts(8000);
         chroma.start();
     }


### PR DESCRIPTION
### 구현
- 인증 이메일 전송 시 `password-reset`과 `signup`으로 구분하여 회원가입 시와 비밀번호 초기화 시 사용하는 API를 분리했습니다.
- RandomGenerator를 수정하여 VerificationCodeGenerator와 NicknameGenerator를 구분하여 용도에 맞는 생성 클래스를 추가하였습니다.
- Generator클래스의 테스트 코드를 추가했습니다.