### PR TITLE
Fix: 학과 공지 업데이트 오류 수정, 학과 목록 조회 api 수정

### DIFF
--- a/src/main/java/com/kustacks/kuring/notice/adapter/in/web/dto/NoticeDepartmentNameResponse.java
+++ b/src/main/java/com/kustacks/kuring/notice/adapter/in/web/dto/NoticeDepartmentNameResponse.java
@@ -5,13 +5,15 @@ import com.kustacks.kuring.notice.application.port.in.dto.NoticeDepartmentNameRe
 public record NoticeDepartmentNameResponse(
         String name,
         String hostPrefix,
-        String korName
+        String korName,
+        boolean graduateSupported
 ) {
     public static NoticeDepartmentNameResponse from(NoticeDepartmentNameResult result) {
         return new NoticeDepartmentNameResponse(
                 result.name(),
                 result.hostPrefix(),
-                result.korName()
+                result.korName(),
+                result.graduateSupported()
         );
     }
 }

--- a/src/main/java/com/kustacks/kuring/notice/application/port/in/dto/NoticeDepartmentNameResult.java
+++ b/src/main/java/com/kustacks/kuring/notice/application/port/in/dto/NoticeDepartmentNameResult.java
@@ -1,13 +1,16 @@
 package com.kustacks.kuring.notice.application.port.in.dto;
 
 import com.kustacks.kuring.notice.domain.DepartmentName;
