### PR TITLE
Feat: 어드민 기능- 전체 사용자 토픽 구독 API 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/admin/adapter/in/web/AdminCommandApiV2.java
+++ b/src/main/java/com/kustacks/kuring/admin/adapter/in/web/AdminCommandApiV2.java
@@ -17,7 +17,6 @@ import com.kustacks.kuring.common.dto.ResponseCodeAndMessages;
 import com.kustacks.kuring.common.utils.converter.StringToDateTimeConverter;
 import com.kustacks.kuring.common.utils.validator.BadWordInitProcessor;
 import com.kustacks.kuring.common.utils.validator.WhitelistWordInitProcessor;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -28,7 +27,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -136,11 +134,12 @@ public class AdminCommandApiV2 {
         return ResponseEntity.ok().body(new BaseResponse<>(ResponseCodeAndMessages.ADMIN_LOAD_WHITELIST_WORDS, null));
     }
 
-    @Hidden
+    @Operation(summary = "사용자 토픽 재구독", description = "모든 사용자의 구독 정보를 기반으로 Firebase 토픽을 재구독합니다")
+    @SecurityRequirement(name = "JWT")
     @Secured(AdminRole.ROLE_ROOT)
-    @GetMapping("/subscribe/all")
-    public ResponseEntity<Void> subscribe() {
-        adminCommandUseCase.subscribeAllUserSameTopic();
-        return ResponseEntity.ok().build();
+    @PostMapping("/users/subscriptions/all")
+    public ResponseEntity<BaseResponse<String>> resubscribeAllUsersToTopics() {
+        adminCommandUseCase.resubscribeAllUsersToTopics();
+        return ResponseEntity.ok().body(new BaseResponse<>(ResponseCodeAndMessages.ADMIN_USER_SUBSCRIPTION_UPDATE_SUCCESS, null));
     }
 }

--- a/src/main/java/com/kustacks/kuring/admin/application/port/in/AdminCommandUseCase.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/port/in/AdminCommandUseCase.java
@@ -11,11 +11,11 @@ public interface AdminCommandUseCase {
 
     void createRealNoticeForAllUser(RealNotificationCommand command);
 
-    void subscribeAllUserSameTopic();
-
     void addAlertSchedule(AlertCreateCommand command);
 
     void cancelAlertSchedule(Long id);
 
     void embeddingCustomData(DataEmbeddingCommand command);
+
+    void resubscribeAllUsersToTopics();
 }

--- a/src/main/java/com/kustacks/kuring/admin/application/port/out/AdminUserFeedbackPort.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/port/out/AdminUserFeedbackPort.java
@@ -4,10 +4,6 @@ import com.kustacks.kuring.user.application.port.out.dto.FeedbackDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
-
 public interface AdminUserFeedbackPort {
-    List<String> findAllToken();
-
     Page<FeedbackDto> findAllFeedbackByPageRequest(Pageable pageable);
 }

--- a/src/main/java/com/kustacks/kuring/admin/application/service/AdminCommandService.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/service/AdminCommandService.java
@@ -1,12 +1,10 @@
 package com.kustacks.kuring.admin.application.service;
 
-import com.google.firebase.messaging.FirebaseMessaging;
 import com.kustacks.kuring.admin.application.port.in.AdminCommandUseCase;
 import com.kustacks.kuring.admin.application.port.in.dto.RealNotificationCommand;
 import com.kustacks.kuring.admin.application.port.in.dto.TestNotificationCommand;
 import com.kustacks.kuring.admin.application.port.out.AdminAlertEventPort;
 import com.kustacks.kuring.admin.application.port.out.AdminEventPort;
-import com.kustacks.kuring.admin.application.port.out.AdminUserFeedbackPort;
 import com.kustacks.kuring.admin.application.port.out.AiEventPort;
 import com.kustacks.kuring.admin.domain.Admin;
 import com.kustacks.kuring.alert.application.port.in.dto.AlertCreateCommand;
@@ -14,7 +12,10 @@ import com.kustacks.kuring.alert.application.port.in.dto.DataEmbeddingCommand;
 import com.kustacks.kuring.auth.userdetails.UserDetailsServicePort;
 import com.kustacks.kuring.common.annotation.UseCase;
 import com.kustacks.kuring.common.properties.ServerProperties;
+import com.kustacks.kuring.message.application.port.out.FirebaseSubscribePort;
 import com.kustacks.kuring.notice.domain.CategoryName;
