### PR TITLE
Feat: 학사일정 엔티티, 테이블 DDL 추가 및 iCal4j 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,9 @@ dependencies {
     // Jsoup
     implementation 'org.jsoup:jsoup:1.14.3'
 
+    // iCal4j
+    implementation 'org.mnode.ical4j:ical4j:4.1.1'
+
     // Firebase
     implementation 'com.google.firebase:firebase-admin:9.3.0'
 

--- a/src/main/java/com/kustacks/kuring/calendar/domain/AcademicEvent.java
+++ b/src/main/java/com/kustacks/kuring/calendar/domain/AcademicEvent.java
@@ -1,0 +1,55 @@
+package com.kustacks.kuring.calendar.domain;
+
+import com.kustacks.kuring.common.domain.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity(name = "academic_event")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AcademicEvent extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "event_uid", nullable = false, updatable = false, length = 255)
+    private String eventUid; // 이벤트 고유 ID
+
+    @Column(name = "summary", nullable = false, length = 255)
+    private String summary; // 이벤트 제목
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description; // 이벤트 설명
+
+    //TODO: 카테고리 확정 시 ENUM화 필요 @김한주 25.08.24
+    @Column(name = "category", length = 20)
+    private String category; // 일정 분류 (예: 학사, 시험, 휴강 등)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "transparent", nullable = false, length = 20)
+    private Transparent transparent; // 이벤트 바쁨 정도 (OPAQUE/TRANSPARENT)
+
+    @Column(name = "sequence", nullable = false)
+    private Integer sequence; // 이벤트 변경 횟수(초기 0, 동기화용)
+
+    @Column(name = "notify_enabled", nullable = false)
+    private Boolean notifyEnabled; // true = 알림 발송 대상, false = 저장만
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime; // 시작일시
+
+    @Column(name = "end_time", nullable = false)
+    private LocalDateTime endTime; // 종료일시
+}

--- a/src/main/java/com/kustacks/kuring/calendar/domain/Transparent.java
+++ b/src/main/java/com/kustacks/kuring/calendar/domain/Transparent.java
@@ -1,0 +1,7 @@
+package com.kustacks.kuring.calendar.domain;
+
+public enum Transparent {
+    OPAQUE, //바쁨(중요일정)
+    TRANSPARENT //바쁘지 않음(미중요일정)
+    ;
+}

--- a/src/main/resources/db/migration/V250824__Create_academic_event_table.sql
+++ b/src/main/resources/db/migration/V250824__Create_academic_event_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE academic_event
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    event_uid      VARCHAR(255) NOT NULL,
+    summary        VARCHAR(255) NOT NULL,
+    description    TEXT,
+    category       VARCHAR(20),
+    transparent    VARCHAR(20)  NOT NULL,
+    sequence       INT          NOT NULL,
+    start_time     DATETIME     NOT NULL,
+    end_time       DATETIME     NOT NULL,
+    notify_enabled BOOLEAN      NOT NULL,
+    created_at     DATETIME(6),
+    updated_at     DATETIME(6)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;


### PR DESCRIPTION
## 관련 이슈
#281 

## 개요
- ICS 포맷 파싱을 위한 iCal4j 의존성 추가했습니다.
- 학사일정 저장 위한 academic_event 테이블 추가했습니다.


## 상세
- iCal4j로 파싱해온 데이터 목록 중 일부 필요한 내용이라 판단되는 내용만 테이블에 추가했습니다.
- 알람보내지 않더라도 모든 내용을 저장하는 것이 나을거 같아 우선 다 저장하고, notifyEnabled로 구분하려합니다.
- Transparent의 경우 OPAQUE(중요일정)  TRANSPARENT(사소한 일정)으로 기본적으로 구분되어있어 저장했습니다.

관련해서 테스트 코드와 출력 예시 첨부합니다