+import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 
 public record NoticeDepartmentNameResult(
         String name,
         String hostPrefix,
-        String korName
+        String korName,
+        boolean graduateSupported
 ) {
-    public static NoticeDepartmentNameResult from(DepartmentName name) {
-        return new NoticeDepartmentNameResult(name.getName(), name.getHostPrefix(), name.getKorName());
+    public static NoticeDepartmentNameResult from(DeptInfo deptInfo) {
+        DepartmentName name = deptInfo.getDepartmentName();
+        return new NoticeDepartmentNameResult(name.getName(), name.getHostPrefix(), name.getKorName(), deptInfo.isSupportGraduateScrap());
     }
 }

--- a/src/main/java/com/kustacks/kuring/notice/application/service/NoticeQueryService.java
+++ b/src/main/java/com/kustacks/kuring/notice/application/service/NoticeQueryService.java
@@ -9,7 +9,11 @@ import com.kustacks.kuring.common.exception.code.ErrorCode;
 import com.kustacks.kuring.notice.adapter.in.web.dto.CommentDetailResponse;
 import com.kustacks.kuring.notice.application.port.in.NoticeCommentReadingUseCase;
 import com.kustacks.kuring.notice.application.port.in.NoticeQueryUseCase;
-import com.kustacks.kuring.notice.application.port.in.dto.*;
+import com.kustacks.kuring.notice.application.port.in.dto.NoticeCategoryNameResult;
+import com.kustacks.kuring.notice.application.port.in.dto.NoticeContentSearchResult;
+import com.kustacks.kuring.notice.application.port.in.dto.NoticeDepartmentNameResult;
+import com.kustacks.kuring.notice.application.port.in.dto.NoticeRangeLookupCommand;
+import com.kustacks.kuring.notice.application.port.in.dto.NoticeRangeLookupResult;
 import com.kustacks.kuring.notice.application.port.out.CommentQueryPort;
 import com.kustacks.kuring.notice.application.port.out.NoticeQueryPort;
 import com.kustacks.kuring.notice.application.port.out.dto.CommentReadModel;
@@ -22,7 +26,13 @@ import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.kustacks.kuring.notice.domain.CategoryName.DEPARTMENT;

--- a/src/main/java/com/kustacks/kuring/notice/application/service/NoticeQueryService.java
+++ b/src/main/java/com/kustacks/kuring/notice/application/service/NoticeQueryService.java
@@ -9,11 +9,7 @@ import com.kustacks.kuring.common.exception.code.ErrorCode;
 import com.kustacks.kuring.notice.adapter.in.web.dto.CommentDetailResponse;
 import com.kustacks.kuring.notice.application.port.in.NoticeCommentReadingUseCase;
 import com.kustacks.kuring.notice.application.port.in.NoticeQueryUseCase;
-import com.kustacks.kuring.notice.application.port.in.dto.NoticeCategoryNameResult;
-import com.kustacks.kuring.notice.application.port.in.dto.NoticeContentSearchResult;
-import com.kustacks.kuring.notice.application.port.in.dto.NoticeDepartmentNameResult;
-import com.kustacks.kuring.notice.application.port.in.dto.NoticeRangeLookupCommand;
-import com.kustacks.kuring.notice.application.port.in.dto.NoticeRangeLookupResult;
+import com.kustacks.kuring.notice.application.port.in.dto.*;
 import com.kustacks.kuring.notice.application.port.out.CommentQueryPort;
 import com.kustacks.kuring.notice.application.port.out.NoticeQueryPort;
 import com.kustacks.kuring.notice.application.port.out.dto.CommentReadModel;
@@ -22,16 +18,11 @@ import com.kustacks.kuring.notice.domain.CategoryName;
 import com.kustacks.kuring.notice.domain.DepartmentName;
 import com.kustacks.kuring.user.application.port.out.RootUserQueryPort;
 import com.kustacks.kuring.user.domain.RootUser;
+import com.kustacks.kuring.worker.scrap.deptinfo.DeptInfo;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.kustacks.kuring.notice.domain.CategoryName.DEPARTMENT;
@@ -48,18 +39,19 @@ public class NoticeQueryService implements NoticeQueryUseCase, NoticeCommentRead
     private final CommentQueryPort commentQueryPort;
     private final RootUserQueryPort rootUserQueryPort;
     private final List<CategoryName> supportedCategoryNameList;
-    private final List<DepartmentName> supportedDepartmentNameList;
+    private final List<DeptInfo> deptInfoList;
 
     public NoticeQueryService(
             NoticeQueryPort noticeQueryPort,
             CommentQueryPort commentQueryPort,
-            RootUserQueryPort rootUserQueryPort
+            RootUserQueryPort rootUserQueryPort,
+            List<DeptInfo> deptInfoList
     ) {
         this.noticeQueryPort = noticeQueryPort;
         this.commentQueryPort = commentQueryPort;
         this.rootUserQueryPort = rootUserQueryPort;
         this.supportedCategoryNameList = Arrays.asList(CategoryName.values());
-        this.supportedDepartmentNameList = Arrays.asList(DepartmentName.values());
+        this.deptInfoList = deptInfoList;
     }
 
     @Override
@@ -87,7 +79,7 @@ public class NoticeQueryService implements NoticeQueryUseCase, NoticeCommentRead
 
     @Override
     public List<NoticeDepartmentNameResult> lookupSupportedDepartments() {
-        return convertDepartmentNameDtos(supportedDepartmentNameList);
+        return convertDepartmentNameDtos(deptInfoList);
     }
 
     @Override
@@ -191,9 +183,9 @@ public class NoticeQueryService implements NoticeQueryUseCase, NoticeCommentRead
                 .toList();
     }
 