+import com.kustacks.kuring.user.application.port.out.UserQueryPort;
+import com.kustacks.kuring.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.InputStreamResource;
@@ -26,8 +27,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
+import static com.kustacks.kuring.message.application.service.FirebaseSubscribeService.ACADEMIC_EVENT_TOPIC;
 import static com.kustacks.kuring.message.application.service.FirebaseSubscribeService.ALL_DEVICE_SUBSCRIBED_TOPIC;
 
 @Slf4j
@@ -36,10 +41,11 @@ import static com.kustacks.kuring.message.application.service.FirebaseSubscribeS
 public class AdminCommandService implements AdminCommandUseCase {
 
     private final UserDetailsServicePort userDetailsServicePort;
-    private final AdminUserFeedbackPort adminUserFeedbackPort;
     private final AdminAlertEventPort adminAlertEventPort;
     private final AdminEventPort adminEventPort;
     private final AiEventPort aiEventPort;
+    private final UserQueryPort userQueryPort;
+    private final FirebaseSubscribePort firebaseSubscribePort;
     private final NoticeProperties noticeProperties;
     private final ServerProperties serverProperties;
     private final PasswordEncoder passwordEncoder;
@@ -107,21 +113,50 @@ public class AdminCommandService implements AdminCommandUseCase {
         }
     }
 
-    /**
-     * TODO : 1회성 API - client v2 배포 후, 단 한번 모든 사용자를 공통 topic에 구독시킨 후 제거 예정
-     */
     @Transactional
     @Override
