### PR TITLE
Fix : 공지사항 FCM 알림 DTO에 id 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/message/application/port/out/dto/NoticeMessageDto.java
+++ b/src/main/java/com/kustacks/kuring/message/application/port/out/dto/NoticeMessageDto.java
@@ -1,16 +1,14 @@
 package com.kustacks.kuring.message.application.port.out.dto;
 
-import com.kustacks.kuring.notice.domain.DepartmentNotice;
-import com.kustacks.kuring.notice.domain.Notice;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.kustacks.kuring.notice.domain.*;
+import lombok.*;
 import org.springframework.util.Assert;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NoticeMessageDto {
+
+    private Long id;
 
     private String type;
 
@@ -27,7 +25,8 @@ public class NoticeMessageDto {
     private String baseUrl;
 
     @Builder
-    private NoticeMessageDto(String articleId, String postedDate, String subject, String category, String categoryKorName, String baseUrl) {
+    private NoticeMessageDto(Long id, String articleId, String postedDate, String subject, String category, String categoryKorName, String baseUrl) {
+        Assert.notNull(id, "id must not be empty");
         Assert.notNull(articleId, "articleId must not be null");
         Assert.notNull(postedDate, "postedDate must not be null");
         Assert.notNull(subject, "subject must not be null");
@@ -36,6 +35,7 @@ public class NoticeMessageDto {
         Assert.notNull(baseUrl, "baseUrl must not be null");
 
         this.type = "notice";
+        this.id = id;
         this.articleId = articleId;
         this.postedDate = postedDate;
         this.subject = subject;
@@ -46,6 +46,7 @@ public class NoticeMessageDto {
 
     public static NoticeMessageDto from(Notice notice) {
         return NoticeMessageDto.builder()
+                .id(notice.getId())
                 .articleId(notice.getArticleId())
                 .postedDate(notice.getPostedDate())
                 .subject(notice.getSubject())
@@ -57,6 +58,7 @@ public class NoticeMessageDto {
 
     public static NoticeMessageDto from(DepartmentNotice departmentNotice) {
         return NoticeMessageDto.builder()
+                .id(departmentNotice.getId())
                 .articleId(departmentNotice.getArticleId())
                 .postedDate(departmentNotice.getPostedDate())
                 .subject(departmentNotice.getSubject())


### PR DESCRIPTION
## 📌 요약
- 공지사항 알림 시 공지의 id를 추가했습니다.

## 🛠️ 상세
- id값이 없어 iOS에서 파싱이 안되고, 댓글 진입이 불가한 현상을 제거하기 위함입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 공지사항 메시지 데이터 구조를 개선했습니다. 고유 식별자 필드가 추가되었으며, 관련 데이터 변환 로직이 최적화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->