### PR TITLE
Feat: 유저 학사일정 알림 설정 관련 기본 설정 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/common/featureflag/KuringFeatures.java
+++ b/src/main/java/com/kustacks/kuring/common/featureflag/KuringFeatures.java
@@ -8,7 +8,8 @@ public enum KuringFeatures {
     UPDATE_KUIS_NOTICE(new Feature("update_kuis_notice")),
     UPDATE_USER(new Feature("update_user")),
     UPDATE_STAFF(new Feature("update_staff")),
-    UPDATE_ACADEMIC_EVENT(new Feature("update_academic_event"));
+    UPDATE_ACADEMIC_EVENT(new Feature("update_academic_event")),
+    NOTIFY_ACADEMIC_EVENT(new Feature("notify_academic_event"));
 
     private final Feature feature;
 

--- a/src/main/java/com/kustacks/kuring/user/domain/User.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/User.java
@@ -61,6 +61,10 @@ public class User implements Serializable {
     @Column(nullable = true)
     private Long loginUserId;
 
+    @Getter(AccessLevel.PUBLIC)
+    @Column(name = "academic_event_notification_enabled", nullable = false)
+    private Boolean academicEventNotificationEnabled = Boolean.TRUE;
+
     //Fcm Token User
     public User(String token) {
         this.fcmToken = token;

--- a/src/main/java/com/kustacks/kuring/user/domain/User.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/User.java
@@ -61,7 +61,6 @@ public class User implements Serializable {
     @Column(nullable = true)
     private Long loginUserId;
 
-    @Getter(AccessLevel.PUBLIC)
     @Column(name = "academic_event_notification_enabled", nullable = false)
     private Boolean academicEventNotificationEnabled = Boolean.TRUE;
 

--- a/src/main/resources/db/migration/V250918__Add_academic_event_notification_to_user.sql
+++ b/src/main/resources/db/migration/V250918__Add_academic_event_notification_to_user.sql
@@ -1,8 +1,3 @@
 -- 사용자 테이블에 학사일정 알림 설정 컬럼 추가
 ALTER TABLE user
     ADD COLUMN academic_event_notification_enabled BOOLEAN NOT NULL DEFAULT TRUE;
-
--- 기존 데이터에 대해서도 명시적으로 true 설정
-UPDATE user
-SET academic_event_notification_enabled = TRUE
-WHERE academic_event_notification_enabled IS NULL;

--- a/src/main/resources/db/migration/V250918__Add_academic_event_notification_to_user.sql
+++ b/src/main/resources/db/migration/V250918__Add_academic_event_notification_to_user.sql
@@ -1,0 +1,8 @@
+-- 사용자 테이블에 학사일정 알림 설정 컬럼 추가
+ALTER TABLE user
+    ADD COLUMN academic_event_notification_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- 기존 데이터에 대해서도 명시적으로 true 설정
+UPDATE user
+SET academic_event_notification_enabled = TRUE
+WHERE academic_event_notification_enabled IS NULL;


### PR DESCRIPTION
## #️⃣ 이슈
#281 

## 📌 요약
- 학사일정 알림 ON/OFF를 위한 기본 설정 추가했습니다.

## 🛠️ 상세
- user테이블에 academic_event_notification_enabled 컬럼을 추가했습니다.
- user 엔티티에 academicEventNotificationEnabled 필드를 추가했습니다.
- 학사일정 알림 전송 FeatureFlag를 추가했습니다.(아직 AWS는 반영 안했습니다)

## 💬 기타
- 사실 알림발송 구현은 1차적으로 되어있어서 테스트만 하면 되는데, 
메시지 전달 형식(제목, 내용) 관련해서 다른 분들이랑 이야기 하고 올리겠슴니다!
- 생각해보니 알림 ON/OFF하는 API가 필요하겠네유?!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 학사 행사 알림 기능이 추가되었습니다.
  * 사용자 계정에 학사 행사 알림 설정이 도입되며 기본값은 활성화입니다.

* Chores
  * 데이터베이스에 사용자 학사 행사 알림 여부 컬럼을 추가했습니다.
  * 기능 플래그를 통해 학사 행사 알림 제공을 제어합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->