### PR TITLE
version 2.13.1

### DIFF
--- a/src/main/java/com/kustacks/kuring/admin/adapter/in/web/AdminCommandApiV2.java
+++ b/src/main/java/com/kustacks/kuring/admin/adapter/in/web/AdminCommandApiV2.java
@@ -13,7 +13,9 @@ import com.kustacks.kuring.auth.authorization.AuthenticationPrincipal;
 import com.kustacks.kuring.auth.context.Authentication;
 import com.kustacks.kuring.auth.secured.Secured;
 import com.kustacks.kuring.common.dto.BaseResponse;
+import com.kustacks.kuring.common.dto.ResponseCodeAndMessages;
 import com.kustacks.kuring.common.utils.converter.StringToDateTimeConverter;
+import com.kustacks.kuring.notice.application.port.in.BadWordInitProcessor;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,10 +26,20 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.*;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.ADMIN_EMBEDDING_NOTICE_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.ADMIN_REAL_NOTICE_CREATE_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.ADMIN_TEST_NOTICE_CREATE_SUCCESS;
 
 @Tag(name = "Admin-Command", description = "관리자가 주체가 되는 정보 수정")
 @Validated
@@ -37,6 +49,7 @@ import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.*;
 public class AdminCommandApiV2 {
 
     private final AdminCommandUseCase adminCommandUseCase;
+    private final BadWordInitProcessor badWordinitProcessor;
 
     @Operation(summary = "테스트 공지 전송", description = "테스트 공지를 전송합니다, 실제 운영시 사용하지 않습니다")
     @SecurityRequirement(name = "JWT")
@@ -99,6 +112,16 @@ public class AdminCommandApiV2 {
         adminCommandUseCase.embeddingCustomData(new DataEmbeddingCommand(file));
 
         return ResponseEntity.ok().body(new BaseResponse<>(ADMIN_EMBEDDING_NOTICE_SUCCESS, null));
+    }
+
+    @Operation(summary = "금칙어 로드", description = "어드민은 DB에 있는 금칙어를 수동으로 로드할 수 있다.")
+    @SecurityRequirement(name = "JWT")
+    @Secured(AdminRole.ROLE_ROOT)
+    @PostMapping("/badwords/reload")
+    public ResponseEntity<BaseResponse<String>> refreshBadWords() {
+        badWordinitProcessor.process();
+
+        return ResponseEntity.ok().body(new BaseResponse<>(ResponseCodeAndMessages.ADMIN_LOAD_BAD_WORDS, null));
     }
 
     @Hidden

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -27,6 +27,7 @@ public enum ResponseCodeAndMessages {
     ADMIN_TEST_NOTICE_CREATE_SUCCESS(HttpStatus.OK.value(), "테스트 공지 생성에 성공하였습니다"),
     ADMIN_REAL_NOTICE_CREATE_SUCCESS(HttpStatus.OK.value(), "실제 공지 생성에 성공하였습니다"),
     ADMIN_EMBEDDING_NOTICE_SUCCESS(HttpStatus.OK.value(), "데이터 임베딩에 생성에 성공하였습니다"),
+    ADMIN_LOAD_BAD_WORDS(HttpStatus.OK.value(), "금칙어 로드에 성공했습니다."),
 
     /* User */
     USER_REGISTER_SUCCESS(HttpStatus.OK.value(), "회원가입에 성공하였습니다"),

--- a/src/main/java/com/kustacks/kuring/notice/application/port/in/BadWordInitProcessor.java
+++ b/src/main/java/com/kustacks/kuring/notice/application/port/in/BadWordInitProcessor.java
@@ -1,0 +1,5 @@
+package com.kustacks.kuring.notice.application.port.in;
+
+public interface BadWordInitProcessor {
+    void process();
+}

--- a/src/main/java/com/kustacks/kuring/notice/application/service/NoticeCommandService.java
+++ b/src/main/java/com/kustacks/kuring/notice/application/service/NoticeCommandService.java
@@ -5,6 +5,7 @@ import com.kustacks.kuring.common.exception.BadWordContainsException;
 import com.kustacks.kuring.common.exception.NoPermissionException;
 import com.kustacks.kuring.common.exception.NotFoundException;
 import com.kustacks.kuring.common.exception.code.ErrorCode;
+import com.kustacks.kuring.notice.application.port.in.BadWordInitProcessor;
 import com.kustacks.kuring.notice.application.port.in.NoticeCommentDeletingUseCase;
 import com.kustacks.kuring.notice.application.port.in.NoticeCommentEditingUseCase;
 import com.kustacks.kuring.notice.application.port.in.NoticeCommentWritingUseCase;
@@ -36,7 +37,8 @@ import java.util.Objects;
 public class NoticeCommandService implements
         NoticeCommentWritingUseCase,
         NoticeCommentEditingUseCase,
-        NoticeCommentDeletingUseCase {
+        NoticeCommentDeletingUseCase,
+        BadWordInitProcessor {
     private static final String COMMENT_REGEX = "[^가-힣a-zA-Z0-9]";
     private final NoticeQueryPort noticeQueryPort;
     private final CommentCommandPort commentCommandPort;
@@ -48,18 +50,7 @@ public class NoticeCommandService implements
 
     @PostConstruct
     public void badWordInit() {
-        List<BadWord> activeBadWords = badWordQueryPort.findAllByActive();
-        if (!activeBadWords.isEmpty()) {
-            Trie.TrieBuilder builder = Trie.builder().ignoreCase();
-
-            for (BadWord badWord : activeBadWords) {
-                builder.addKeyword(badWord.getWord());
-            }
-
-            badWordTrie = builder.build();
-        }
-
-        log.info("금칙어 로드 완료 - 총 {} 개", activeBadWords.size());
+        process();
     }
 
     @Override
@@ -129,6 +120,22 @@ public class NoticeCommandService implements
         commentCommandPort.delete(findComment);
 
         log.info("delete notice-comment, user{}, notice{}, comment{}", rootUser.getId(), findNotice.getId(), findComment.getId());
+    }
+
+    @Override
+    public void process() {
+        List<BadWord> activeBadWords = badWordQueryPort.findAllByActive();
+        if (!activeBadWords.isEmpty()) {
+            Trie.TrieBuilder builder = Trie.builder().ignoreCase();
+
+            for (BadWord badWord : activeBadWords) {
+                builder.addKeyword(badWord.getWord());
+            }
+
+            badWordTrie = builder.build();
+        }
+
+        log.info("금칙어 로드 완료 - 총 {} 개", activeBadWords.size());
     }
 
     private void validateText(String content) {

--- a/src/test/java/com/kustacks/kuring/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/AdminAcceptanceTest.java
@@ -18,6 +18,7 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
+import static com.kustacks.kuring.acceptance.AdminStep.금칙어_로드_요청;
 import static com.kustacks.kuring.acceptance.AdminStep.사용자_피드백_조회_요청;
 import static com.kustacks.kuring.acceptance.AdminStep.신고_목록_조회_요청;
 import static com.kustacks.kuring.acceptance.AdminStep.신고_목록_조회_확인;
@@ -218,6 +219,19 @@ class AdminAcceptanceTest extends IntegrationTestSupport {
                 () -> assertThat(response.jsonPath().getString("message")).isEqualTo("예약 알림 조회에 성공하였습니다"),
                 () -> assertThat(response.jsonPath().getString("data[0].status")).isEqualTo("CANCELED")
         );
+    }
+
+    @DisplayName("[v2] Admin은 금칙어 수동 로드할 수 있다.")
+    @Test
+    void admin_can_load_bad_words() {
+        // given
+        String accessToken = 로그인_되어_있음(ADMIN_LOGIN_ID, ADMIN_PASSWORD);
+
+        // when
+        var 금칙어_로드_응답 = 금칙어_로드_요청(accessToken);
+
+        // then
+        AdminStep.금칙어_로드_응답_확인(금칙어_로드_응답);
     }
 
     /**

--- a/src/test/java/com/kustacks/kuring/acceptance/AdminStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/AdminStep.java
@@ -30,6 +30,15 @@ public class AdminStep {
         );
     }
 
+    public static void 금칙어_로드_응답_확인(ExtractableResponse<Response> response) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("금칙어 로드에 성공했습니다."),
+                () -> assertThat(response.jsonPath().getList("data")).isNull()
+        );
+    }
+
     public static ExtractableResponse<Response> 사용자_피드백_조회_요청(String accessToken) {
         return RestAssured
                 .given().log().all()
@@ -77,6 +86,16 @@ public class AdminStep {
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().delete("/api/v2/admin/alerts/{id}", alertId)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 금칙어_로드_요청(String accessToken) {
+        return RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/api/v2/admin/badwords/reload")
                 .then().log().all()
                 .extract();
     }


### PR DESCRIPTION
* refactor: 금칙어 로드 UseCase 추가

* refactor: PostConstruct 시 금칙어 로드 로직 변경

* feat: Admin을 통해 금칙어 로드 하는 API 추가

* test: Admin 금칙어 로드 API 인수 테스트 추가

* test: Admin 금칙어 로드 API 인수 테스트 경로 변경

* refactor: BadWordLoadUseCase 인터페이스명 변경(BadWordInitProcessor)

* refactor: BadWordInitProcessor 인터페이스명 변경에 따른 메서드명 변경