### PR TITLE
Fix : Github Actions Docker Engine 29.x 업데이트 대응 (testcontainers 2.0.2 업그레이드)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers-junit-jupiter:2.0.2"
     testImplementation "org.testcontainers:testcontainers-mariadb:2.0.2"
     testImplementation "org.testcontainers:testcontainers-chromadb:2.0.2"
+    testImplementation "org.apache.commons:commons-lang3:3.18.0"
     testImplementation 'io.projectreactor:reactor-test'
 }
 


### PR DESCRIPTION
## #️⃣ 이슈

## 📌 요약
- testcontainers2.0.2 업그레이드
- apache commons-lang3 3.18.0 고정하도록 의존성 추가 

## 🛠️ 상세
- https://github.com/ku-ring/ku-ring-backend-web/actions/runs/21974601450 github actions fail 발생

### 원인 
<img width="2184" height="341" alt="image" src="https://github.com/user-attachments/assets/5f0e41b4-7f97-428f-af91-7d55c3807ffd" />
- docker engine 버전이 지원하지 않는 api version을 docker-java가 사용중.
- docker-java는 testcontainers에서 사용

### 원인
- 2026년 2월 9일에 Github Actions 환경에서 지원하는 ubuntu-latest(24.04)의 Docker Engine 버전이 29.x대로 업그레이드 되면서 API version이 1.43이하로는 지원하지 않아 생기는 문제.
- 기존 사용하던 testcontainers는 1.19.x 버전으로 내장된 docker client(docker-java)가 1.32 api version을 사용중이라 지원하지 않았음.

### 해결
- testcontainers버전 2.x로 업그레이드
- apache common-lang3 버전도 3.13버전은 사용 불가해서 3.18로 고정.

## 💬 기타
### 참고자료
https://stackoverflow.com/questions/79817033/sudden-docker-error-about-client-api-version
https://github.com/testcontainers/testcontainers-java/issues/11212
https://github.com/actions/runner-images/issues/13474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * 테스트 라이브러리 의존성을 업그레이드했습니다. Testcontainers 및 관련 테스트 컴포넌트를 버전 1.19.8에서 2.0.2로 업데이트하여 테스트 인프라의 안정성과 호환성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->