-    public void subscribeAllUserSameTopic() {
-        String topic = serverProperties.ifDevThenAddSuffix(ALL_DEVICE_SUBSCRIBED_TOPIC);
+    public void resubscribeAllUsersToTopics() {
+        List<User> allUsers = userQueryPort.findAllWithSubscriptions();
+        Map<String, List<String>> topicSubscriptions = new HashMap<>();
 
-        FirebaseMessaging instance = FirebaseMessaging.getInstance();
-        List<String> allToken = adminUserFeedbackPort.findAllToken();
+        //User 당 (1 + 학사일정 알림 구독여부 + 유저별 카테고리 구독 수 + 유저별 학과 구독 수) 반복
+        //User 당 최대 2 + 카테고리 수 + 학과 수 => 넉넉 잡아 80
+        //ex. User 5000명 * 80 => 400,000번 반복
+        for (User user : allUsers) {
+            String fcmToken = user.getFcmToken();
 
-        int size = allToken.size();
-        for (int i = 0; i < size; i += 500) {
-            List<String> subList = allToken.subList(i, Math.min(i + 500, size));
-            instance.subscribeToTopicAsync(subList, topic);
+            // allDevice 토픽 - 모든 사용자
+            String allDeviceTopic = serverProperties.ifDevThenAddSuffix(ALL_DEVICE_SUBSCRIBED_TOPIC);
+            topicSubscriptions.computeIfAbsent(allDeviceTopic, k -> new LinkedList<>()).add(fcmToken);
+
+            // academicEvent 토픽 - 학사일정 알림이 활성화된 사용자
+            if (user.isAcademicEventNotificationEnabled()) {
+                String academicEventTopic = serverProperties.ifDevThenAddSuffix(ACADEMIC_EVENT_TOPIC);
+                topicSubscriptions.computeIfAbsent(academicEventTopic, k -> new LinkedList<>()).add(fcmToken);
+            }
+
+            // 카테고리별 토픽
+            user.getSubscribedCategoryList().forEach(category -> {
+                String categoryTopic = serverProperties.ifDevThenAddSuffix(category.getName());
+                topicSubscriptions.computeIfAbsent(categoryTopic, k -> new LinkedList<>()).add(fcmToken);
+            });
+
+            // 학과별 토픽
+            user.getSubscribedDepartmentList().forEach(department -> {
+                String departmentTopic = serverProperties.ifDevThenAddSuffix(department.getName());
+                topicSubscriptions.computeIfAbsent(departmentTopic, k -> new LinkedList<>()).add(fcmToken);
+            });
+        }
+
+        // 토픽별로 500개씩 나누어 구독 처리
+        for (Map.Entry<String, List<String>> entry : topicSubscriptions.entrySet()) {
+            String topic = entry.getKey();
+            List<String> tokens = entry.getValue();
+
+            for (int i = 0; i < tokens.size(); i += 500) {
+                List<String> batch = tokens.subList(i, Math.min(i + 500, tokens.size()));
+                firebaseSubscribePort.subscribeToTopic(batch, topic);
+            }
         }
     }
 

--- a/src/main/java/com/kustacks/kuring/admin/application/service/AdminCommandService.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/service/AdminCommandService.java
@@ -113,7 +113,6 @@ public class AdminCommandService implements AdminCommandUseCase {
         }
     }
 
-    @Transactional
     @Override
     public void resubscribeAllUsersToTopics() {
         List<User> allUsers = userQueryPort.findAllWithSubscriptions();

--- a/src/main/java/com/kustacks/kuring/admin/application/service/AdminCommandService.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/service/AdminCommandService.java
@@ -152,10 +152,22 @@ public class AdminCommandService implements AdminCommandUseCase {
             String topic = entry.getKey();
             List<String> tokens = entry.getValue();
 
+            log.info("Resubscribing {} users to topic: {}", tokens.size(), topic);
+
+            int successCount = 0;
+            int failureCount = 0;
+
             for (int i = 0; i < tokens.size(); i += 500) {
                 List<String> batch = tokens.subList(i, Math.min(i + 500, tokens.size()));
-                firebaseSubscribePort.subscribeToTopic(batch, topic);
+                try {
+                    firebaseSubscribePort.subscribeToTopic(batch, topic);
+                    successCount += batch.size();
+                } catch (Exception e) {
+                    failureCount += batch.size();
+                }
             }
+
+            log.info("Resubscribed {} users to topic: {}. {} users failed.", successCount, topic, failureCount);
         }
     }
 

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -29,6 +29,7 @@ public enum ResponseCodeAndMessages {
     ADMIN_EMBEDDING_NOTICE_SUCCESS(HttpStatus.OK.value(), "데이터 임베딩에 생성에 성공하였습니다"),
     ADMIN_LOAD_BAD_WORDS(HttpStatus.OK.value(), "금칙어 로드에 성공했습니다."),
     ADMIN_LOAD_WHITELIST_WORDS(HttpStatus.OK.value(), "허용 단어 로드에 성공했습니다."),
+    ADMIN_USER_SUBSCRIPTION_UPDATE_SUCCESS(HttpStatus.OK.value(), "사용자들의 구독 정보를 성공적으로 재설정했습니다."),
 
     /* User */
     USER_REGISTER_SUCCESS(HttpStatus.OK.value(), "회원가입에 성공하였습니다"),

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -31,11 +31,6 @@ public class UserPersistenceAdapter implements UserCommandPort, UserQueryPort, A
     }
 
     @Override
-    public List<String> findAllToken() {
-        return userRepository.findAllFcmTokens();
-    }
-
-    @Override
     public Optional<User> findByToken(String token) {
         if (token == null || token.isBlank()) {
             return Optional.empty();
@@ -65,6 +60,11 @@ public class UserPersistenceAdapter implements UserCommandPort, UserQueryPort, A
     @Override
     public List<User> findAll() {
         return userRepository.findAll();
+    }
+
+    @Override
+    public List<User> findAllWithSubscriptions() {
+        return userRepository.findAllWithSubscriptions();
     }
 
     @Override

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserQueryRepository.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserQueryRepository.java
@@ -13,5 +13,7 @@ interface UserQueryRepository {
 
     List<User> findByPageRequest(Pageable pageable);
 
+    List<User> findAllWithSubscriptions();
+
     void resetAllUserQuestionCount();
 }

--- a/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/out/persistence/UserQueryRepositoryImpl.java
@@ -45,6 +45,16 @@ class UserQueryRepositoryImpl implements UserQueryRepository {
                 .fetch();
     }
 
+    @Override
+    public List<User> findAllWithSubscriptions() {
+        return queryFactory
+                .selectFrom(user)
+                .leftJoin(user.categories.categoryNamesSet).fetchJoin()
+                .leftJoin(user.departments.departmentNamesSet).fetchJoin()
+                .distinct()
+                .fetch();
+    }
+
     @Transactional
     @Override
     public void resetAllUserQuestionCount() {

--- a/src/main/java/com/kustacks/kuring/user/application/port/out/UserQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/user/application/port/out/UserQueryPort.java
@@ -11,6 +11,8 @@ public interface UserQueryPort {
     Optional<User> findByToken(String token);
 
     List<User> findAll();
+
+    List<User> findAllWithSubscriptions();
     List<User> findByPageRequest(Pageable pageable);
     List<User> findByLoggedInUserId(Long id);
     

--- a/src/main/java/com/kustacks/kuring/user/domain/User.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/User.java
@@ -35,6 +35,7 @@ public class User implements Serializable {
     @Column(name = "id", nullable = false)
     private Long id;
 
+    @Getter(AccessLevel.PUBLIC)
     @Column(name = "fcm_token", unique = true, nullable = false)
     private String fcmToken;
 

--- a/src/main/resources/db/migration/V251008__Alter_academic_event_category_column_size.sql
+++ b/src/main/resources/db/migration/V251008__Alter_academic_event_category_column_size.sql
@@ -1,0 +1,2 @@
+-- 학사일정 카테고리 컬럼 사이즈를 20에서 30으로 확장
+ALTER TABLE academic_event MODIFY COLUMN category VARCHAR (30);

--- a/src/test/java/com/kustacks/kuring/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/AdminAcceptanceTest.java
@@ -18,7 +18,17 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
-import static com.kustacks.kuring.acceptance.AdminStep.*;
+import static com.kustacks.kuring.acceptance.AdminStep.금칙어_로드_요청;
+import static com.kustacks.kuring.acceptance.AdminStep.사용자_토픽_재구독_요청;
+import static com.kustacks.kuring.acceptance.AdminStep.사용자_토픽_재구독_응답_확인;
+import static com.kustacks.kuring.acceptance.AdminStep.사용자_피드백_조회_요청;
+import static com.kustacks.kuring.acceptance.AdminStep.신고_목록_조회_요청;
+import static com.kustacks.kuring.acceptance.AdminStep.신고_목록_조회_확인;
+import static com.kustacks.kuring.acceptance.AdminStep.알림_예약;
+import static com.kustacks.kuring.acceptance.AdminStep.예약_알림_삭제;
+import static com.kustacks.kuring.acceptance.AdminStep.예약_알림_조회;
+import static com.kustacks.kuring.acceptance.AdminStep.피드백_조회_확인;
+import static com.kustacks.kuring.acceptance.AdminStep.허용_단어_로드_요청;
 import static com.kustacks.kuring.acceptance.AuthStep.로그인_되어_있음;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -354,6 +364,19 @@ class AdminAcceptanceTest extends IntegrationTestSupport {
                 () -> assertThat(response.jsonPath().getString("message")).isEqualTo("인증에 실패하였습니다"),
                 () -> assertThat(response.jsonPath().getString("data")).isNull()
         );
+    }
+
+    @DisplayName("[v2] Admin은 모든 사용자의 토픽을 재구독할 수 있다")
+    @Test
+    void admin_can_resubscribe_all_users_to_topics() {
+        // given
+        String adminAccessToken = 로그인_되어_있음(ADMIN_LOGIN_ID, ADMIN_PASSWORD);
+
+        // when
+        var 재구독_응답 = 사용자_토픽_재구독_요청(adminAccessToken);
+
+        // then
+        사용자_토픽_재구독_응답_확인(재구독_응답);
     }
 
     private void 댓글_작성_및_신고() {

--- a/src/test/java/com/kustacks/kuring/acceptance/AdminStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/AdminStep.java
@@ -118,4 +118,23 @@ public class AdminStep {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 사용자_토픽_재구독_요청(String accessToken) {
+        return RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/api/v2/admin/users/subscriptions/all")
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 사용자_토픽_재구독_응답_확인(ExtractableResponse<Response> response) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("사용자들의 구독 정보를 성공적으로 재설정했습니다."),
+                () -> assertThat(response.jsonPath().getString("data")).isNull()
+        );
+    }
 }


### PR DESCRIPTION
## #️⃣ 이슈

## 📌 요약
- DB정보를 바탕으로 Firebase에 구독하는 API를 추가하였습니다.

## 🛠️ 상세
- allDevice, academicEvent, 카테고리별 토픽, 학과별 토픽을 재구독합니다.

## 💬 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 관리자용 POST /api/v2/admin/users/subscriptions/all 엔드포인트 추가로 모든 사용자 대상 토픽 일괄 재구독을 수행하고 표준화된 성공 응답을 반환합니다.
  * 기존의 GET 기반 엔드포인트는 제거되었습니다.
* **문서**
  * 새 엔드포인트에 대한 API 요약 및 보안 요구 사항(JWT) 설명이 추가되었습니다.
* **테스트**
  * 신규 엔드포인트에 대한 수락 테스트와 테스트 스텝을 추가해 응답 코드·메시지 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->