```java
package com.kustacks.kuring;

import net.fortuna.ical4j.data.CalendarBuilder;
import net.fortuna.ical4j.data.ParserException;
import net.fortuna.ical4j.model.Calendar;
import net.fortuna.ical4j.model.component.VEvent;
import org.junit.jupiter.api.BeforeAll;
import org.junit.jupiter.api.Test;

import java.io.IOException;
import java.io.InputStream;
import java.net.URL;

public class IcsParsingTest {

    final static String calendarUrl = "https://outlook.office365.com/owa/calendar/0a5e22263dff43609142c77a5ad9b947%40konkuk.ac.kr/3131b7dad7b44597a670d9fb9ed777e28600923425300845442/calendar.ics";

    static Calendar calendar;

    @BeforeAll
    static void setup() throws IOException, ParserException {
        URL url = new URL(calendarUrl);
        InputStream in = url.openStream();
        CalendarBuilder builder = new CalendarBuilder();
        calendar = builder.build(in);
    }

    @Test
    void printEntireCalendar() {
        //1. 전체 ICS 내용 출력
        System.out.println(calendar);
    }

    @Test
    void printAllComponents() {
        //2. 전체 ICS 내용 중 Component만 출력(VTIMEZONE, VEVENT)
        calendar.getComponents().forEach(component -> {
            System.out.println(component);
            System.out.println();
        });
    }

    @Test
    void printAllEvents() {
        //3. 전체 ICS 내용 중 VEVENT만 출력(실제 일정들)
        calendar.getComponents("VEVENT").forEach(component -> {
            System.out.println(component);
            System.out.println();
        });
    }

    @Test
    void printImportantEventNames() {
        //4. 중요일정 이름만 출력
        calendar.getComponents("VEVENT").stream()
                .map(component -> (VEvent) component)
                .filter(event -> event.getTimeTransparency().getValue().equals("OPAQUE"))
                .forEach(event -> {
                    System.out.println(event.getSummary().toString().trim());
                });
    }
}
```

### 일정 출력 예시

```env
BEGIN:VEVENT // ICS타입 정보
DESCRIPTION:\n // 상세설명
UID:040000008200E00074C5B7101A82E0080000000033C0B88EDFBAD9010000000000000000100000006ECC99F08500CA4096B671977C2912F7 // 고유 이벤트 ID값
SUMMARY:하계방학 // 제목(요약)
DTSTART;VALUE=DATE:20240622 // 시작일시
DTEND;VALUE=DATE:20240902 // 종료일시
CLASS:PUBLIC //공개여부(PUBLIC, PRIVATE)
PRIORITY:5 // 우선순위(1~9) -> 현재 건대는 모두 5
DTSTAMP:20250824T134939Z // 서버 시간
TRANSP:TRANSPARENT //중요도(바쁨정도) - OPAQUE, TRASPARENT
STATUS:CONFIRMED // 상태
SEQUENCE:0 // 변경 이력(초기 0)
LOCATION: // 장소 or URL
X-MICROSOFT-CDO-APPT-SEQUENCE:0 // MS Outlook 자체 정보
X-MICROSOFT-CDO-BUSYSTATUS:FREE // MS Outlook 자체 정보
X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY // MS Outlook 자체 정보
X-MICROSOFT-CDO-ALLDAYEVENT:TRUE // MS Outlook 자체 정보
X-MICROSOFT-CDO-IMPORTANCE:1 // MS Outlook 자체 정보
X-MICROSOFT-CDO-INSTTYPE:0 // MS Outlook 자체 정보
X-MICROSOFT-DONOTFORWARDMEETING:FALSE // MS Outlook 자체 정보
X-MICROSOFT-DISALLOW-COUNTER:FALSE // MS Outlook 자체 정보
X-MICROSOFT-REQUESTEDATTENDANCEMODE:DEFAULT // MS Outlook 자체 정보
X-MICROSOFT-ISRESPONSEREQUESTED:FALSE // MS Outlook 자체 정보
END:VEVENT
```

## 리뷰 요청사항
1. 테이블명과 컬럼명, 클래스명과 필드명 혹시나 문제 생길 여지 없는지 검토 부탁드립니다.
2. 적절한 내용만 뽑는다고 뽑아봤는데 과하게 추가되었거나 더 필요한 정보가 없을까 싶습니다.
3. 카테고리를 현재 String으로 해놨는데, 추후에 카테고리가 확정되면 ENUM변경하는데 문제 없을지..?? 아마 DB 컬럼 정의에서 문제가 생길 수도 있지 않을까 싶긴한데...
