### PR TITLE
Feat: 댓글 신고 API 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/admin/adapter/in/web/AdminQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/admin/adapter/in/web/AdminQueryApiV2.java
@@ -7,6 +7,7 @@ import com.kustacks.kuring.auth.authorization.AuthenticationPrincipal;
 import com.kustacks.kuring.auth.context.Authentication;
 import com.kustacks.kuring.auth.secured.Secured;
 import com.kustacks.kuring.common.dto.BaseResponse;
+import com.kustacks.kuring.report.application.port.in.dto.AdminReportsResult;
 import com.kustacks.kuring.user.application.port.in.dto.AdminFeedbacksResult;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,7 +27,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.*;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.ALERT_SEARCH_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.AUTH_AUTHENTICATION_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.FEEDBACK_SEARCH_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.REPORT_SEARCH_SUCCESS;
 
 @Tag(name = "Admin-Query", description = "관리자가 주체가 되는 정보 조회")
 @Validated
@@ -59,6 +63,18 @@ public class AdminQueryApiV2 {
     ) {
         List<AdminAlertResponse> alerts = adminQueryUseCase.lookupAlerts(page, size);
         return ResponseEntity.ok().body(new BaseResponse<>(ALERT_SEARCH_SUCCESS, alerts));
+    }
+
+    @Operation(summary = "신고 목록 조회", description = "사용자의 모든 신고 목록을 조회합니다")
+    @SecurityRequirement(name = "JWT")
+    @Secured(AdminRole.ROLE_ROOT)
+    @GetMapping("/reports")
+    public ResponseEntity<BaseResponse<List<AdminReportsResult>>> getReports(
+            @Parameter(description = "페이지") @RequestParam(name = "page") @Min(0) int page,
+            @Parameter(description = "단일 페이지의 사이즈, 1 ~ 30까지 허용") @RequestParam(name = "size") @Min(1) @Max(30) int size
+    ) {
+        List<AdminReportsResult> result = adminQueryUseCase.lookupReports(page, size);
+        return ResponseEntity.ok().body(new BaseResponse<>(REPORT_SEARCH_SUCCESS, result));
     }
 
     /**

--- a/src/main/java/com/kustacks/kuring/admin/application/port/in/AdminQueryUseCase.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/port/in/AdminQueryUseCase.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.admin.application.port.in;
 
 import com.kustacks.kuring.admin.adapter.in.web.dto.AdminAlertResponse;
+import com.kustacks.kuring.report.application.port.in.dto.AdminReportsResult;
 import com.kustacks.kuring.user.application.port.in.dto.AdminFeedbacksResult;
 
 import java.util.List;
@@ -9,4 +10,6 @@ public interface AdminQueryUseCase {
     List<AdminFeedbacksResult> lookupFeedbacks(int page, int size);
 
     List<AdminAlertResponse> lookupAlerts(int page, int size);
+
+    List<AdminReportsResult> lookupReports(int page, int size);
 }

--- a/src/main/java/com/kustacks/kuring/admin/application/port/out/AdminUserReportPort.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/port/out/AdminUserReportPort.java
@@ -1,0 +1,9 @@
+package com.kustacks.kuring.admin.application.port.out;
+
+import com.kustacks.kuring.report.domain.Report;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface AdminUserReportPort {
+    Page<Report> findAllReportByPageRequest(Pageable pageable);
+}

--- a/src/main/java/com/kustacks/kuring/admin/application/service/AdminQueryService.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/service/AdminQueryService.java
@@ -4,7 +4,9 @@ import com.kustacks.kuring.admin.adapter.in.web.dto.AdminAlertResponse;
 import com.kustacks.kuring.admin.application.port.in.AdminQueryUseCase;
 import com.kustacks.kuring.admin.application.port.out.AdminAlertQueryPort;
 import com.kustacks.kuring.admin.application.port.out.AdminUserFeedbackPort;
+import com.kustacks.kuring.admin.application.port.out.AdminUserReportPort;
 import com.kustacks.kuring.common.annotation.UseCase;
+import com.kustacks.kuring.report.application.port.in.dto.AdminReportsResult;
 import com.kustacks.kuring.user.application.port.in.dto.AdminFeedbacksResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +23,7 @@ public class AdminQueryService implements AdminQueryUseCase {
 
     private final AdminUserFeedbackPort adminUserFeedbackPort;
     private final AdminAlertQueryPort adminAlertQueryPort;
+    private final AdminUserReportPort adminUserReportPort;
 
     @Transactional(readOnly = true)
     @Override
@@ -47,6 +50,23 @@ public class AdminQueryService implements AdminQueryUseCase {
                         alert.getContent(),
                         alert.getStatus(),
                         alert.getAlertTime()
+                ))
+                .toList();
+    }
+
+    @Override
+    public List<AdminReportsResult> lookupReports(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Order.desc("createdAt")));
+        return adminUserReportPort.findAllReportByPageRequest(pageRequest)
+                .stream()
+                .map(report -> AdminReportsResult.of(
+                        report.getId(),
+                        report.getTargetId(),
+                        report.getUserId(),
+                        report.getTargetType(),
+                        report.getContent(),
+                        report.getCreatedAt(),
+                        report.getUpdatedAt()
                 ))
                 .toList();
     }

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -50,11 +50,16 @@ public enum ResponseCodeAndMessages {
     /* Email */
     EMAIL_SEND_SUCCESS(HttpStatus.OK.value(), "이메일 전송에 성공했습니다."),
     EMAIL_CODE_VERIFY_SUCCESS(HttpStatus.OK.value(),"인증에 성공했습니다."),
