### PR TITLE
Fix: 학사일정 알림 및 업데이트 시간 수정

### DIFF
--- a/src/main/java/com/kustacks/kuring/worker/notification/AcademicEventNotificationScheduler.java
+++ b/src/main/java/com/kustacks/kuring/worker/notification/AcademicEventNotificationScheduler.java
@@ -16,8 +16,8 @@ public class AcademicEventNotificationScheduler {
     private final AcademicEventNotificationUseCase academicEventNotificationUseCase;
     private final FeatureFlags featureFlags;
 
-    // 매주 월요일 새벽 5시 학사일정 알림 전송
-    @Scheduled(cron = "0 0 5 * * 1", zone = "Asia/Seoul")
+    // 매일 아침 9시 학사일정 알림 전송
+    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
     public void sendDailyAcademicEventNotifications() {
         if (featureFlags.isEnabled(KuringFeatures.NOTIFY_ACADEMIC_EVENT.getFeature())) {
             log.info("******** 일일 학사일정 알림 발송 시작 ********");

--- a/src/main/java/com/kustacks/kuring/worker/update/calendar/AcademicEventUpdater.java
+++ b/src/main/java/com/kustacks/kuring/worker/update/calendar/AcademicEventUpdater.java
@@ -24,8 +24,8 @@ public class AcademicEventUpdater {
     private final AcademicEventDbSynchronizer academicEventDbSynchronizer;
     private final FeatureFlags featureFlags;
 
-    //매월 1일 00시 00분 업데이트 진행
-    @Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul")
+    //매주 월요일 새벽 5시 학사일정 업데이트 진행
+    @Scheduled(cron = "0 0 5 * * 1", zone = "Asia/Seoul")
     public void update() {
         if (featureFlags.isEnabled(KuringFeatures.UPDATE_ACADEMIC_EVENT.getFeature())) {
             log.info("******** 학사일정 업데이트 시작 ********");


### PR DESCRIPTION
## #️⃣ 이슈

## 📌 요약
- 학사일정 알림과 업데이트 두가지 스케쥴링의 업데이트 시간이 서로 바뀌어 있는 문제를 수정했습니다.

## 🛠️ 상세

## 💬 기타