### PR TITLE
Fix : 비밀번호 초기화 인증코드 이메일 전송 방식 수정 및 검증 추가 #253

### DIFF
--- a/src/main/java/com/kustacks/kuring/email/application/service/EmailCommandService.java
+++ b/src/main/java/com/kustacks/kuring/email/application/service/EmailCommandService.java
@@ -52,6 +52,9 @@ public class EmailCommandService implements EmailCommandUseCase {
 
     @Override
     public void sendPasswordResetVerificationEmail(String email) {
+        checkKonkukEmail(email);
+        checkSignedUpEmail(email);
+
         String code = VerificationCodeGenerator.generateVerificationCode();
 
         String htmlTextWithCode = templateEnginePort.process(TEMPLATE_FILE, createVariables(code));
@@ -65,6 +68,12 @@ public class EmailCommandService implements EmailCommandUseCase {
     private void checkKonkukEmail(String email) {
         if (!email.endsWith(TO_EMIL_SUFFIX)) {
             throw new EmailBusinessException(ErrorCode.EMAIL_INVALID_SUFFIX);
+        }
+    }
+
+    private void checkSignedUpEmail(String email) {
+        if (!rootUserQueryPort.existRootUserByEmail(email)) {
+            throw new InvalidStateException(ErrorCode.ROOT_USER_NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/kustacks/kuring/notice/domain/DepartmentName.java
+++ b/src/main/java/com/kustacks/kuring/notice/domain/DepartmentName.java
@@ -88,7 +88,7 @@ public enum DepartmentName {
 
     ELE_EDU_CENTER("elective_education_center", "sgedu", "교양교육센터"),
     VOLUNTEER("volunteer_center", "kuvolunteer", "사회봉사센터"),
-    LIBERAL_STUDIES("liberal_studies", "kusls", "KU자율전공학부");
+    LIBERAL_STUDIES("liberal_studies", "kusls", "KU자유전공학부");
 
     private static final Map<String, String> NAME_MAP;
     private static final Map<String, String> HOST_PREFIX_MAP;

--- a/src/test/java/com/kustacks/kuring/acceptance/EmailAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/EmailAcceptanceTest.java
@@ -7,12 +7,14 @@ import org.springframework.http.HttpStatus;
 
 import static com.kustacks.kuring.acceptance.CommonStep.실패_응답_확인;
 import static com.kustacks.kuring.acceptance.EmailStep.비밀번호초기화_인증코드_이메일_전송_요청;
+import static com.kustacks.kuring.acceptance.EmailStep.비밀번호초기화_인증코드_이메일_전송_요청_둘다없음;
+import static com.kustacks.kuring.acceptance.EmailStep.비밀번호초기화_인증코드_이메일_전송_요청_바디만;
+import static com.kustacks.kuring.acceptance.EmailStep.비밀번호초기화_인증코드_이메일_전송_요청_토큰만;
 import static com.kustacks.kuring.acceptance.EmailStep.인증_이메일_전송_응답_확인;
 import static com.kustacks.kuring.acceptance.EmailStep.인증코드_인증_요청;
 import static com.kustacks.kuring.acceptance.EmailStep.인증코드_인증_응답_확인;
 import static com.kustacks.kuring.acceptance.EmailStep.회원가입_인증코드_이메일_전송_요청;
 import static com.kustacks.kuring.acceptance.UserStep.사용자_로그인_되어_있음;
-import static com.kustacks.kuring.acceptance.UserStep.사용자_회원가입_요청;
 
 @DisplayName("인수 : 이메일")
 class EmailAcceptanceTest extends IntegrationTestSupport {
@@ -52,6 +54,52 @@ class EmailAcceptanceTest extends IntegrationTestSupport {
         인증_이메일_전송_응답_확인((인증_이메일_전송_응답));
     }
 
+    @DisplayName("로그인한 사용자가 토큰으로 비밀번호 초기화 이메일 인증코드를 성공적으로 발송한다.")
+    @Test
+    void send_email_verification_code_for_password_reset_with_token_only() {
+        //given
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        // when
+        var 인증_이메일_전송_응답 = 비밀번호초기화_인증코드_이메일_전송_요청_토큰만(accessToken);
+
+        // then
+        인증_이메일_전송_응답_확인((인증_이메일_전송_응답));
+    }
+
+    @DisplayName("비로그인 사용자가 이메일로 비밀번호 초기화 인증코드를 성공적으로 발송한다.")
+    @Test
+    void send_email_verification_code_for_password_reset_with_body_only() {
+        // when
+        var 인증_이메일_전송_응답 = 비밀번호초기화_인증코드_이메일_전송_요청_바디만(USER_EMAIL);
+
+        // then
+        인증_이메일_전송_응답_확인((인증_이메일_전송_응답));
+    }
+
+    @DisplayName("토큰과 바디 둘 다 있는 경우 토큰값으로 비밀번호 초기화 인증코드를 성공적으로 발송한다.")
+    @Test
+    void send_email_verification_code_for_password_reset_with_both_token_and_body_fails() {
+        //given
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        // when
+        var 인증_이메일_전송_응답 = 비밀번호초기화_인증코드_이메일_전송_요청(USER_EMAIL, accessToken);
+
+        // then
+        인증_이메일_전송_응답_확인((인증_이메일_전송_응답));
+    }
+
+    @DisplayName("토큰과 바디 둘 다 없는 경우 비밀번호 초기화 이메일 요청은 실패한다.")
+    @Test
+    void send_email_verification_code_for_password_reset_with_neither_token_nor_body_fails() {
+        // when
+        var 인증_이메일_전송_응답 = 비밀번호초기화_인증코드_이메일_전송_요청_둘다없음();
+
+        // then
+        실패_응답_확인(인증_이메일_전송_응답, HttpStatus.BAD_REQUEST);
+    }
+
     @DisplayName("잘못된 인증코드로 인증을 시도한다.")
     @Test
     void verify_with_invalid_verification_code() {
@@ -62,15 +110,41 @@ class EmailAcceptanceTest extends IntegrationTestSupport {
         실패_응답_확인(인증코드_인증_응답, HttpStatus.BAD_REQUEST);
     }
 
-
-    @DisplayName("이미 가입된 이메일로 회원가입 이메일 인증코드 요청을 보냄.")
+    @DisplayName("가입된 이메일로 회원가입 인증코드 요청을 보낼 시 실패한다.")
     @Test
     void duplicate_email_fail() {
-        //given
-        사용자_회원가입_요청(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
-
         // when - 이미 가입된 이메일로 인증코드 요청
         var 인증_이메일_전송_응답 = 회원가입_인증코드_이메일_전송_요청(USER_EMAIL);
+
+        // then
+        실패_응답_확인(인증_이메일_전송_응답, HttpStatus.BAD_REQUEST);
+    }
+
+    @DisplayName("미가입 이메일로 비밀번호 초기화 인증코드 요청시 실패한다.")
+    @Test
+    void send_password_reset_verification_code_to_unregistered_email_fails() {
+        // 미가입 이메일로 요청
+        var 인증_이메일_전송_응답 = 비밀번호초기화_인증코드_이메일_전송_요청_바디만("unregistered@konkuk.ac.kr");
+
+        // then
+        실패_응답_확인(인증_이메일_전송_응답, HttpStatus.NOT_FOUND);
+    }
+
+    @DisplayName("건국대 이메일(@konkuk.ac.kr)이 아닌 이메일로 회원가입 인증코드 요청시 실패한다.")
+    @Test
+    void send_signup_verification_code_to_non_konkuk_email_fails() {
+        // 건국대 이메일이 아닌 이메일로 요청
+        var 인증_이메일_전송_응답 = 회원가입_인증코드_이메일_전송_요청("test@gmail.com");
+
+        // then
+        실패_응답_확인(인증_이메일_전송_응답, HttpStatus.BAD_REQUEST);
+    }
+
+    @DisplayName("건국대 이메일(@konkuk.ac.kr)이 아닌 이메일로 비밀번호 초기화 인증코드 요청시 실패한다.")
+    @Test
+    void send_password_reset_verification_code_to_non_konkuk_email_fails() {
+        // 건국대 이메일이 아닌 이메일로 요청
+        var 인증_이메일_전송_응답 = 비밀번호초기화_인증코드_이메일_전송_요청_바디만("test@gmail.com");
 
         // then
         실패_응답_확인(인증_이메일_전송_응답, HttpStatus.BAD_REQUEST);

--- a/src/test/java/com/kustacks/kuring/acceptance/EmailStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/EmailStep.java
@@ -34,6 +34,35 @@ public class EmailStep {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 비밀번호초기화_인증코드_이메일_전송_요청_토큰만(String accessToken) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + accessToken)
+                .when().post("/api/v2/verification-code/password-reset")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 비밀번호초기화_인증코드_이메일_전송_요청_바디만(String email) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new EmailVerificationRequest(email))
+                .when().post("/api/v2/verification-code/password-reset")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 비밀번호초기화_인증코드_이메일_전송_요청_둘다없음() {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/api/v2/verification-code/password-reset")
+                .then().log().all()
+                .extract();
+    }
+
     public static void 인증_이메일_전송_응답_확인(ExtractableResponse<Response> response) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),


### PR DESCRIPTION
## 구현사항
- 비밀번호 초기화 인증코드 이메일 전송 시 헤더 or body값으로 이메일 받도록 수정
- 만약, 둘다 값이 없는경우 400에러 발생
- 비밀번호 초기화 인증코드 이메일 전송 시 이메일 검증 로직 추가(회원가입 된 사용자, 학교 이메일 도메인)
- 헤더 or body값만 있는 경우, 둘다 없는 경우에 대한 인수 테스트 추가
- 자율전공 -> 자유전공 오타 수정

> 관련 이슈 : #253 