+
+    REPORT_SEARCH_SUCCESS(HttpStatus.OK.value(), "신고 목록 조회에 성공하였습니다"),
+    REPORT_COMMENT_SUCCESS(HttpStatus.CREATED.value(), "댓글 신고에 성공했습니다"),
+
     /**
      * ErrorCodes about auth
      */
     AUTH_AUTHENTICATION_SUCCESS(HttpStatus.OK.value(), "인증에 성공하였습니다"),
-    AUTH_AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED.value(), "인증에 실패하였습니다");
+    AUTH_AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED.value(), "인증에 실패하였습니다"),
+    ;
 
     private final int code;
     private final String message;

--- a/src/main/java/com/kustacks/kuring/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/kustacks/kuring/common/exception/code/ErrorCode.java
@@ -92,6 +92,8 @@ public enum ErrorCode {
     EMAIL_INVALID_TEMPLATE(HttpStatus.BAD_REQUEST, "잘못된 이메일 발송 양식입니다."),
     EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST, "중복된 사용자 이메일입니다."),
 
+    REPORT_COMMENT_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 신고된 댓글입니다."),
+    REPORT_INVALID_TARGET_TYPE(HttpStatus.NOT_FOUND, "잘못된 신고 타입입니다."),
     // AI 관련
     AI_SIMILAR_DOCUMENTS_NOT_FOUND(HttpStatus.NOT_FOUND, "죄송합니다, 해당 내용은 2024년도 6월 이후에 작성된 공지 내용에서 확인할 수 없는 내용입니다."),
 