-    private List<NoticeDepartmentNameResult> convertDepartmentNameDtos(List<DepartmentName> departmentNames) {
-        return departmentNames.stream()
-                .filter(dn -> !dn.equals(DepartmentName.COMM_DESIGN))
+    private List<NoticeDepartmentNameResult> convertDepartmentNameDtos(List<DeptInfo> deptInfos) {
+        return deptInfos.stream()
+                .filter(dept -> !dept.getDepartmentName().equals(DepartmentName.COMM_DESIGN))
                 .map(NoticeDepartmentNameResult::from)
                 .toList();
     }

--- a/src/main/java/com/kustacks/kuring/notice/domain/DepartmentName.java
+++ b/src/main/java/com/kustacks/kuring/notice/domain/DepartmentName.java
@@ -77,6 +77,7 @@ public enum DepartmentName {
     LIVING_DESIGN("living_design", "livingdesign", "리빙디자인학과"),
     CONT_ART("contemporary_art", "contemporaryart", "현대미술학과"),
     MOV_IMAGE("moving_image_film", "movingimages", "영상학과"),
+    MEDIA_ACTING("media_acting", "mediaacting", "매체연기학과"),
 
     JAPANESE_EDU("japanese_education", "japan", "일어교육과"),
     MATH_EDU("mathematics_education", "mathedu", "수학교육과"),
@@ -84,7 +85,7 @@ public enum DepartmentName {
     MUSIC_EDU("music_education", "music", "음악교육과"),
     EDU_TECH("education_technology", "edutech", "교육공학과"),
     ENGLISH_EDU("english_education", "englishedu", "영어교육과"),
-    EDUCATION("education", "edu", "교육학과"),
+    EDUCATION("education", "edu", "교직과"),
 
     ELE_EDU_CENTER("elective_education_center", "sgedu", "교양교육센터"),
     VOLUNTEER("volunteer_center", "kuvolunteer", "사회봉사센터"),

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/architecture/ArchitectureDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/architecture/ArchitectureDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.architecture;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class ArchitectureDept extends ArchitectureCollege {
     public ArchitectureDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class ArchitectureDept extends ArchitectureCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(ARCHITECTURE.getHostPrefix(), 397);
         this.departmentName = ARCHITECTURE;
         this.noticeGraduationInfo = new NoticeScrapInfo(ARCHITECTURE.getHostPrefix(), 748);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/IndustrialDesignDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/IndustrialDesignDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.art_design;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class IndustrialDesignDept extends ArtDesignCollege {
     public IndustrialDesignDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class IndustrialDesignDept extends ArtDesignCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(IND_DESIGN.getHostPrefix(), 4017);
         this.departmentName = IND_DESIGN;
         this.noticeGraduationInfo = new NoticeScrapInfo(IND_DESIGN.getHostPrefix(), 5683);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/LivingDesignDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/LivingDesignDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.art_design;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -18,7 +19,8 @@ public class LivingDesignDept extends ArtDesignCollege {
     public LivingDesignDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -30,5 +32,6 @@ public class LivingDesignDept extends ArtDesignCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(LIVING_DESIGN.getHostPrefix(), 962);
         this.departmentName = LIVING_DESIGN;
         this.noticeGraduationInfo = new NoticeScrapInfo(LIVING_DESIGN.getHostPrefix(), 487);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/MediaActingDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/MediaActingDept.java
@@ -1,0 +1,32 @@
+package com.kustacks.kuring.worker.scrap.deptinfo.art_design;
+
+import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
+import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
+import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
+import com.kustacks.kuring.worker.scrap.deptinfo.RegisterDepartmentMap;
+import com.kustacks.kuring.worker.scrap.deptinfo.StaffScrapInfo;
+
+import java.util.List;
+
+import static com.kustacks.kuring.notice.domain.DepartmentName.MEDIA_ACTING;
+
+@RegisterDepartmentMap(key = MEDIA_ACTING)
+public class MediaActingDept extends ArtDesignCollege {
+
+    public MediaActingDept(
+            LatestPageNoticeApiClient latestPageNoticeApiClient,
+            LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
+            LatestPageNoticeProperties latestPageNoticeProperties
+    ) {
+        super();
+        this.noticeApiClient = latestPageNoticeApiClient;
+        this.htmlParser = latestPageNoticeHtmlParser;
+        this.latestPageNoticeProperties = latestPageNoticeProperties;
+
+        List<Integer> siteIds = List.of(11299);
+        this.staffScrapInfo = new StaffScrapInfo(MEDIA_ACTING.getHostPrefix(), siteIds);
+        this.noticeScrapInfo = new NoticeScrapInfo(MEDIA_ACTING.getHostPrefix(), 493);
+        this.departmentName = MEDIA_ACTING;
+    }
+}

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/MovingImageFilmDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/art_design/MovingImageFilmDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.art_design;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class MovingImageFilmDept extends ArtDesignCollege {
     public MovingImageFilmDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class MovingImageFilmDept extends ArtDesignCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(MOV_IMAGE.getHostPrefix(), 491);
         this.departmentName = MOV_IMAGE;
         this.noticeGraduationInfo = new NoticeScrapInfo(MOV_IMAGE.getHostPrefix(), 5710);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/EducationalTechnologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/EducationalTechnologyDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.education;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class EducationalTechnologyDept extends EducationCollege {
     public EducationalTechnologyDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class EducationalTechnologyDept extends EducationCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(EDU_TECH.getHostPrefix(), 4020);
         this.departmentName = EDU_TECH;
         this.noticeGraduationInfo = new NoticeScrapInfo(EDU_TECH.getHostPrefix(), 4092);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/EnglishEducationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/EnglishEducationDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.education;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class EnglishEducationDept extends EducationCollege {
     public EnglishEducationDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class EnglishEducationDept extends EducationCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(ENGLISH_EDU.getHostPrefix(), 505);
         this.departmentName = ENGLISH_EDU;
         this.noticeGraduationInfo = new NoticeScrapInfo(ENGLISH_EDU.getHostPrefix(), 990);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/PhysicalEducationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/education/PhysicalEducationDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.education;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class PhysicalEducationDept extends EducationCollege {
     public PhysicalEducationDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class PhysicalEducationDept extends EducationCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(PHY_EDU.getHostPrefix(), 501);
         this.departmentName = PHY_EDU;
         this.noticeGraduationInfo = new NoticeScrapInfo(PHY_EDU.getHostPrefix(), 979);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/BiologicalDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/BiologicalDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class BiologicalDept extends EngineeringCollege {
     public BiologicalDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class BiologicalDept extends EngineeringCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(BIOLOGICAL.getHostPrefix(), 790);
         this.departmentName = BIOLOGICAL;
         this.noticeGraduationInfo = new NoticeScrapInfo(BIOLOGICAL.getHostPrefix(), 417);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ChemicalDivisionDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ChemicalDivisionDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class ChemicalDivisionDept extends EngineeringCollege {
     public ChemicalDivisionDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class ChemicalDivisionDept extends EngineeringCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(CHEMI_DIV.getHostPrefix(), 409);
         this.departmentName = CHEMI_DIV;
         this.noticeGraduationInfo = new NoticeScrapInfo(CHEMI_DIV.getHostPrefix(), 769);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/CivilEnvironmentDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/CivilEnvironmentDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class CivilEnvironmentDept extends EngineeringCollege {
     public CivilEnvironmentDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class CivilEnvironmentDept extends EngineeringCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(CIVIL_ENV.getHostPrefix(), 401);
         this.departmentName = CIVIL_ENV;
         this.noticeGraduationInfo = new NoticeScrapInfo(CIVIL_ENV.getHostPrefix(), 756);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ComputerScienceDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ComputerScienceDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class ComputerScienceDept extends EngineeringCollege {
     public ComputerScienceDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class ComputerScienceDept extends EngineeringCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(COMPUTER.getHostPrefix(), 775);
         this.departmentName = COMPUTER;
         this.noticeGraduationInfo = new NoticeScrapInfo(COMPUTER.getHostPrefix(), 411);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ElectricalElectronicsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/ElectricalElectronicsDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class ElectricalElectronicsDept extends EngineeringCollege {
     public ElectricalElectronicsDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class ElectricalElectronicsDept extends EngineeringCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(ELEC_ELEC.getHostPrefix(), 407);
         this.departmentName = ELEC_ELEC;
         this.noticeGraduationInfo = new NoticeScrapInfo(ELEC_ELEC.getHostPrefix(), 767);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/IndustrialDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/engineering/IndustrialDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.engineering;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class IndustrialDept extends EngineeringCollege {
     public IndustrialDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class IndustrialDept extends EngineeringCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(INDUSTRIAL.getHostPrefix(), 413);
         this.departmentName = INDUSTRIAL;
         this.noticeGraduationInfo = new NoticeScrapInfo(INDUSTRIAL.getHostPrefix(), 778);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/BioMedicalScienceDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/BioMedicalScienceDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class BioMedicalScienceDept extends KuIntegratedScienceCollege {
     public BioMedicalScienceDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class BioMedicalScienceDept extends KuIntegratedScienceCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(BIO_MEDICAL.getHostPrefix(), 880);
         this.departmentName = BIO_MEDICAL;
         this.noticeGraduationInfo = new NoticeScrapInfo(BIO_MEDICAL.getHostPrefix(), 883);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/CosmeticsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/CosmeticsDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class CosmeticsDept extends KuIntegratedScienceCollege {
     public CosmeticsDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class CosmeticsDept extends KuIntegratedScienceCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(COSMETICS.getHostPrefix(), 457);
         this.departmentName = COSMETICS;
         this.noticeGraduationInfo = new NoticeScrapInfo(COSMETICS.getHostPrefix(), 873);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/EnergyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/ku_integrated_science/EnergyDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.ku_integrated_science;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class EnergyDept extends KuIntegratedScienceCollege {
     public EnergyDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class EnergyDept extends KuIntegratedScienceCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(ENERGY.getHostPrefix(), 451);
         this.departmentName = ENERGY;
         this.noticeGraduationInfo = new NoticeScrapInfo(ENERGY.getHostPrefix(), 848);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/ChineseDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/ChineseDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class ChineseDept extends LiberalArtCollege {
     public ChineseDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class ChineseDept extends LiberalArtCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(CHINESE.getHostPrefix(), 353);
         this.departmentName = CHINESE;
         this.noticeGraduationInfo = new NoticeScrapInfo(CHINESE.getHostPrefix(), 709);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/CultureContentDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/CultureContentDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class CultureContentDept extends LiberalArtCollege {
     public CultureContentDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class CultureContentDept extends LiberalArtCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(CULTURE_CONT.getHostPrefix(), 661);
         this.departmentName = CULTURE_CONT;
         this.noticeGraduationInfo = new NoticeScrapInfo(CULTURE_CONT.getHostPrefix(), 379);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/EnglishDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/EnglishDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class EnglishDept extends LiberalArtCollege {
     public EnglishDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class EnglishDept extends LiberalArtCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(ENGLISH.getHostPrefix(), 347);
         this.departmentName = ENGLISH;
         this.noticeGraduationInfo = new NoticeScrapInfo(ENGLISH.getHostPrefix(), 350);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/GeologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/GeologyDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class GeologyDept extends LiberalArtCollege {
     public GeologyDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class GeologyDept extends LiberalArtCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(GEOLOGY.getHostPrefix(), 373);
         this.departmentName = GEOLOGY;
         this.noticeGraduationInfo = new NoticeScrapInfo(GEOLOGY.getHostPrefix(), 716);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/HistoryDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/HistoryDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class HistoryDept extends LiberalArtCollege {
     public HistoryDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class HistoryDept extends LiberalArtCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(HISTORY.getHostPrefix(), 361);
         this.departmentName = HISTORY;
         this.noticeGraduationInfo = new NoticeScrapInfo(HISTORY.getHostPrefix(), 363);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/KoreanDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/KoreanDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class KoreanDept extends LiberalArtCollege {
     public KoreanDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class KoreanDept extends LiberalArtCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(KOREAN.getHostPrefix(), 334);
         this.departmentName = KOREAN;
         this.noticeGraduationInfo = new NoticeScrapInfo(KOREAN.getHostPrefix(), 332);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/MediaCommunicationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/MediaCommunicationDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class MediaCommunicationDept extends LiberalArtCollege {
     public MediaCommunicationDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class MediaCommunicationDept extends LiberalArtCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(MEDIA_COMM.getHostPrefix(), 375);
         this.departmentName = MEDIA_COMM;
         this.noticeGraduationInfo = new NoticeScrapInfo(MEDIA_COMM.getHostPrefix(), 602);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/PhilosophyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/PhilosophyDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.liberal_art;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class PhilosophyDept extends LiberalArtCollege {
     public PhilosophyDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class PhilosophyDept extends LiberalArtCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(PHILOSOPHY.getHostPrefix(), 356);
         this.departmentName = PHILOSOPHY;
         this.noticeGraduationInfo = new NoticeScrapInfo(PHILOSOPHY.getHostPrefix(), 360);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/real_estate/RealEstateDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/real_estate/RealEstateDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.real_estate;
 
 import com.kustacks.kuring.worker.parser.notice.RealEstateNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.RealEstateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -16,7 +17,8 @@ public class RealEstateDept extends RealEstateCollege {
 
     public RealEstateDept(RealEstateNoticeApiClient realEstateNoticeApiClient,
                           RealEstateNoticeHtmlParser realEstateNoticeHtmlParser,
-                          LatestPageNoticeProperties latestPageNoticeProperties) {
+                          LatestPageNoticeProperties latestPageNoticeProperties,
+                          LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient) {
         super();
         this.noticeApiClient = realEstateNoticeApiClient;
         this.htmlParser = realEstateNoticeHtmlParser;
@@ -27,5 +29,6 @@ public class RealEstateDept extends RealEstateCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(REAL_ESTATE.getHostPrefix(), 1563);
         this.departmentName = REAL_ESTATE;
         this.noticeGraduationInfo = new NoticeScrapInfo(REAL_ESTATE.getHostPrefix(), 1565);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/AnimalScienceTechnologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/AnimalScienceTechnologyDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_biology;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class AnimalScienceTechnologyDept extends SanghuoBiologyCollege {
     public AnimalScienceTechnologyDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class AnimalScienceTechnologyDept extends SanghuoBiologyCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(ANIMAL_SCIENCE.getHostPrefix(), 914);
         this.departmentName = ANIMAL_SCIENCE;
         this.noticeGraduationInfo = new NoticeScrapInfo(ANIMAL_SCIENCE.getHostPrefix(), 469);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/BiologicalSciencesDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/BiologicalSciencesDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_biology;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -18,7 +19,8 @@ public class BiologicalSciencesDept extends SanghuoBiologyCollege {
     public BiologicalSciencesDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -30,5 +32,6 @@ public class BiologicalSciencesDept extends SanghuoBiologyCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(BIO_SCIENCE.getHostPrefix(), 909);
         this.departmentName = BIO_SCIENCE;
         this.noticeGraduationInfo = new NoticeScrapInfo(BIO_SCIENCE.getHostPrefix(), 905);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/FoodMarketingSafetyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/sanghuo_biology/FoodMarketingSafetyDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.sanghuo_biology;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class FoodMarketingSafetyDept extends SanghuoBiologyCollege {
     public FoodMarketingSafetyDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class FoodMarketingSafetyDept extends SanghuoBiologyCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(FOOD_MARKETING.getHostPrefix(), 929);
         this.departmentName = FOOD_MARKETING;
         this.noticeGraduationInfo = new NoticeScrapInfo(FOOD_MARKETING.getHostPrefix(), 475);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/science/MathematicsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/science/MathematicsDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.science;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class MathematicsDept extends ScienceCollege {
     public MathematicsDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class MathematicsDept extends ScienceCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(MATH.getHostPrefix(), 727);
         this.departmentName = MATH;
         this.noticeGraduationInfo = new NoticeScrapInfo(MATH.getHostPrefix(), 391);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/science/PhysicsDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/science/PhysicsDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.science;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -16,7 +17,8 @@ public class PhysicsDept extends ScienceCollege {
     public PhysicsDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -28,5 +30,6 @@ public class PhysicsDept extends ScienceCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(PHYSICS.getHostPrefix(), 393);
         this.departmentName = PHYSICS;
         this.noticeGraduationInfo = new NoticeScrapInfo(PHYSICS.getHostPrefix(), 735);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/InternationalTradeDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/InternationalTradeDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.social_science;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class InternationalTradeDept extends SocialSciencesCollege {
     public InternationalTradeDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class InternationalTradeDept extends SocialSciencesCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(INT_TRADE.getHostPrefix(), 429);
         this.departmentName = INT_TRADE;
         this.noticeGraduationInfo = new NoticeScrapInfo(INT_TRADE.getHostPrefix(), 815);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/PoliticalScienceDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/PoliticalScienceDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.social_science;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class PoliticalScienceDept extends SocialSciencesCollege {
     public PoliticalScienceDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class PoliticalScienceDept extends SocialSciencesCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(POLITICS.getHostPrefix(), 803);
         this.departmentName = POLITICS;
         this.noticeGraduationInfo = new NoticeScrapInfo(POLITICS.getHostPrefix(), 421);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/PublicAdministrationDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/social_science/PublicAdministrationDept.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.worker.scrap.deptinfo.social_science;
 
 import com.kustacks.kuring.worker.parser.notice.LatestPageNoticeHtmlParser;
+import com.kustacks.kuring.worker.scrap.client.notice.LatestPageGraduateNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.LatestPageNoticeApiClient;
 import com.kustacks.kuring.worker.scrap.client.notice.property.LatestPageNoticeProperties;
 import com.kustacks.kuring.worker.scrap.deptinfo.NoticeScrapInfo;
@@ -17,7 +18,8 @@ public class PublicAdministrationDept extends SocialSciencesCollege {
     public PublicAdministrationDept(
             LatestPageNoticeApiClient latestPageNoticeApiClient,
             LatestPageNoticeHtmlParser latestPageNoticeHtmlParser,
-            LatestPageNoticeProperties latestPageNoticeProperties
+            LatestPageNoticeProperties latestPageNoticeProperties,
+            LatestPageGraduateNoticeApiClient latestPageGraduateNoticeApiClient
     ) {
         super();
         this.noticeApiClient = latestPageNoticeApiClient;
@@ -29,5 +31,6 @@ public class PublicAdministrationDept extends SocialSciencesCollege {
         this.noticeScrapInfo = new NoticeScrapInfo(ADMINISTRATION.getHostPrefix(), 855);
         this.departmentName = ADMINISTRATION;
         this.noticeGraduationInfo = new NoticeScrapInfo(ADMINISTRATION.getHostPrefix(), 427);
+        this.latestPageGraduateNoticeApiClient = latestPageGraduateNoticeApiClient;
     }
 }

--- a/src/main/java/com/kustacks/kuring/worker/update/notice/DepartmentGraduationNoticeUpdater.java
+++ b/src/main/java/com/kustacks/kuring/worker/update/notice/DepartmentGraduationNoticeUpdater.java
@@ -112,8 +112,8 @@ public class DepartmentGraduationNoticeUpdater {
         return newNoticeList;
     }
 
-    private List<DepartmentNotice> saveNewNotices(List<CommonNoticeFormatDto> scrapResults, List<Integer> savedArticleIds, DepartmentName departmentNameEnum, boolean important, boolean graduate) {
-        List<DepartmentNotice> newNotices = noticeUpdateSupport.filteringSoonSaveDepartmentNotices(scrapResults, savedArticleIds, departmentNameEnum, important, graduate);
+    private List<DepartmentNotice> saveNewNotices(List<CommonNoticeFormatDto> scrapResults, List<Integer> savedArticleIds, DepartmentName departmentNameEnum, boolean important, boolean graduated) {
+        List<DepartmentNotice> newNotices = noticeUpdateSupport.filteringSoonSaveDepartmentNotices(scrapResults, savedArticleIds, departmentNameEnum, important, graduated);
         noticeCommandPort.saveAllDepartmentNotices(newNotices);
         return newNotices;
     }
@@ -141,8 +141,8 @@ public class DepartmentGraduationNoticeUpdater {
         }
     }
 
-    private void synchronizationWithDb(List<CommonNoticeFormatDto> scrapResults, List<Integer> savedArticleIds, DepartmentName departmentNameEnum, boolean important, boolean graduate) {
-        List<DepartmentNotice> newNotices = noticeUpdateSupport.filteringSoonSaveDepartmentNotices(scrapResults, savedArticleIds, departmentNameEnum, important, graduate);
+    private void synchronizationWithDb(List<CommonNoticeFormatDto> scrapResults, List<Integer> savedArticleIds, DepartmentName departmentNameEnum, boolean important, boolean graduated) {
+        List<DepartmentNotice> newNotices = noticeUpdateSupport.filteringSoonSaveDepartmentNotices(scrapResults, savedArticleIds, departmentNameEnum, important, graduated);
 
         List<Integer> latestNoticeIds = noticeUpdateSupport.extractDepartmentNoticeIds(scrapResults);
 

--- a/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
@@ -12,7 +12,14 @@ import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
-import static com.kustacks.kuring.acceptance.CategoryStep.*;
+import static com.kustacks.kuring.acceptance.CategoryStep.사용자가_구독한_카테고리_목록_조회_요청;
+import static com.kustacks.kuring.acceptance.CategoryStep.지원하는_카테고리_조회_요청;
+import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_구독_요청;
+import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_구독_요청_응답_확인;
+import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_수정_요청;
+import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_조회_요청_응답_확인;
+import static com.kustacks.kuring.acceptance.CategoryStep.학과_조회_요청;
+import static com.kustacks.kuring.acceptance.CategoryStep.학과_조회_응답_확인;
 import static com.kustacks.kuring.acceptance.CommonStep.실패_응답_확인;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -53,7 +60,7 @@ class CategoryAcceptanceTest extends IntegrationTestSupport {
         var 학과_조회_요청_응답 = 학과_조회_요청();
 
         // then
-        학과_조회_응답_확인(학과_조회_요청_응답, 62);
+        학과_조회_응답_확인(학과_조회_요청_응답, 63);
     }
 
     /**

--- a/src/test/java/com/kustacks/kuring/worker/update/notice/DepartmentNoticeUpdaterTest.java
+++ b/src/test/java/com/kustacks/kuring/worker/update/notice/DepartmentNoticeUpdaterTest.java
@@ -64,7 +64,7 @@ class DepartmentNoticeUpdaterTest {
         List<CommonNoticeFormatDto> importantNoticeList = new ArrayList<>();
         List<CommonNoticeFormatDto> normalNoticeList = new ArrayList<>();
 
-        for(int i = 0; i < 30; i++) {
+        for (int i = 0; i < 30; i++) {
             CommonNoticeFormatDto importantFormatDto = CommonNoticeFormatDto.builder().articleId(String.valueOf(i)).updatedDate("2021-01-01").subject("important" + i)
                     .postedDate("2021-01-01").fullUrl("https://library.konkuk.ac.kr/library-guide/bulletins/important/71921")
                     .important(true).build();
@@ -78,5 +78,21 @@ class DepartmentNoticeUpdaterTest {
 
         result.add(new ComplexNoticeFormatDto(importantNoticeList, normalNoticeList));
         return result;
+    }
+
+    @DisplayName("학과별(학사) 전체 공지 업데이트 테스트")
+    @Test
+    void updateAll_undergraduate_test() throws InterruptedException {
+        // given
+        doReturn(createDepartmentNoticesFixture()).when(scrapperTemplate).scrap(any(), any());
+        doNothing().when(firebaseService).sendNotifications(anyList());
+
+        // when
+        departmentNoticeUpdater.updateAll();
+        noticeUpdaterThreadTaskExecutor.getThreadPoolExecutor().awaitTermination(2, TimeUnit.SECONDS);
+
+        // then
+        Long count = noticeQueryPort.count();
+        assertThat(count).isEqualTo(3720);
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈
#299

## 📌 요약
학과(대학원) 공지 업데이트가 제대로 안되는 오류를 수정했습니다. 
학과 목록 조회 api 응답에 대학원 여부도 보여주도록 수정하였습니다.

## 🛠️ 상세
- 대학원 공지를 지원하는 학과 객체에서 LatestPageGraduateNoticeApiClient 누락으로 deptInfo.scrapGraduateAllPageHtml()에서 업데이트 로직이 멈추던 문제 
-> 대학원 공지 지원하는 학과 객채들에 LatestPageGraduateNoticeApiClient 주입하여 해결 

- 학과 목록 조회 api 응답에 graduateSupported 필드 추가 
-> 원래 DepartmentName 기반으로 구현돼있었는데 DepartmentName은 name, hostPrefix, korName만 갖고 있어서 NoticeQueryService에서 DeptInfo를 사용하도록 변경 
-> 기존 isSupportGraduateScrap() 활용하여 대학원 공지 지원 여부 판단

- '매체연기학과'가 구현 누락 돼있어서 추가하였습니다. 

## 💬 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 학과 목록에 대학원 공지 지원 여부(graduate 지원 여부) 표시가 추가되었습니다.
  - 예술디자인대학에 매체연기학과가 새로 추가되었습니다.
- Changes
  - 교육학과 표기가 '교직과'로 업데이트되었습니다.
  - 다수 학과에서 대학원 공지 수집 지원이 확대되어 관련 데이터가 반영됩니다.
  - 학과 목록 조회 기대값(카운트) 관련 검증 값이 조정되었습니다.
- Tests
  - 전체 공지 업데이트 경로에 대한 통합 테스트가 추가/강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->