--- a/src/main/java/com/kustacks/kuring/report/adapter/in/web/ReportCommandApiV2.java
+++ b/src/main/java/com/kustacks/kuring/report/adapter/in/web/ReportCommandApiV2.java
@@ -1,0 +1,53 @@
+package com.kustacks.kuring.report.adapter.in.web;
+
+import com.kustacks.kuring.common.annotation.RestWebAdapter;
+import com.kustacks.kuring.common.dto.BaseResponse;
+import com.kustacks.kuring.common.exception.BusinessException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
+import com.kustacks.kuring.report.adapter.in.web.dto.ReportRequest;
+import com.kustacks.kuring.report.application.port.in.ReportCommandUseCase;
+import com.kustacks.kuring.report.application.port.in.ReportCommandUseCase.ReportCommentCommand;
+import com.kustacks.kuring.report.domain.ReportTargetType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.REPORT_COMMENT_SUCCESS;
+import static com.kustacks.kuring.report.domain.ReportTargetType.COMMENT;
+
+@Tag(name = "Report-Command", description = "신고 기능")
+@Validated
+@RequiredArgsConstructor
+@RestWebAdapter(path = "/api/v2/reports")
+public class ReportCommandApiV2 {
+
+    private static final String FCM_TOKEN_HEADER_KEY = "User-Token";
+
+    private final ReportCommandUseCase reportCommandUseCase;
+
+    @Operation(summary = "신고하기", description = "특정 항목을 신고합니다.")
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> report(
+            @RequestHeader(FCM_TOKEN_HEADER_KEY) String userToken,
+            @RequestBody ReportRequest request
+    ) {
+        ReportTargetType targetType = ReportTargetType.fromString(request.reportType());
+        if (targetType.match(COMMENT)) {
+            var command = new ReportCommentCommand(
+                    request.targetId(),
+                    userToken,
+                    request.content(),
+                    targetType);
+
+            reportCommandUseCase.process(command);
+            return ResponseEntity.status(REPORT_COMMENT_SUCCESS.getCode())
+                    .body(new BaseResponse<>(REPORT_COMMENT_SUCCESS, null));
+        }
+        throw new BusinessException(ErrorCode.REPORT_INVALID_TARGET_TYPE);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/report/adapter/in/web/dto/ReportRequest.java
+++ b/src/main/java/com/kustacks/kuring/report/adapter/in/web/dto/ReportRequest.java
@@ -1,0 +1,8 @@
+package com.kustacks.kuring.report.adapter.in.web.dto;
+
+public record ReportRequest(
+        Long targetId,
+        String reportType,
+        String content
+) {
+}

--- a/src/main/java/com/kustacks/kuring/report/adapter/out/exception/ReportExceptionHandler.java
+++ b/src/main/java/com/kustacks/kuring/report/adapter/out/exception/ReportExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.kustacks.kuring.report.adapter.out.exception;
+
+import com.kustacks.kuring.common.dto.ErrorResponse;
+import com.kustacks.kuring.report.application.service.exception.ReportBusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ReportExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> reportExceptionHandler(ReportBusinessException exception) {
+        log.warn("[ReportBusinessException] {}", exception.getMessage());
+        return ResponseEntity.status(exception.getErrorCode().getHttpStatus())
+                .body(new ErrorResponse(exception.getErrorCode()));
+    }
+}

--- a/src/main/java/com/kustacks/kuring/report/adapter/out/persistence/ReportPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/report/adapter/out/persistence/ReportPersistenceAdapter.java
@@ -1,0 +1,36 @@
+package com.kustacks.kuring.report.adapter.out.persistence;
+
+import com.kustacks.kuring.admin.application.port.out.AdminUserReportPort;
+import com.kustacks.kuring.common.annotation.PersistenceAdapter;
+import com.kustacks.kuring.report.application.port.out.ReportCommandPort;
+import com.kustacks.kuring.report.application.port.out.ReportQueryPort;
+import com.kustacks.kuring.report.domain.Report;
+import com.kustacks.kuring.report.domain.ReportTargetType;
+import com.kustacks.kuring.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+class ReportPersistenceAdapter implements ReportCommandPort, ReportQueryPort, AdminUserReportPort {
+
+    private final ReportRepository reportRepository;
+
+    @Override
+    public void save(Report report) {
+        reportRepository.save(report);
+    }
+
+    @Override
+    public Optional<Report> findByReporterAndTargetIdAndType(User user, Long targetId, ReportTargetType type) {
+        return reportRepository.findByReporterAndTargetIdAndTargetType(user, targetId, type);
+    }
+
+    @Override
+    public Page<Report> findAllReportByPageRequest(Pageable pageable) {
+        return reportRepository.findAll(pageable);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/report/adapter/out/persistence/ReportRepository.java
+++ b/src/main/java/com/kustacks/kuring/report/adapter/out/persistence/ReportRepository.java
@@ -1,0 +1,13 @@
+package com.kustacks.kuring.report.adapter.out.persistence;
+
+import com.kustacks.kuring.report.domain.Report;
+import com.kustacks.kuring.report.domain.ReportTargetType;
+import com.kustacks.kuring.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    Optional<Report> findByReporterAndTargetIdAndTargetType(User reporter, Long targetId, ReportTargetType targetType);
+}

--- a/src/main/java/com/kustacks/kuring/report/application/port/in/ReportCommandUseCase.java
+++ b/src/main/java/com/kustacks/kuring/report/application/port/in/ReportCommandUseCase.java
@@ -1,0 +1,16 @@
+package com.kustacks.kuring.report.application.port.in;
+
+import com.kustacks.kuring.report.domain.ReportTargetType;
+
+public interface ReportCommandUseCase {
+
+    void process(ReportCommentCommand command);
+
+    record ReportCommentCommand(
+            Long targetId,
+            String userToken,
+            String content,
+            ReportTargetType targetType
+    ) {
+    }
+}

--- a/src/main/java/com/kustacks/kuring/report/application/port/in/dto/AdminReportsResult.java
+++ b/src/main/java/com/kustacks/kuring/report/application/port/in/dto/AdminReportsResult.java
@@ -1,0 +1,25 @@
+package com.kustacks.kuring.report.application.port.in.dto;
+
+import java.time.LocalDateTime;
+
+public record AdminReportsResult(
+        Long id,
+        Long targetId,
+        Long userId,
+        String type,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static AdminReportsResult of(
+            Long id,
+            Long targetId,
+            Long userId,
+            String type,
+            String content,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return new AdminReportsResult(id, targetId, userId, type, content, createdAt, updatedAt);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/report/application/port/out/ReportCommandPort.java
+++ b/src/main/java/com/kustacks/kuring/report/application/port/out/ReportCommandPort.java
@@ -1,0 +1,8 @@
+package com.kustacks.kuring.report.application.port.out;
+
+import com.kustacks.kuring.report.domain.Report;
+
+public interface ReportCommandPort {
+
+    void save(Report report);
+}

--- a/src/main/java/com/kustacks/kuring/report/application/port/out/ReportQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/report/application/port/out/ReportQueryPort.java
@@ -1,0 +1,12 @@
+package com.kustacks.kuring.report.application.port.out;
+
+import com.kustacks.kuring.report.domain.Report;
+import com.kustacks.kuring.report.domain.ReportTargetType;
+import com.kustacks.kuring.user.domain.User;
+
+import java.util.Optional;
+
+public interface ReportQueryPort {
+
+    Optional<Report> findByReporterAndTargetIdAndType(User user, Long targetId, ReportTargetType type);
+}

--- a/src/main/java/com/kustacks/kuring/report/application/service/ReportCommandService.java
+++ b/src/main/java/com/kustacks/kuring/report/application/service/ReportCommandService.java
@@ -1,0 +1,52 @@
+package com.kustacks.kuring.report.application.service;
+
+import com.kustacks.kuring.common.annotation.UseCase;
+import com.kustacks.kuring.common.exception.NotFoundException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
+import com.kustacks.kuring.notice.application.port.out.CommentQueryPort;
+import com.kustacks.kuring.notice.domain.Comment;
+import com.kustacks.kuring.report.application.port.in.ReportCommandUseCase;
+import com.kustacks.kuring.report.application.port.out.ReportCommandPort;
+import com.kustacks.kuring.report.application.port.out.ReportQueryPort;
+import com.kustacks.kuring.report.application.service.exception.ReportBusinessException;
+import com.kustacks.kuring.report.domain.Report;
+import com.kustacks.kuring.user.application.port.out.UserQueryPort;
+import com.kustacks.kuring.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+class ReportCommandService implements ReportCommandUseCase {
+
+    private final ReportCommandPort reportCommandPort;
+    private final ReportQueryPort reportQueryPort;
+    private final UserQueryPort userQueryPort;
+    private final CommentQueryPort commentQueryPort;
+
+    @Override
+    public void process(ReportCommentCommand command) {
+        User reporter = findUserByTokenOrThrow(command.userToken());
+        findCommentByIdOrThrow(command.targetId());
+        reportQueryPort.findByReporterAndTargetIdAndType(reporter, command.targetId(), command.targetType())
+                .ifPresentOrElse(
+                        report -> {
+                            throw new ReportBusinessException(ErrorCode.REPORT_COMMENT_DUPLICATE);
+                        },
+                        () -> {
+                            reportCommandPort.save(new Report(command.targetId(), command.content(), reporter, command.targetType()));
+                        }
+                );
+    }
+
+    private Comment findCommentByIdOrThrow(Long commentId) {
+        return commentQueryPort.findById(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+    }
+
+    private User findUserByTokenOrThrow(String token) {
+        return userQueryPort.findByToken(token)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/kustacks/kuring/report/application/service/exception/ReportBusinessException.java
+++ b/src/main/java/com/kustacks/kuring/report/application/service/exception/ReportBusinessException.java
@@ -1,0 +1,10 @@
+package com.kustacks.kuring.report.application.service.exception;
+
+import com.kustacks.kuring.common.exception.BusinessException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
+
+public class ReportBusinessException extends BusinessException {
+    public ReportBusinessException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/report/domain/Report.java
+++ b/src/main/java/com/kustacks/kuring/report/domain/Report.java
@@ -1,0 +1,64 @@
+package com.kustacks.kuring.report.domain;
+
+import com.kustacks.kuring.common.domain.BaseTimeEntity;
+import com.kustacks.kuring.common.domain.Content;
+import com.kustacks.kuring.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report extends BaseTimeEntity {
+
+    @Getter()
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, nullable = false)
+    private Long id;
+
+    @Getter()
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Embedded
+    private Content content;
+
+    @Column(name = "target_type", nullable = false, length = 30)
+    @Enumerated(value = EnumType.STRING)
+    private ReportTargetType targetType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id")
+    private User reporter;
+
+    public Report(Long targetId, String content, User reporter, ReportTargetType targetType) {
+        this.targetId = targetId;
+        this.content = new Content(content);
+        this.reporter = reporter;
+        this.targetType = targetType;
+    }
+
+    public String getContent() {
+        return content.getValue();
+    }
+
+    public Long getUserId() {
+        return reporter.getId();
+    }
+
+    public String getTargetType() {
+        return targetType.name();
+    }
+}

--- a/src/main/java/com/kustacks/kuring/report/domain/ReportTargetType.java
+++ b/src/main/java/com/kustacks/kuring/report/domain/ReportTargetType.java
@@ -1,0 +1,21 @@
+package com.kustacks.kuring.report.domain;
+
+import com.kustacks.kuring.common.exception.NotFoundException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
+
+public enum ReportTargetType {
+    COMMENT;
+
+    public static ReportTargetType fromString(String value) {
+        for (ReportTargetType reportTargetType : ReportTargetType.values()) {
+            if (reportTargetType.name().equalsIgnoreCase(value)) {
+                return reportTargetType;
+            }
+        }
+        throw new NotFoundException(ErrorCode.REPORT_INVALID_TARGET_TYPE);
+    }
+
+    public boolean match(ReportTargetType type) {
+        return this.equals(type);
+    }
+}

--- a/src/main/resources/db/migration/V250530__Create_Report_Table.sql
+++ b/src/main/resources/db/migration/V250530__Create_Report_Table.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS `report`
+(
+    id
+    BIGINT
+    NOT
+    NULL
+    AUTO_INCREMENT,
+    target_id
+    BIGINT
+    NOT
+    NULL,
+    target_type
+    VARCHAR
+(
+    30
+) NOT NULL,
+    content VARCHAR
+(
+    256
+) NOT NULL,
+    reporter_id BIGINT,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY
+(
+    id
+),
+    CONSTRAINT FK_reportTBL_userTBL
+    FOREIGN KEY
+(
+    reporter_id
+) REFERENCES user
+(
+    id
+) ON DELETE SET NULL
+    ) ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_unicode_ci;

--- a/src/test/java/com/kustacks/kuring/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/AdminAcceptanceTest.java
@@ -18,7 +18,13 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
-import static com.kustacks.kuring.acceptance.AdminStep.*;
+import static com.kustacks.kuring.acceptance.AdminStep.사용자_피드백_조회_요청;
+import static com.kustacks.kuring.acceptance.AdminStep.신고_목록_조회_요청;
+import static com.kustacks.kuring.acceptance.AdminStep.신고_목록_조회_확인;
+import static com.kustacks.kuring.acceptance.AdminStep.알림_예약;
+import static com.kustacks.kuring.acceptance.AdminStep.예약_알림_삭제;
+import static com.kustacks.kuring.acceptance.AdminStep.예약_알림_조회;
+import static com.kustacks.kuring.acceptance.AdminStep.피드백_조회_확인;
 import static com.kustacks.kuring.acceptance.AuthStep.로그인_되어_있음;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -57,6 +63,25 @@ class AdminAcceptanceTest extends IntegrationTestSupport {
 
         // then
         피드백_조회_확인(사용자_피드백);
+    }
+
+    /**
+     * given : 사전에 등록된 어드민가 피드백들이 이다
+     * when : 어드민이 피드백 조회시
+     * then : 성공적으로 조회된다
+     */
+    @DisplayName("[v2] 신고 목록 조회")
+    @Test
+    void role_root_admin_search_reports() {
+        댓글_작성_및_신고();
+        // given
+        String accessToken = 로그인_되어_있음(ADMIN_LOGIN_ID, ADMIN_PASSWORD);
+
+        // when
+        var 신고_목록 = 신고_목록_조회_요청(accessToken);
+
+        // then
+        신고_목록_조회_확인(신고_목록);
     }
 
     /**
@@ -309,5 +334,17 @@ class AdminAcceptanceTest extends IntegrationTestSupport {
                 () -> assertThat(response.jsonPath().getString("message")).isEqualTo("인증에 실패하였습니다"),
                 () -> assertThat(response.jsonPath().getString("data")).isNull()
         );
+    }
+
+    private void 댓글_작성_및_신고() {
+        String userAccessToken = UserStep.사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        NoticeStep.공지에_댓글_추가(1L, userAccessToken, "댓글 내용 1");
+        NoticeStep.공지에_댓글_추가(1L, userAccessToken, "댓글 내용 2");
+        NoticeStep.공지에_댓글_추가(1L, userAccessToken, "댓글 내용 3");
+
+        ReportStep.신고_요청(USER_FCM_TOKEN, 1L, "comment", "댓글 신고 내용 1");
+        ReportStep.신고_요청(USER_FCM_TOKEN, 2L, "comment", "댓글 신고 내용 2");
+        ReportStep.신고_요청(USER_FCM_TOKEN, 3L, "comment", "댓글 신고 내용 3");
     }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/AdminStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/AdminStep.java
@@ -21,12 +21,31 @@ public class AdminStep {
         );
     }
 
+    public static void 신고_목록_조회_확인(ExtractableResponse<Response> response) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("신고 목록 조회에 성공하였습니다"),
+                () -> assertThat(response.jsonPath().getList("data")).hasSize(3)
+        );
+    }
+
     public static ExtractableResponse<Response> 사용자_피드백_조회_요청(String accessToken) {
         return RestAssured
                 .given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/api/v2/admin/feedbacks?page=0&size=10")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 신고_목록_조회_요청(String accessToken) {
+        return RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/api/v2/admin/reports?page=0&size=10")
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/com/kustacks/kuring/acceptance/ReportAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/ReportAcceptanceTest.java
@@ -1,0 +1,62 @@
+package com.kustacks.kuring.acceptance;
+
+import com.kustacks.kuring.support.IntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.kustacks.kuring.acceptance.NoticeStep.공지에_댓글_추가;
+import static com.kustacks.kuring.acceptance.ReportStep.신고_요청;
+import static com.kustacks.kuring.acceptance.ReportStep.신고_요청_에러_응답_확인;
+import static com.kustacks.kuring.acceptance.ReportStep.신고_요청_응답_확인;
+import static com.kustacks.kuring.acceptance.UserStep.사용자_로그인_되어_있음;
+
+@DisplayName("인수 : 신고")
+public class ReportAcceptanceTest extends IntegrationTestSupport {
+
+    @BeforeEach
+    void 댓글_작성_되어_있음() {
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+        공지에_댓글_추가(1L, accessToken, "댓글 내용 1");
+    }
+
+    @DisplayName("사용자는 댓글을 신고할 수 있다.")
+    @Test
+    void user_can_report_comment() {
+        // when
+        var 신고_요청_응답 = 신고_요청(USER_FCM_TOKEN, 1L, "COMMENT", "신고합니다!!");
+
+        // then
+        신고_요청_응답_확인(신고_요청_응답, 201, "댓글 신고에 성공했습니다");
+    }
+
+    @DisplayName("존재하지 않는 토큰을 가진 사용자는 신고할 수 없다.")
+    @Test
+    void user_can_not_report_comment_with_wrong_token() {
+        // when
+        var 신고_요청_응답 = 신고_요청("wrong token", 1L, "COMMENT", "신고합니다!!");
+
+        // then
+        신고_요청_에러_응답_확인(신고_요청_응답, 404, "해당 사용자를 찾을 수 없습니다.");
+    }
+
+    @DisplayName("존재하지 않는 신고 대상으로 신고할 수 없다.")
+    @Test
+    void user_can_not_report_comment_with_wrong_target_id() {
+        // when
+        var 신고_요청_응답 = 신고_요청(USER_FCM_TOKEN, 1L, "cumment", "신고합니다!!");
+
+        // then
+        신고_요청_에러_응답_확인(신고_요청_응답, 404, "잘못된 신고 타입입니다.");
+    }
+
+    @DisplayName("존재하지 않는 댓글 id로 신고할 수 없다.")
+    @Test
+    void send_email_verification_code_for_signup() {
+        // when
+        var 신고_요청_응답 = 신고_요청(USER_FCM_TOKEN, 999L, "COMMENT", "신고합니다!!");
+
+        // then
+        신고_요청_에러_응답_확인(신고_요청_응답, 404, "해당 댓글을 찾을 수 없습니다.");
+    }
+}

--- a/src/test/java/com/kustacks/kuring/acceptance/ReportStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/ReportStep.java
@@ -1,0 +1,42 @@
+package com.kustacks.kuring.acceptance;
+
+import com.kustacks.kuring.report.adapter.in.web.dto.ReportRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class ReportStep {
+
+    public static void 신고_요청_응답_확인(ExtractableResponse<Response> response, int statusCode, String message) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(statusCode),
+                () -> assertThat(response.body().jsonPath().getInt("code")).isEqualTo(statusCode),
+                () -> assertThat(response.body().jsonPath().getString("message")).isEqualTo(message),
+                () -> assertThat(response.body().jsonPath().getString("data")).isNull()
+        );
+    }
+
+    public static void 신고_요청_에러_응답_확인(ExtractableResponse<Response> response, int statusCode, String message) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(statusCode),
+                () -> assertThat(response.body().jsonPath().getInt("resultCode")).isEqualTo(statusCode),
+                () -> assertThat(response.body().jsonPath().getString("resultMsg")).isEqualTo(message),
+                () -> assertThat(response.body().jsonPath().getBoolean("isSuccess")).isFalse()
+        );
+    }
+
+    public static ExtractableResponse<Response> 신고_요청(String token, Long targetId, String reportType, String content) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("User-Token", token)
+                .body(new ReportRequest(targetId, reportType, content))
+                .when().post("/api/v2/reports")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/com/kustacks/kuring/archunit/DependencyRuleTests.java
+++ b/src/test/java/com/kustacks/kuring/archunit/DependencyRuleTests.java
@@ -127,6 +127,29 @@ class DependencyRuleTests {
 						.importPackages("com.kustacks.kuring.email.."));
 	}
 
+	@DisplayName("Report 아키텍처 검증")
+	@Test
+	void validateReportArchitecture() {
+		HexagonalArchitecture.boundedContext("com.kustacks.kuring.report")
+
+				.withDomainLayer("domain")
+
+				.withAdaptersLayer("adapter")
+				.incoming("in.web")
+				.outgoing("out.persistence")
+				.and()
+
+				.withApplicationLayer("application")
+				.services("service")
+				.incomingPorts("port.in")
+				.outgoingPorts("port.out")
+				.and()
+
+				.withConfiguration("configuration")
+				.check(new ClassFileImporter()
+						.importPackages("com.kustacks.kuring.report.."));
+	}
+
 	@DisplayName("테스트 페키지 의존성 검증")
 	@Test
 	void testPackageDependencies() {


### PR DESCRIPTION
### 구현 내용
- 댓글 테이블 DDL문을 Flyway DB Schema로 작성했습니다.
- 댓글 신고 API를 추가했습니다.
- 어드민을 통해 전체 신고 목록을 조회할 수 있습니다.
- 댓글 도메인에 대한 의존성 테스트를 추가했습니다.
- 댓글 신고에 대한 인수테스트를 추가했습니다.
- 어드민 신고 목록 조회 인수테스르를 추가했습니다.

### 상세 내용
- Report Entity의 경우 ReportTargetType(COMMENT)을 바탕으로 신고 대상을 구분합니다.
- targetId를 기반으로 신고대상(댓글 등)을 구분합니다.

### 고민?
- 테스트 작성하다 보니 DatbaseConfigurer 에서 댓글에대 한 init이 없어서 추가했으나, 댓글 부분에서 테스트가 깨지는 현상이 생겨 필요한 부분에만 추가했는데 이를 init을 사용하는게 맞을지 혹은 필요 시에만 넣는게 맞을지 고민을 했습니닷
- 신고라는 기능은 어디에서나 쓰일 수 있기 때문에 `reportTargetType`과 `targetId`으로 구분되는데 좋은 방향성인지? 고민이됩니닷