### PR TITLE
Feat : 동아리 구독 추가/삭제, 구독자 알림 기능 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubPersistenceAdapter.java
@@ -1,0 +1,61 @@
+package com.kustacks.kuring.club.adapter.out.persistence;
+
+import com.kustacks.kuring.club.application.port.out.ClubQueryPort;
+import com.kustacks.kuring.club.application.port.out.ClubSubscriptionCommandPort;
+import com.kustacks.kuring.club.application.port.out.ClubSubscriptionQueryPort;
+import com.kustacks.kuring.club.domain.Club;
+import com.kustacks.kuring.club.domain.ClubSubscribe;
+import com.kustacks.kuring.common.annotation.PersistenceAdapter;
+import com.kustacks.kuring.user.domain.RootUser;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ClubPersistenceAdapter implements ClubQueryPort, ClubSubscriptionCommandPort, ClubSubscriptionQueryPort {
+
+    private final ClubRepository clubRepository;
+    private final ClubSubscribeRepository clubSubscribeRepository;
+
+    @Override
+    public Optional<Club> findClubById(Long id) {
+        return clubRepository.findById(id);
+    }
+
+    @Override
+    public List<Club> findClubsBetweenDates(LocalDateTime start, LocalDateTime end) {
+        return clubRepository.findClubsBetweenDates(start, end);
+    }
+
+    @Override
+    public List<Club> findNextDayRecruitEndClubs(LocalDateTime now) {
+        LocalDate tomorrow = now.toLocalDate().plusDays(1);
+        LocalDateTime startInclusive = tomorrow.atStartOfDay();
+        LocalDateTime endExclusive = tomorrow.plusDays(1).atStartOfDay();
+        return findClubsBetweenDates(startInclusive, endExclusive);
+    }
+
+    @Override
+    public boolean existsSubscription(Long rootUserId, Long clubId) {
+        return clubSubscribeRepository.existsByRootUserIdAndClubId(rootUserId, clubId);
+    }
+
+    @Override
+    public void saveSubscription(RootUser rootUser, Club club) {
+        clubSubscribeRepository.save(new ClubSubscribe(rootUser, club));
+    }
+
+    @Override
+    public void deleteSubscription(RootUser rootUser, Club club) {
+        clubSubscribeRepository.deleteByRootUserAndClub(rootUser, club);
+    }
+
+    @Override
+    public long countSubscriptions(Long rootUserId) {
+        return clubSubscribeRepository.countByRootUserId(rootUserId);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubQueryRepository.java
+++ b/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubQueryRepository.java
@@ -1,0 +1,11 @@
+package com.kustacks.kuring.club.adapter.out.persistence;
+
+import com.kustacks.kuring.club.domain.Club;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ClubQueryRepository {
+
+    List<Club> findClubsBetweenDates(LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubQueryRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.kustacks.kuring.club.adapter.out.persistence;
+
+import com.kustacks.kuring.club.domain.Club;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.kustacks.kuring.club.domain.QClub.club;
+
+@RequiredArgsConstructor
+class ClubQueryRepositoryImpl implements ClubQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Club> findClubsBetweenDates(LocalDateTime start, LocalDateTime end) {
+        return queryFactory.selectFrom(club)
+                .where(
+                        club.isAlways.isFalse(),
+                        recruitEndAtGoe(start),
+                        recruitEndAtLt(end)
+                )
+                .fetch();
+    }
+
+    private BooleanExpression recruitEndAtGoe(LocalDateTime start) {
+        return start != null ? club.recruitEndAt.goe(start) : null;
+    }
+
+    private BooleanExpression recruitEndAtLt(LocalDateTime end) {
+        return end != null ? club.recruitEndAt.lt(end) : null;
+    }
+}

--- a/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubRepository.java
+++ b/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubRepository.java
@@ -1,0 +1,7 @@
+package com.kustacks.kuring.club.adapter.out.persistence;
+
+import com.kustacks.kuring.club.domain.Club;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface ClubRepository extends JpaRepository<Club, Long>, ClubQueryRepository {
+}

--- a/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubSubscribeRepository.java
+++ b/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubSubscribeRepository.java
@@ -1,0 +1,15 @@
+package com.kustacks.kuring.club.adapter.out.persistence;
+
+import com.kustacks.kuring.club.domain.Club;
+import com.kustacks.kuring.club.domain.ClubSubscribe;
+import com.kustacks.kuring.user.domain.RootUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface ClubSubscribeRepository extends JpaRepository<ClubSubscribe, Long> {
+
+    boolean existsByRootUserIdAndClubId(Long rootUserId, Long clubId);
+
+    long countByRootUserId(Long rootUserId);
+
+    void deleteByRootUserAndClub(RootUser rootUser, Club club);
+}

--- a/src/main/java/com/kustacks/kuring/club/application/port/in/ClubNotificationUseCase.java
+++ b/src/main/java/com/kustacks/kuring/club/application/port/in/ClubNotificationUseCase.java
@@ -1,0 +1,6 @@
+package com.kustacks.kuring.club.application.port.in;
+
+public interface ClubNotificationUseCase {
+
+    void sendDeadlineNotifications();
+}

--- a/src/main/java/com/kustacks/kuring/club/application/port/in/ClubSubscriptionUseCase.java
+++ b/src/main/java/com/kustacks/kuring/club/application/port/in/ClubSubscriptionUseCase.java
@@ -1,0 +1,10 @@
+package com.kustacks.kuring.club.application.port.in;
+
+import com.kustacks.kuring.club.application.port.in.dto.ClubSubscriptionCommand;
+
+public interface ClubSubscriptionUseCase {
+
+    long addSubscription(ClubSubscriptionCommand command);
+
+    long removeSubscription(ClubSubscriptionCommand command);
+}

--- a/src/main/java/com/kustacks/kuring/club/application/port/in/dto/ClubSubscriptionCommand.java
+++ b/src/main/java/com/kustacks/kuring/club/application/port/in/dto/ClubSubscriptionCommand.java
@@ -1,0 +1,7 @@
+package com.kustacks.kuring.club.application.port.in.dto;
+
+public record ClubSubscriptionCommand(
+        String email,
+        Long clubId
+) {
+}

--- a/src/main/java/com/kustacks/kuring/club/application/port/out/ClubQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/club/application/port/out/ClubQueryPort.java
@@ -1,0 +1,16 @@
+package com.kustacks.kuring.club.application.port.out;
+
+import com.kustacks.kuring.club.domain.Club;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface ClubQueryPort {
+
+    Optional<Club> findClubById(Long id);
+
+    List<Club> findClubsBetweenDates(LocalDateTime start, LocalDateTime end);
+
+    List<Club> findNextDayRecruitEndClubs(LocalDateTime now);
+}

--- a/src/main/java/com/kustacks/kuring/club/application/port/out/ClubSubscriptionCommandPort.java
+++ b/src/main/java/com/kustacks/kuring/club/application/port/out/ClubSubscriptionCommandPort.java
@@ -1,0 +1,11 @@
+package com.kustacks.kuring.club.application.port.out;
+
+import com.kustacks.kuring.club.domain.Club;
+import com.kustacks.kuring.user.domain.RootUser;
+
+public interface ClubSubscriptionCommandPort {
+
+    void saveSubscription(RootUser rootUser, Club club);
+
+    void deleteSubscription(RootUser rootUser, Club club);
+}

--- a/src/main/java/com/kustacks/kuring/club/application/port/out/ClubSubscriptionQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/club/application/port/out/ClubSubscriptionQueryPort.java
@@ -1,0 +1,8 @@
+package com.kustacks.kuring.club.application.port.out;
+
+public interface ClubSubscriptionQueryPort {
+
+    boolean existsSubscription(Long rootUserId, Long clubId);
+
+    long countSubscriptions(Long rootUserId);
+}

--- a/src/main/java/com/kustacks/kuring/club/application/service/ClubCommandService.java
+++ b/src/main/java/com/kustacks/kuring/club/application/service/ClubCommandService.java
@@ -9,6 +9,7 @@ import com.kustacks.kuring.club.domain.Club;
 import com.kustacks.kuring.common.annotation.UseCase;
 import com.kustacks.kuring.common.exception.InvalidStateException;
 import com.kustacks.kuring.common.exception.code.ErrorCode;
+import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.user.application.port.out.RootUserQueryPort;
 import com.kustacks.kuring.user.application.port.out.UserEventPort;
 import com.kustacks.kuring.user.application.port.out.UserQueryPort;
@@ -25,6 +26,7 @@ public class ClubCommandService implements ClubSubscriptionUseCase {
 
     private static final String CLUB_TOPIC_PREFIX = "club.";
 
+    private final ServerProperties serverProperties;
     private final ClubQueryPort clubQueryPort;
     private final ClubSubscriptionCommandPort clubSubscriptionCommandPort;
     private final ClubSubscriptionQueryPort countSubscriptionsQueryPort;
@@ -90,6 +92,6 @@ public class ClubCommandService implements ClubSubscriptionUseCase {
     }
 
     private String makeTopic(Club club) {
-        return CLUB_TOPIC_PREFIX + club.getId();
+        return serverProperties.ifDevThenAddSuffix(CLUB_TOPIC_PREFIX + club.getId());
     }
 }

--- a/src/main/java/com/kustacks/kuring/club/application/service/ClubCommandService.java
+++ b/src/main/java/com/kustacks/kuring/club/application/service/ClubCommandService.java
@@ -1,0 +1,95 @@
+package com.kustacks.kuring.club.application.service;
+
+import com.kustacks.kuring.club.application.port.in.ClubSubscriptionUseCase;
+import com.kustacks.kuring.club.application.port.in.dto.ClubSubscriptionCommand;
+import com.kustacks.kuring.club.application.port.out.ClubQueryPort;
+import com.kustacks.kuring.club.application.port.out.ClubSubscriptionCommandPort;
+import com.kustacks.kuring.club.application.port.out.ClubSubscriptionQueryPort;
+import com.kustacks.kuring.club.domain.Club;
+import com.kustacks.kuring.common.annotation.UseCase;
+import com.kustacks.kuring.common.exception.InvalidStateException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
+import com.kustacks.kuring.user.application.port.out.RootUserQueryPort;
+import com.kustacks.kuring.user.application.port.out.UserEventPort;
+import com.kustacks.kuring.user.application.port.out.UserQueryPort;
+import com.kustacks.kuring.user.domain.RootUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class ClubCommandService implements ClubSubscriptionUseCase {
+
+    private static final String CLUB_TOPIC_PREFIX = "club.";
+
+    private final ClubQueryPort clubQueryPort;
+    private final ClubSubscriptionCommandPort clubSubscriptionCommandPort;
+    private final ClubSubscriptionQueryPort countSubscriptionsQueryPort;
+    private final RootUserQueryPort rootUserQueryPort;
+    private final UserQueryPort userQueryPort;
+    private final UserEventPort userEventPort;
+
+    @Override
+    public long addSubscription(ClubSubscriptionCommand command) {
+        RootUser rootUser = findRootUserByEmail(command.email());
+        Club club = findClubById(command.clubId());
+
+        if (isAlreadySubscription(rootUser, club)) {
+            throw new InvalidStateException(ErrorCode.CLUB_ALREADY_SUBSCRIBED);
+        }
+
+        clubSubscriptionCommandPort.saveSubscription(rootUser, club);
+        subscribeAllLoggedInDevices(rootUser.getId(), makeTopic(club));
+
+        return countSubscriptionsQueryPort.countSubscriptions(rootUser.getId());
+    }
+
+    @Override
+    public long removeSubscription(ClubSubscriptionCommand command) {
+        RootUser rootUser = findRootUserByEmail(command.email());
+        Club club = findClubById(command.clubId());
+
+        if (!isAlreadySubscription(rootUser, club)) {
+            throw new InvalidStateException(ErrorCode.CLUB_NOT_SUBSCRIBED);
+        }
+        clubSubscriptionCommandPort.deleteSubscription(rootUser, club);
+        unsubscribeAllLoggedInDevices(rootUser.getId(), makeTopic(club));
+
+        return countSubscriptionsQueryPort.countSubscriptions(rootUser.getId());
+    }
+
+    private boolean isAlreadySubscription(RootUser rootUser, Club club) {
+        return countSubscriptionsQueryPort.existsSubscription(rootUser.getId(), club.getId());
+    }
+
+    private RootUser findRootUserByEmail(String email) {
+        return rootUserQueryPort.findRootUserByEmail(email)
+                .orElseThrow(() -> new InvalidStateException(ErrorCode.ROOT_USER_NOT_FOUND));
+    }
+
+    private Club findClubById(Long id) {
+        return clubQueryPort.findClubById(id)
+                .orElseThrow(() -> new InvalidStateException(ErrorCode.CLUB_NOT_FOUND));
+    }
+
+    private void subscribeAllLoggedInDevices(Long rootUserId, String topic) {
+        userQueryPort.findByLoggedInUserId(rootUserId)
+                .forEach(user -> userEventPort.subscribeEvent(user.getFcmToken(), topic));
+
+        log.info("동아리 토픽 구독 완료. rootUserId={}, topic={}", rootUserId, topic);
+    }
+
+    private void unsubscribeAllLoggedInDevices(Long rootUserId, String topic) {
+        userQueryPort.findByLoggedInUserId(rootUserId)
+                .forEach(user -> userEventPort.unsubscribeEvent(user.getFcmToken(), topic));
+
+        log.info("동아리 토픽 구독 해제 완료. rootUserId={}, topic={}", rootUserId, topic);
+    }
+
+    private String makeTopic(Club club) {
+        return CLUB_TOPIC_PREFIX + club.getId();
+    }
+}

--- a/src/main/java/com/kustacks/kuring/club/application/service/ClubNotificationService.java
+++ b/src/main/java/com/kustacks/kuring/club/application/service/ClubNotificationService.java
@@ -1,0 +1,82 @@
+package com.kustacks.kuring.club.application.service;
+
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.kustacks.kuring.club.application.port.in.ClubNotificationUseCase;
+import com.kustacks.kuring.club.application.port.out.ClubQueryPort;
+import com.kustacks.kuring.club.domain.Club;
+import com.kustacks.kuring.common.annotation.UseCase;
+import com.kustacks.kuring.common.properties.ServerProperties;
+import com.kustacks.kuring.message.application.port.out.FirebaseMessagingPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static com.kustacks.kuring.message.domain.MessageType.CLUB;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class ClubNotificationService implements ClubNotificationUseCase {
+
+    private static final String CLUB_TOPIC_PREFIX = "club.";
+    private static final String D_DAY_1_TITLE = "[D-1] %s 동아리 모집";
+    private static final String D_DAY_1_BODY = "내일 마감되기 전에 지원하세요!";
+
+    private final ClubQueryPort clubQueryPort;
+    private final FirebaseMessagingPort firebaseMessagingPort;
+    private final ServerProperties serverProperties;
+
+    @Override
+    public void sendDeadlineNotifications() {
+        List<Club> clubs = findDeadlineClubs();
+        clubs.forEach(this::sendDeadLineClubNotification);
+    }
+
+    private void sendDeadLineClubNotification(Club club) {
+        try {
+            Message message = buildMessage(club);
+            firebaseMessagingPort.send(message);
+            log.info("동아리 마감 알림 발송 완료. clubId={}", club.getId());
+        } catch (Exception e) {
+            log.error("동아리 마감 알림 발송 실패. clubId={}", club.getId(), e);
+        }
+    }
+
+    private List<Club> findDeadlineClubs() {
+        return clubQueryPort.findNextDayRecruitEndClubs(LocalDateTime.now());
+    }
+
+    private Message buildMessage(Club club) {
+        String messageTitle = String.format(D_DAY_1_TITLE, club.getName());
+
+        return Message.builder()
+                .setNotification(buildNotification(messageTitle, D_DAY_1_BODY))
+                .setTopic(buildTopic(club))
+                .putAllData(buildMessageData(messageTitle, D_DAY_1_BODY, club))
+                .build();
+    }
+
+    private Map<String, String> buildMessageData(String title, String body, Club club) {
+        return Map.of(
+                "clubId", String.valueOf(club.getId()),
+                "title", title,
+                "body", body,
+                "messageType", CLUB.getValue()
+        );
+    }
+
+    private String buildTopic(Club club) {
+        return serverProperties.ifDevThenAddSuffix(CLUB_TOPIC_PREFIX + club.getId());
+    }
+
+    private Notification buildNotification(String title, String body) {
+        return Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+    }
+}

--- a/src/main/java/com/kustacks/kuring/club/domain/Club.java
+++ b/src/main/java/com/kustacks/kuring/club/domain/Club.java
@@ -16,7 +16,6 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @Entity
 @Getter
@@ -76,15 +75,4 @@ public class Club {
     @Column(columnDefinition = "TEXT")
     private String qualifications;
 
-    @Override
-    public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) return false;
-        Club club = (Club) o;
-        return Objects.equals(id, club.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(id);
-    }
 }

--- a/src/main/java/com/kustacks/kuring/club/domain/Club.java
+++ b/src/main/java/com/kustacks/kuring/club/domain/Club.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -74,4 +75,16 @@ public class Club {
 
     @Column(columnDefinition = "TEXT")
     private String qualifications;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Club club = (Club) o;
+        return Objects.equals(id, club.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
 }

--- a/src/main/java/com/kustacks/kuring/club/domain/ClubSubscribe.java
+++ b/src/main/java/com/kustacks/kuring/club/domain/ClubSubscribe.java
@@ -1,6 +1,6 @@
 package com.kustacks.kuring.club.domain;
 
-import com.kustacks.kuring.user.domain.User;
+import com.kustacks.kuring.user.domain.RootUser;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "club_subscribe",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"club_id", "user_id"})
+                @UniqueConstraint(columnNames = {"club_id", "root_user_id"})
         }
 )
 @Getter
@@ -34,6 +34,11 @@ public class ClubSubscribe {
     private Club club;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "root_user_id", nullable = false)
+    private RootUser rootUser;
+
+    public ClubSubscribe(RootUser rootUser, Club club) {
+        this.rootUser = rootUser;
+        this.club = club;
+    }
 }

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -62,6 +62,11 @@ public enum ResponseCodeAndMessages {
     ACADEMIC_EVENT_SEARCH_SUCCESS(HttpStatus.OK.value(), "학사일정 조회에 성공했습니다."),
     ACADEMIC_EVENT_NOTIFICATION_UPDATE_SUCCESS(HttpStatus.OK.value(), "학사일정 알림 설정이 변경되었습니다."),
 
+    /* Club */
+    CLUB_SUBSCRIPTION_LOOKUP_SUCCESS(HttpStatus.OK.value(), "조회되었습니다."),
+    CLUB_SUBSCRIPTION_ADD_SUCCESS(HttpStatus.OK.value(), "구독에 성공했습니다."),
+    CLUB_SUBSCRIPTION_DELETE_SUCCESS(HttpStatus.OK.value(), "구독이 취소되었습니다."),
+
     /**
      * ErrorCodes about auth
      */

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -63,7 +63,6 @@ public enum ResponseCodeAndMessages {
     ACADEMIC_EVENT_NOTIFICATION_UPDATE_SUCCESS(HttpStatus.OK.value(), "학사일정 알림 설정이 변경되었습니다."),
 
     /* Club */
-    CLUB_SUBSCRIPTION_LOOKUP_SUCCESS(HttpStatus.OK.value(), "조회되었습니다."),
     CLUB_SUBSCRIPTION_ADD_SUCCESS(HttpStatus.OK.value(), "구독에 성공했습니다."),
     CLUB_SUBSCRIPTION_DELETE_SUCCESS(HttpStatus.OK.value(), "구독이 취소되었습니다."),
 

--- a/src/main/java/com/kustacks/kuring/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/kustacks/kuring/common/exception/code/ErrorCode.java
@@ -59,6 +59,9 @@ public enum ErrorCode {
 
     CLUB_CATEGORY_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "서버에서 지원하지 않는 동아리 카테고리입니다."),
     CLUB_DIVISION_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "서버에서 지원하지 않는 동아리 소속입니다."),
+    CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 동아리입니다."),
+    CLUB_ALREADY_SUBSCRIBED(HttpStatus.BAD_REQUEST, "이미 구독한 동아리입니다."),
+    CLUB_NOT_SUBSCRIBED(HttpStatus.BAD_REQUEST, "구독하지 않은 동아리입니다."),
 
 
     STAFF_SCRAPER_EXCEED_RETRY_LIMIT("교직원 업데이트 재시도 횟수를 초과했습니다."),

--- a/src/main/java/com/kustacks/kuring/common/featureflag/KuringFeatures.java
+++ b/src/main/java/com/kustacks/kuring/common/featureflag/KuringFeatures.java
@@ -10,7 +10,8 @@ public enum KuringFeatures {
     UPDATE_USER(new Feature("update_user")),
     UPDATE_STAFF(new Feature("update_staff")),
     UPDATE_ACADEMIC_EVENT(new Feature("update_academic_event")),
-    NOTIFY_ACADEMIC_EVENT(new Feature("notify_academic_event"));
+    NOTIFY_ACADEMIC_EVENT(new Feature("notify_academic_event")),
+    NOTIFY_CLUB_DEADLINE(new Feature("notify_club_deadline"));
 
     private final Feature feature;
 

--- a/src/main/java/com/kustacks/kuring/message/domain/MessageType.java
+++ b/src/main/java/com/kustacks/kuring/message/domain/MessageType.java
@@ -9,7 +9,8 @@ public enum MessageType {
 
     NOTICE("notice"),
     ADMIN("admin"),
-    ACADEMIC("academic");
+    ACADEMIC("academic"),
+    CLUB("club");
 
     private final String value;
 }

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserClubSubscriptionApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserClubSubscriptionApiV2.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -56,14 +57,14 @@ class UserClubSubscriptionApiV2 {
     @Operation(summary = "사용자 동아리 구독 제거")
     @SecurityRequirement(name = FCM_TOKEN_HEADER_KEY)
     @SecurityRequirement(name = "JWT")
-    @DeleteMapping
+    @DeleteMapping("/{clubId}")
     public ResponseEntity<BaseResponse<UserClubSubscriptionCountResponse>> deleteSubscription(
             @RequestHeader(FCM_TOKEN_HEADER_KEY) String userToken,
             @RequestHeader(AuthorizationExtractor.AUTHORIZATION) String bearerToken,
-            @Valid @RequestBody UserClubSubscriptionRequest request
+            @PathVariable Long clubId
     ) {
         String email = validateJwtAndGetEmail(extractAuthorizationValue(bearerToken, AuthorizationType.BEARER));
-        long subscriptionCount = clubSubscriptionUseCase.removeSubscription(new ClubSubscriptionCommand(email, request.id()));
+        long subscriptionCount = clubSubscriptionUseCase.removeSubscription(new ClubSubscriptionCommand(email, clubId));
 
         return ResponseEntity.ok(new BaseResponse<>(CLUB_SUBSCRIPTION_DELETE_SUCCESS, new UserClubSubscriptionCountResponse(subscriptionCount)));
     }

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserClubSubscriptionApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserClubSubscriptionApiV2.java
@@ -1,0 +1,77 @@
+package com.kustacks.kuring.user.adapter.in.web;
+
+import com.kustacks.kuring.auth.authentication.AuthorizationExtractor;
+import com.kustacks.kuring.auth.authentication.AuthorizationType;
+import com.kustacks.kuring.auth.token.JwtTokenProvider;
+import com.kustacks.kuring.club.application.port.in.ClubSubscriptionUseCase;
+import com.kustacks.kuring.club.application.port.in.dto.ClubSubscriptionCommand;
+import com.kustacks.kuring.common.annotation.RestWebAdapter;
+import com.kustacks.kuring.common.dto.BaseResponse;
+import com.kustacks.kuring.common.exception.InvalidStateException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
+import com.kustacks.kuring.user.adapter.in.web.dto.UserClubSubscriptionCountResponse;
+import com.kustacks.kuring.user.adapter.in.web.dto.UserClubSubscriptionRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import static com.kustacks.kuring.auth.authentication.AuthorizationExtractor.extractAuthorizationValue;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CLUB_SUBSCRIPTION_ADD_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CLUB_SUBSCRIPTION_DELETE_SUCCESS;
+
+@Tag(name = "User-Club-Subscription", description = "동아리 구독")
+@Validated
+@RequiredArgsConstructor
+@RestWebAdapter(path = "/api/v2/users/subscriptions/clubs")
+class UserClubSubscriptionApiV2 {
+
+    private static final String FCM_TOKEN_HEADER_KEY = "User-Token";
+
+    private final ClubSubscriptionUseCase clubSubscriptionUseCase;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "사용자 동아리 구독 추가")
+    @SecurityRequirement(name = FCM_TOKEN_HEADER_KEY)
+    @SecurityRequirement(name = "JWT")
+    @PostMapping
+    public ResponseEntity<BaseResponse<UserClubSubscriptionCountResponse>> addSubscription(
+            @RequestHeader(FCM_TOKEN_HEADER_KEY) String userToken,
+            @RequestHeader(AuthorizationExtractor.AUTHORIZATION) String bearerToken,
+            @Valid @RequestBody UserClubSubscriptionRequest request
+    ) {
+        String email = validateJwtAndGetEmail(extractAuthorizationValue(bearerToken, AuthorizationType.BEARER));
+        long subscriptionCount = clubSubscriptionUseCase.addSubscription(new ClubSubscriptionCommand(email, request.id()));
+
+        return ResponseEntity.ok(new BaseResponse<>(CLUB_SUBSCRIPTION_ADD_SUCCESS, new UserClubSubscriptionCountResponse(subscriptionCount)));
+    }
+
+    @Operation(summary = "사용자 동아리 구독 제거")
+    @SecurityRequirement(name = FCM_TOKEN_HEADER_KEY)
+    @SecurityRequirement(name = "JWT")
+    @DeleteMapping
+    public ResponseEntity<BaseResponse<UserClubSubscriptionCountResponse>> deleteSubscription(
+            @RequestHeader(FCM_TOKEN_HEADER_KEY) String userToken,
+            @RequestHeader(AuthorizationExtractor.AUTHORIZATION) String bearerToken,
+            @Valid @RequestBody UserClubSubscriptionRequest request
+    ) {
+        String email = validateJwtAndGetEmail(extractAuthorizationValue(bearerToken, AuthorizationType.BEARER));
+        long subscriptionCount = clubSubscriptionUseCase.removeSubscription(new ClubSubscriptionCommand(email, request.id()));
+
+        return ResponseEntity.ok(new BaseResponse<>(CLUB_SUBSCRIPTION_DELETE_SUCCESS, new UserClubSubscriptionCountResponse(subscriptionCount)));
+    }
+
+    private String validateJwtAndGetEmail(String jwtToken) {
+        if (!jwtTokenProvider.validateToken(jwtToken)) {
+            throw new InvalidStateException(ErrorCode.JWT_INVALID_TOKEN);
+        }
+        return jwtTokenProvider.getPrincipal(jwtToken);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserClubSubscriptionApiV2.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/UserClubSubscriptionApiV2.java
@@ -35,13 +35,15 @@ import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CLUB_SUBSCR
 class UserClubSubscriptionApiV2 {
 
     private static final String FCM_TOKEN_HEADER_KEY = "User-Token";
+    private static final String JWT_TOKEN_HEADER_KEY = "JWT";
+
 
     private final ClubSubscriptionUseCase clubSubscriptionUseCase;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Operation(summary = "사용자 동아리 구독 추가")
     @SecurityRequirement(name = FCM_TOKEN_HEADER_KEY)
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = JWT_TOKEN_HEADER_KEY)
     @PostMapping
     public ResponseEntity<BaseResponse<UserClubSubscriptionCountResponse>> addSubscription(
             @RequestHeader(FCM_TOKEN_HEADER_KEY) String userToken,
@@ -56,7 +58,7 @@ class UserClubSubscriptionApiV2 {
 
     @Operation(summary = "사용자 동아리 구독 제거")
     @SecurityRequirement(name = FCM_TOKEN_HEADER_KEY)
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = JWT_TOKEN_HEADER_KEY)
     @DeleteMapping("/{clubId}")
     public ResponseEntity<BaseResponse<UserClubSubscriptionCountResponse>> deleteSubscription(
             @RequestHeader(FCM_TOKEN_HEADER_KEY) String userToken,

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserClubSubscriptionCountResponse.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserClubSubscriptionCountResponse.java
@@ -1,0 +1,6 @@
+package com.kustacks.kuring.user.adapter.in.web.dto;
+
+public record UserClubSubscriptionCountResponse(
+        Long subscriptionCount
+) {
+}

--- a/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserClubSubscriptionRequest.java
+++ b/src/main/java/com/kustacks/kuring/user/adapter/in/web/dto/UserClubSubscriptionRequest.java
@@ -1,0 +1,8 @@
+package com.kustacks.kuring.user.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserClubSubscriptionRequest(
+        @NotNull Long id
+) {
+}

--- a/src/main/java/com/kustacks/kuring/worker/notification/ClubNotificationScheduler.java
+++ b/src/main/java/com/kustacks/kuring/worker/notification/ClubNotificationScheduler.java
@@ -1,0 +1,31 @@
+package com.kustacks.kuring.worker.notification;
+
+import com.kustacks.kuring.club.application.port.in.ClubNotificationUseCase;
+import com.kustacks.kuring.common.featureflag.FeatureFlags;
+import com.kustacks.kuring.common.featureflag.KuringFeatures;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClubNotificationScheduler {
+
+    private final ClubNotificationUseCase clubNotificationUseCase;
+    private final FeatureFlags featureFlags;
+
+    @Scheduled(cron = "0 0 18 * * *", zone = "Asia/Seoul")
+    public void sendClubDeadlineNotifications() {
+        if (featureFlags.isEnabled(KuringFeatures.NOTIFY_CLUB_DEADLINE.getFeature())) {
+            log.info("******** 동아리 마감 임박 알림 발송 시작 ********");
+            try {
+                clubNotificationUseCase.sendDeadlineNotifications();
+                log.info("******** 동아리 마감 임박 알림 발송 완료 ********");
+            } catch (Exception e) {
+                log.error("동아리 마감 임박 알림 발송 중 오류가 발생했습니다.", e);
+            }
+        }
+    }
+}

--- a/src/main/resources/db/migration/V260217__Alter_club_subscribe_to_root_user.sql
+++ b/src/main/resources/db/migration/V260217__Alter_club_subscribe_to_root_user.sql
@@ -1,0 +1,35 @@
+-- 1) root_user FK로 전환하기 위한 임시 컬럼 추가
+ALTER TABLE club_subscribe
+    ADD COLUMN root_user_id BIGINT NULL;
+
+-- 2) 기존 user_id -> user.login_user_id(root_user.id)로 데이터 이관
+UPDATE club_subscribe cs
+    JOIN user u ON cs.user_id = u.id
+SET cs.root_user_id = u.login_user_id;
+
+-- 3) 기존 user FK/unique 제약 제거
+ALTER TABLE club_subscribe
+    DROP FOREIGN KEY fk_club_subscribe_user;
+
+ALTER TABLE club_subscribe
+    DROP INDEX uk_club_user;
+
+-- 4) 기존 user_id 컬럼 제거 및 root_user_id NOT NULL 강제
+ALTER TABLE club_subscribe
+    DROP COLUMN user_id;
+
+ALTER TABLE club_subscribe
+    MODIFY COLUMN root_user_id BIGINT NOT NULL;
+
+-- 5) root_user FK 추가 (동아리/계정 삭제 시 구독도 함께 삭제)
+ALTER TABLE club_subscribe
+    ADD CONSTRAINT fk_club_subscribe_root_user
+        FOREIGN KEY (root_user_id) REFERENCES root_user (id)
+            ON DELETE CASCADE;
+
+-- 6) 동아리-계정 구독 중복 방지 unique 제약 추가
+ALTER TABLE club_subscribe
+    ADD CONSTRAINT uk_club_root_user UNIQUE (club_id, root_user_id);
+
+-- 7) root_user 기준 조회 성능을 위한 인덱스 추가
+CREATE INDEX idx_club_subscribe_root_user ON club_subscribe (root_user_id);

--- a/src/main/resources/db/migration/V260217__Alter_club_subscribe_to_root_user.sql
+++ b/src/main/resources/db/migration/V260217__Alter_club_subscribe_to_root_user.sql
@@ -1,25 +1,24 @@
--- 1) root_user FK로 전환하기 위한 임시 컬럼 추가
-ALTER TABLE club_subscribe
-    ADD COLUMN root_user_id BIGINT NULL;
+-- root_user로 바꾸면 데이터 이관을 해야하나, 아직 데이터가 존재하지 않는 개발 단계이므로 데이터 삭제하고 진행.
+-- 1) 기존 device(user) 기준 구독 데이터는 유지하지 않는다.
+DELETE FROM club_subscribe;
 
--- 2) 기존 user_id -> user.login_user_id(root_user.id)로 데이터 이관
-UPDATE club_subscribe cs
-    JOIN user u ON cs.user_id = u.id
-SET cs.root_user_id = u.login_user_id;
-
--- 3) 기존 user FK/unique 제약 제거
+-- 2) 기존 user FK/unique/index 제약 제거
 ALTER TABLE club_subscribe
     DROP FOREIGN KEY fk_club_subscribe_user;
 
 ALTER TABLE club_subscribe
     DROP INDEX uk_club_user;
 
--- 4) 기존 user_id 컬럼 제거 및 root_user_id NOT NULL 강제
+ALTER TABLE club_subscribe
+    DROP INDEX idx_club_subscribe_user;
+
+-- 3) root_user_id 컬럼 추가
+ALTER TABLE club_subscribe
+    ADD COLUMN root_user_id BIGINT NOT NULL;
+
+-- 4) 기존 user_id 컬럼 제거
 ALTER TABLE club_subscribe
     DROP COLUMN user_id;
-
-ALTER TABLE club_subscribe
-    MODIFY COLUMN root_user_id BIGINT NOT NULL;
 
 -- 5) root_user FK 추가 (동아리/계정 삭제 시 구독도 함께 삭제)
 ALTER TABLE club_subscribe

--- a/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
@@ -14,40 +14,7 @@ import java.util.List;
 import static com.kustacks.kuring.acceptance.CommonStep.실패_응답_확인;
 import static com.kustacks.kuring.acceptance.EmailStep.인증코드_인증_요청;
 import static com.kustacks.kuring.acceptance.EmailStep.회원가입_인증코드_이메일_전송_요청;
-import static com.kustacks.kuring.acceptance.UserStep.구독한_학과_목록_조회_요청;
-import static com.kustacks.kuring.acceptance.UserStep.남은_질문_횟수_조회;
-import static com.kustacks.kuring.acceptance.UserStep.로그아웃_요청;
-import static com.kustacks.kuring.acceptance.UserStep.로그아웃_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.로그인_요청;
-import static com.kustacks.kuring.acceptance.UserStep.로그인_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.루트유저_남은_질문_횟수_조회;
-import static com.kustacks.kuring.acceptance.UserStep.북마크_생성_요청;
-import static com.kustacks.kuring.acceptance.UserStep.북마크_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.북마크_조회_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.북마크한_공지_조회_요청;
-import static com.kustacks.kuring.acceptance.UserStep.비밀번호_변경_요청;
-import static com.kustacks.kuring.acceptance.UserStep.비밀번호_변경_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.사용자_로그인_되어_있음;
-import static com.kustacks.kuring.acceptance.UserStep.사용자_정보_조회_요청;
-import static com.kustacks.kuring.acceptance.UserStep.사용자_정보_조회_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.사용자_카테고리_구독_목록_조회_요청;
-import static com.kustacks.kuring.acceptance.UserStep.사용자_학과_조회_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.사용자_회원가입_요청;
-import static com.kustacks.kuring.acceptance.UserStep.액세스_토큰으로_비밀번호_변경_요청;
-import static com.kustacks.kuring.acceptance.UserStep.질문_횟수_응답_검증;
-import static com.kustacks.kuring.acceptance.UserStep.카테고리_구독_목록_조회_요청_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.카테고리_구독_요청;
-import static com.kustacks.kuring.acceptance.UserStep.카테고리_구독_요청_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.피드백_요청_v2;
-import static com.kustacks.kuring.acceptance.UserStep.피드백_요청_응답_확인_v2;
-import static com.kustacks.kuring.acceptance.UserStep.학과_구독_요청;
-import static com.kustacks.kuring.acceptance.UserStep.학과_구독_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.학사일정_알림_토글_요청;
-import static com.kustacks.kuring.acceptance.UserStep.학사일정_알림_토글_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.회원_가입_요청;
-import static com.kustacks.kuring.acceptance.UserStep.회원_탈퇴_요청;
-import static com.kustacks.kuring.acceptance.UserStep.회원_탈퇴_응답_확인;
-import static com.kustacks.kuring.acceptance.UserStep.회원가입_응답_확인;
+import static com.kustacks.kuring.acceptance.UserStep.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -58,6 +25,7 @@ import static org.mockito.Mockito.doThrow;
 class UserAcceptanceTest extends IntegrationTestSupport {
 
     public static final String NEW_EMAIL = "new-client@konkuk.ac.kr";
+    private static final Long TEST_CLUB_ID = 1L;
 
     /**
      * Given: 가입되지 않은 사용자가 있다
@@ -522,5 +490,57 @@ class UserAcceptanceTest extends IntegrationTestSupport {
 
         // then
         학사일정_알림_토글_응답_확인(두번째_토글_응답, true);
+    }
+
+    @DisplayName("[v2] 사용자는 동아리를 구독할 수 있다")
+    @Test
+    void add_club_subscription_success() {
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        var response = 동아리_구독_추가_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID);
+
+        동아리_구독_추가_성공_응답_확인(response, 1L);
+    }
+
+    @DisplayName("[v2] 이미 구독한 동아리는 다시 구독할 수 없다")
+    @Test
+    void add_club_subscription_fail_when_already_subscribed() {
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        동아리_구독_추가_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID);
+        var response = 동아리_구독_추가_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID);
+
+        실패_응답_확인(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @DisplayName("[v2] 존재하지 않는 동아리 구독은 실패한다")
+    @Test
+    void add_club_subscription_fail_when_club_not_found() {
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        var response = 동아리_구독_추가_요청(USER_FCM_TOKEN, accessToken, 99999L);
+
+        실패_응답_확인(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @DisplayName("[v2] 사용자는 동아리 구독을 취소할 수 있다")
+    @Test
+    void remove_club_subscription_success() {
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        동아리_구독_추가_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID);
+        var response = 동아리_구독_제거_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID);
+
+        동아리_구독_제거_성공_응답_확인(response, 0L);
+    }
+
+    @DisplayName("[v2] 구독하지 않은 동아리 취소는 실패한다")
+    @Test
+    void remove_club_subscription_fail_when_not_subscribed() {
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        var response = 동아리_구독_제거_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID);
+
+        실패_응답_확인(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -4,6 +4,7 @@ import com.kustacks.kuring.auth.dto.UserRegisterRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserAcademicEventNotificationRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserBookmarkRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserCategoriesSubscribeRequest;
+import com.kustacks.kuring.user.adapter.in.web.dto.UserClubSubscriptionRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserDepartmentsSubscribeRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserFeedbackRequest;
 import com.kustacks.kuring.user.adapter.in.web.dto.UserLoginRequest;
@@ -84,11 +85,61 @@ public class UserStep {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 동아리_구독_추가_요청(String userToken, String accessToken, Long clubId) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("User-Token", userToken)
+                .header("Authorization", "Bearer " + accessToken)
+                .body(new UserClubSubscriptionRequest(clubId))
+                .when().post("/api/v2/users/subscriptions/clubs")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 동아리_구독_제거_요청(String userToken, String accessToken, Long clubId) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("User-Token", userToken)
+                .header("Authorization", "Bearer " + accessToken)
+                .body(new UserClubSubscriptionRequest(clubId))
+                .when().delete("/api/v2/users/subscriptions/clubs")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 동아리_구독_추가_요청_유저토큰없음(String accessToken, Long clubId) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + accessToken)
+                .body(new UserClubSubscriptionRequest(clubId))
+                .when().post("/api/v2/users/subscriptions/clubs")
+                .then().log().all()
+                .extract();
+    }
+
     public static void 학과_구독_응답_확인(ExtractableResponse<Response> response) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
                 () -> assertThat(response.jsonPath().getString("message")).isEqualTo("사용자의 학과 구독에 성공하였습니다")
+        );
+    }
+
+    public static void 동아리_구독_추가_성공_응답_확인(ExtractableResponse<Response> response, long expectedCount) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("구독에 성공했습니다."),
+                () -> assertThat(response.jsonPath().getLong("data.subscriptionCount")).isEqualTo(expectedCount)
+        );
+    }
+
+    public static void 동아리_구독_제거_성공_응답_확인(ExtractableResponse<Response> response, long expectedCount) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(200),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("구독이 취소되었습니다."),
+                () -> assertThat(response.jsonPath().getLong("data.subscriptionCount")).isEqualTo(expectedCount)
         );
     }
 

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -101,8 +101,7 @@ public class UserStep {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("User-Token", userToken)
                 .header("Authorization", "Bearer " + accessToken)
-                .body(new UserClubSubscriptionRequest(clubId))
-                .when().delete("/api/v2/users/subscriptions/clubs")
+                .when().delete("/api/v2/users/subscriptions/clubs/{clubId}", clubId)
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserStep.java
@@ -107,16 +107,6 @@ public class UserStep {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 동아리_구독_추가_요청_유저토큰없음(String accessToken, Long clubId) {
-        return RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", "Bearer " + accessToken)
-                .body(new UserClubSubscriptionRequest(clubId))
-                .when().post("/api/v2/users/subscriptions/clubs")
-                .then().log().all()
-                .extract();
-    }
-
     public static void 학과_구독_응답_확인(ExtractableResponse<Response> response) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),

--- a/src/test/java/com/kustacks/kuring/archunit/DependencyRuleTests.java
+++ b/src/test/java/com/kustacks/kuring/archunit/DependencyRuleTests.java
@@ -173,6 +173,28 @@ class DependencyRuleTests {
                         .importPackages("com.kustacks.kuring.calendar.."));
     }
 
+	@DisplayName("Club Domain 의존성 검증")
+	@Test
+	void validateClubDomainDependencies() {
+		HexagonalArchitecture.boundedContext("com.kustacks.kuring.club")
+
+				.withDomainLayer("domain")
+
+				.withAdaptersLayer("adapter")
+				.outgoing("out.persistence")
+				.and()
+
+				.withApplicationLayer("application")
+				.services("service")
+				.incomingPorts("port.in")
+				.outgoingPorts("port.out")
+				.and()
+
+				.withConfiguration("configuration")
+				.check(new ClassFileImporter()
+						.importPackages("com.kustacks.kuring.club.."));
+	}
+
 	@DisplayName("테스트 페키지 의존성 검증")
 	@Test
 	void testPackageDependencies() {

--- a/src/test/java/com/kustacks/kuring/club/adapter/out/persistence/ClubPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/club/adapter/out/persistence/ClubPersistenceAdapterTest.java
@@ -1,7 +1,5 @@
 package com.kustacks.kuring.club.adapter.out.persistence;
 
-import com.kustacks.kuring.club.domain.Club;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,36 +29,23 @@ class ClubPersistenceAdapterTest {
     @Mock
     private ClubSubscribeRepository clubSubscribeRepository;
 
-    @Mock
-    private EntityManager entityManager;
 
     @DisplayName("내일 마감 동아리 조회는 [내일 00:00, 내일모레 00:00) 범위를 사용한다")
     @Test
     void find_tomorrow_recruit_end_clubs_with_expected_window() {
+        //given
         LocalDateTime now = LocalDateTime.of(2026, 2, 19, 18, 0, 0);
         when(clubRepository.findClubsBetweenDates(any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(List.of());
 
+        //when
         adapter.findNextDayRecruitEndClubs(now);
 
+        //then
         ArgumentCaptor<LocalDateTime> startCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
         ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
         verify(clubRepository).findClubsBetweenDates(startCaptor.capture(), endCaptor.capture());
 
         assertThat(startCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 2, 20, 0, 0, 0));
         assertThat(endCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 2, 21, 0, 0, 0));
-    }
-
-    @DisplayName("기간 조회 메서드는 repository를 그대로 위임한다")
-    @Test
-    void find_clubs_between_dates_delegate_to_repository() {
-        LocalDateTime start = LocalDateTime.of(2026, 2, 20, 0, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2026, 2, 21, 0, 0, 0);
-        List<Club> expected = List.of();
-        when(clubRepository.findClubsBetweenDates(start, end)).thenReturn(expected);
-
-        List<Club> actual = adapter.findClubsBetweenDates(start, end);
-
-        assertThat(actual).isEqualTo(expected);
-        verify(clubRepository).findClubsBetweenDates(start, end);
     }
 }

--- a/src/test/java/com/kustacks/kuring/club/adapter/out/persistence/ClubPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/club/adapter/out/persistence/ClubPersistenceAdapterTest.java
@@ -1,0 +1,66 @@
+package com.kustacks.kuring.club.adapter.out.persistence;
+
+import com.kustacks.kuring.club.domain.Club;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ClubPersistenceAdapter")
+class ClubPersistenceAdapterTest {
+
+    @InjectMocks
+    private ClubPersistenceAdapter adapter;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ClubSubscribeRepository clubSubscribeRepository;
+
+    @Mock
+    private EntityManager entityManager;
+
+    @DisplayName("내일 마감 동아리 조회는 [내일 00:00, 내일모레 00:00) 범위를 사용한다")
+    @Test
+    void find_tomorrow_recruit_end_clubs_with_expected_window() {
+        LocalDateTime now = LocalDateTime.of(2026, 2, 19, 18, 0, 0);
+        when(clubRepository.findClubsBetweenDates(any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(List.of());
+
+        adapter.findNextDayRecruitEndClubs(now);
+
+        ArgumentCaptor<LocalDateTime> startCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(clubRepository).findClubsBetweenDates(startCaptor.capture(), endCaptor.capture());
+
+        assertThat(startCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 2, 20, 0, 0, 0));
+        assertThat(endCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 2, 21, 0, 0, 0));
+    }
+
+    @DisplayName("기간 조회 메서드는 repository를 그대로 위임한다")
+    @Test
+    void find_clubs_between_dates_delegate_to_repository() {
+        LocalDateTime start = LocalDateTime.of(2026, 2, 20, 0, 0, 0);
+        LocalDateTime end = LocalDateTime.of(2026, 2, 21, 0, 0, 0);
+        List<Club> expected = List.of();
+        when(clubRepository.findClubsBetweenDates(start, end)).thenReturn(expected);
+
+        List<Club> actual = adapter.findClubsBetweenDates(start, end);
+
+        assertThat(actual).isEqualTo(expected);
+        verify(clubRepository).findClubsBetweenDates(start, end);
+    }
+}

--- a/src/test/java/com/kustacks/kuring/club/adapter/out/persistence/ClubPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/club/adapter/out/persistence/ClubPersistenceAdapterTest.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,7 +46,9 @@ class ClubPersistenceAdapterTest {
         ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
         verify(clubRepository).findClubsBetweenDates(startCaptor.capture(), endCaptor.capture());
 
-        assertThat(startCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 2, 20, 0, 0, 0));
-        assertThat(endCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 2, 21, 0, 0, 0));
+        assertAll(
+                () -> assertThat(startCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 2, 20, 0, 0, 0)),
+                () -> assertThat(endCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 2, 21, 0, 0, 0))
+        );
     }
 }

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
@@ -12,6 +12,7 @@ import com.kustacks.kuring.user.application.port.out.UserEventPort;
 import com.kustacks.kuring.user.application.port.out.UserQueryPort;
 import com.kustacks.kuring.user.domain.RootUser;
 import com.kustacks.kuring.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,11 +57,20 @@ class ClubCommandServiceTest {
     @Mock
     private UserEventPort userEventPort;
 
+    private RootUser rootUser;
+
+    private Club club;
+
+    @BeforeEach
+    void setUp() {
+        rootUser = rootUser();
+        club = club();
+    }
+
     @DisplayName("구독 추가 성공")
     @Test
     void add_subscription_success() {
-        RootUser rootUser = rootUser();
-        Club club = club();
+        //given
         when(club.getId()).thenReturn(1L);
         User user1 = new User("token-1");
         User user2 = new User("token-2");
@@ -71,8 +81,10 @@ class ClubCommandServiceTest {
         when(userQueryPort.findByLoggedInUserId(1L)).thenReturn(List.of(user1, user2));
         when(clubSubscriptionQueryPort.countSubscriptions(1L)).thenReturn(1L);
 
+        //when
         long count = service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L));
 
+        //then
         assertThat(count).isEqualTo(1L);
         verify(userEventPort).subscribeEvent("token-1", "club.1");
         verify(userEventPort).subscribeEvent("token-2", "club.1");
@@ -81,8 +93,7 @@ class ClubCommandServiceTest {
     @DisplayName("이미 구독된 동아리는 추가할 수 없다")
     @Test
     void add_subscription_fail_when_already_subscribed() {
-        RootUser rootUser = rootUser();
-        Club club = club();
+        //given
         when(club.getId()).thenReturn(1L);
 
         when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
@@ -90,6 +101,7 @@ class ClubCommandServiceTest {
         when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
         when(clubSubscriptionQueryPort.existsSubscription(1L, 1L)).thenReturn(Boolean.TRUE);
 
+        //when & then
         assertThatThrownBy(() -> service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
                 .isInstanceOf(InvalidStateException.class)
                 .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
@@ -98,28 +110,10 @@ class ClubCommandServiceTest {
         verify(userEventPort, never()).subscribeEvent(anyString(), anyString());
     }
 
-    @DisplayName("존재하지 않는 동아리는 구독할 수 없다")
-    @Test
-    void add_subscription_fail_when_club_not_found() {
-        RootUser rootUser = rootUser();
-
-        when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
-                .thenReturn(Optional.of(rootUser));
-        when(clubQueryPort.findClubById(1L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
-                .isInstanceOf(InvalidStateException.class)
-                .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
-                .isEqualTo(ErrorCode.CLUB_NOT_FOUND);
-
-        verify(userEventPort, never()).subscribeEvent(anyString(), anyString());
-    }
-
     @DisplayName("구독 제거 성공")
     @Test
     void remove_subscription_success() {
-        RootUser rootUser = rootUser();
-        Club club = club();
+        //given
         when(club.getId()).thenReturn(1L);
         User user1 = new User("token-1");
 
@@ -129,8 +123,10 @@ class ClubCommandServiceTest {
         when(clubSubscriptionQueryPort.existsSubscription(1L, club.getId())).thenReturn(Boolean.TRUE);
         when(userQueryPort.findByLoggedInUserId(1L)).thenReturn(List.of(user1));
 
+        //when
         long count = service.removeSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L));
 
+        //then
         assertThat(count).isEqualTo(0L);
         verify(userEventPort).unsubscribeEvent("token-1", "club.1");
     }
@@ -138,20 +134,37 @@ class ClubCommandServiceTest {
     @DisplayName("구독하지 않은 동아리는 제거할 수 없다")
     @Test
     void remove_subscription_fail_when_not_subscribed() {
-        RootUser rootUser = rootUser();
-        Club club = club();
-
+        //given
+        when(club.getId()).thenReturn(1L);
         when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
                 .thenReturn(Optional.of(rootUser));
         when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
-        when(club.getId()).thenReturn(1L);
+        when(clubSubscriptionQueryPort.existsSubscription(1L, club.getId())).thenReturn(Boolean.FALSE);
 
+        //when & then
         assertThatThrownBy(() -> service.removeSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
                 .isInstanceOf(InvalidStateException.class)
                 .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
                 .isEqualTo(ErrorCode.CLUB_NOT_SUBSCRIBED);
 
         verify(userEventPort, never()).unsubscribeEvent(anyString(), anyString());
+    }
+
+    @DisplayName("존재하지 않는 동아리는 구독할 수 없다")
+    @Test
+    void add_subscription_fail_when_club_not_found() {
+        //given
+        when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
+                .thenReturn(Optional.of(rootUser));
+        when(clubQueryPort.findClubById(1L)).thenReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
+                .isInstanceOf(InvalidStateException.class)
+                .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.CLUB_NOT_FOUND);
+
+        verify(userEventPort, never()).subscribeEvent(anyString(), anyString());
     }
 
     private RootUser rootUser() {

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
@@ -1,0 +1,166 @@
+package com.kustacks.kuring.club.application.service;
+
+import com.kustacks.kuring.club.application.port.in.dto.ClubSubscriptionCommand;
+import com.kustacks.kuring.club.application.port.out.ClubQueryPort;
+import com.kustacks.kuring.club.application.port.out.ClubSubscriptionCommandPort;
+import com.kustacks.kuring.club.application.port.out.ClubSubscriptionQueryPort;
+import com.kustacks.kuring.club.domain.Club;
+import com.kustacks.kuring.common.exception.InvalidStateException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
+import com.kustacks.kuring.user.application.port.out.RootUserQueryPort;
+import com.kustacks.kuring.user.application.port.out.UserEventPort;
+import com.kustacks.kuring.user.application.port.out.UserQueryPort;
+import com.kustacks.kuring.user.domain.RootUser;
+import com.kustacks.kuring.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ClubSubscriptionCommandService")
+class ClubCommandServiceTest {
+
+    @InjectMocks
+    private ClubCommandService service;
+
+    @Mock
+    private ClubQueryPort clubQueryPort;
+
+    @Mock
+    private ClubSubscriptionCommandPort clubSubscriptionCommandPort;
+
+    @Mock
+    private ClubSubscriptionQueryPort clubSubscriptionQueryPort;
+
+    @Mock
+    private RootUserQueryPort rootUserQueryPort;
+
+    @Mock
+    private UserQueryPort userQueryPort;
+
+    @Mock
+    private UserEventPort userEventPort;
+
+    @DisplayName("구독 추가 성공")
+    @Test
+    void add_subscription_success() {
+        RootUser rootUser = rootUser();
+        Club club = club();
+        when(club.getId()).thenReturn(1L);
+        User user1 = new User("token-1");
+        User user2 = new User("token-2");
+
+        when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
+                .thenReturn(Optional.of(rootUser));
+        when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
+        when(userQueryPort.findByLoggedInUserId(1L)).thenReturn(List.of(user1, user2));
+        when(clubSubscriptionQueryPort.countSubscriptions(1L)).thenReturn(1L);
+
+        long count = service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L));
+
+        assertThat(count).isEqualTo(1L);
+        verify(userEventPort).subscribeEvent("token-1", "club.1");
+        verify(userEventPort).subscribeEvent("token-2", "club.1");
+    }
+
+    @DisplayName("이미 구독된 동아리는 추가할 수 없다")
+    @Test
+    void add_subscription_fail_when_already_subscribed() {
+        RootUser rootUser = rootUser();
+        Club club = club();
+        when(club.getId()).thenReturn(1L);
+
+        when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
+                .thenReturn(Optional.of(rootUser));
+        when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
+        when(clubSubscriptionQueryPort.existsSubscription(1L, 1L)).thenReturn(Boolean.TRUE);
+
+        assertThatThrownBy(() -> service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
+                .isInstanceOf(InvalidStateException.class)
+                .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.CLUB_ALREADY_SUBSCRIBED);
+
+        verify(userEventPort, never()).subscribeEvent(anyString(), anyString());
+    }
+
+    @DisplayName("존재하지 않는 동아리는 구독할 수 없다")
+    @Test
+    void add_subscription_fail_when_club_not_found() {
+        RootUser rootUser = rootUser();
+
+        when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
+                .thenReturn(Optional.of(rootUser));
+        when(clubQueryPort.findClubById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
+                .isInstanceOf(InvalidStateException.class)
+                .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.CLUB_NOT_FOUND);
+
+        verify(userEventPort, never()).subscribeEvent(anyString(), anyString());
+    }
+
+    @DisplayName("구독 제거 성공")
+    @Test
+    void remove_subscription_success() {
+        RootUser rootUser = rootUser();
+        Club club = club();
+        when(club.getId()).thenReturn(1L);
+        User user1 = new User("token-1");
+
+        when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
+                .thenReturn(Optional.of(rootUser));
+        when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
+        when(clubSubscriptionQueryPort.existsSubscription(1L, club.getId())).thenReturn(Boolean.TRUE);
+        when(userQueryPort.findByLoggedInUserId(1L)).thenReturn(List.of(user1));
+
+        long count = service.removeSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L));
+
+        assertThat(count).isEqualTo(0L);
+        verify(userEventPort).unsubscribeEvent("token-1", "club.1");
+    }
+
+    @DisplayName("구독하지 않은 동아리는 제거할 수 없다")
+    @Test
+    void remove_subscription_fail_when_not_subscribed() {
+        RootUser rootUser = rootUser();
+        Club club = club();
+
+        when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
+                .thenReturn(Optional.of(rootUser));
+        when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
+        when(club.getId()).thenReturn(1L);
+
+        assertThatThrownBy(() -> service.removeSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
+                .isInstanceOf(InvalidStateException.class)
+                .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.CLUB_NOT_SUBSCRIBED);
+
+        verify(userEventPort, never()).unsubscribeEvent(anyString(), anyString());
+    }
+
+    private RootUser rootUser() {
+        RootUser rootUser = new RootUser("client@konkuk.ac.kr", "password", "nickname");
+        ReflectionTestUtils.setField(rootUser, "id", 1L);
+        return rootUser;
+    }
+
+    private Club club() {
+        return mock(Club.class);
+    }
+}

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -85,9 +86,11 @@ class ClubCommandServiceTest {
         long count = service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L));
 
         //then
-        assertThat(count).isEqualTo(1L);
-        verify(userEventPort).subscribeEvent("token-1", "club.1");
-        verify(userEventPort).subscribeEvent("token-2", "club.1");
+        assertAll(
+                () -> assertThat(count).isEqualTo(1L),
+                () -> verify(userEventPort).subscribeEvent("token-1", "club.1"),
+                () -> verify(userEventPort).subscribeEvent("token-2", "club.1")
+        );
     }
 
     @DisplayName("이미 구독된 동아리는 추가할 수 없다")
@@ -102,12 +105,13 @@ class ClubCommandServiceTest {
         when(clubSubscriptionQueryPort.existsSubscription(1L, 1L)).thenReturn(Boolean.TRUE);
 
         //when & then
-        assertThatThrownBy(() -> service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
-                .isInstanceOf(InvalidStateException.class)
-                .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
-                .isEqualTo(ErrorCode.CLUB_ALREADY_SUBSCRIBED);
-
-        verify(userEventPort, never()).subscribeEvent(anyString(), anyString());
+        assertAll(
+                () -> assertThatThrownBy(() -> service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
+                        .isInstanceOf(InvalidStateException.class)
+                        .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.CLUB_ALREADY_SUBSCRIBED),
+                () -> verify(userEventPort, never()).subscribeEvent(anyString(), anyString())
+        );
     }
 
     @DisplayName("구독 제거 성공")
@@ -127,8 +131,10 @@ class ClubCommandServiceTest {
         long count = service.removeSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L));
 
         //then
-        assertThat(count).isEqualTo(0L);
-        verify(userEventPort).unsubscribeEvent("token-1", "club.1");
+        assertAll(
+                () -> assertThat(count).isEqualTo(0L),
+                () -> verify(userEventPort).unsubscribeEvent("token-1", "club.1")
+        );
     }
 
     @DisplayName("구독하지 않은 동아리는 제거할 수 없다")
@@ -142,12 +148,13 @@ class ClubCommandServiceTest {
         when(clubSubscriptionQueryPort.existsSubscription(1L, club.getId())).thenReturn(Boolean.FALSE);
 
         //when & then
-        assertThatThrownBy(() -> service.removeSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
-                .isInstanceOf(InvalidStateException.class)
-                .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
-                .isEqualTo(ErrorCode.CLUB_NOT_SUBSCRIBED);
-
-        verify(userEventPort, never()).unsubscribeEvent(anyString(), anyString());
+        assertAll(
+                () -> assertThatThrownBy(() -> service.removeSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
+                        .isInstanceOf(InvalidStateException.class)
+                        .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.CLUB_NOT_SUBSCRIBED),
+                () -> verify(userEventPort, never()).unsubscribeEvent(anyString(), anyString())
+        );
     }
 
     @DisplayName("존재하지 않는 동아리는 구독할 수 없다")
@@ -159,12 +166,13 @@ class ClubCommandServiceTest {
         when(clubQueryPort.findClubById(1L)).thenReturn(Optional.empty());
 
         //when & then
-        assertThatThrownBy(() -> service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
-                .isInstanceOf(InvalidStateException.class)
-                .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
-                .isEqualTo(ErrorCode.CLUB_NOT_FOUND);
-
-        verify(userEventPort, never()).subscribeEvent(anyString(), anyString());
+        assertAll(
+                () -> assertThatThrownBy(() -> service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L)))
+                        .isInstanceOf(InvalidStateException.class)
+                        .extracting(ex -> ((InvalidStateException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.CLUB_NOT_FOUND),
+                () -> verify(userEventPort, never()).subscribeEvent(anyString(), anyString())
+        );
     }
 
     private RootUser rootUser() {

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
@@ -7,6 +7,7 @@ import com.kustacks.kuring.club.application.port.out.ClubSubscriptionQueryPort;
 import com.kustacks.kuring.club.domain.Club;
 import com.kustacks.kuring.common.exception.InvalidStateException;
 import com.kustacks.kuring.common.exception.code.ErrorCode;
+import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.user.application.port.out.RootUserQueryPort;
 import com.kustacks.kuring.user.application.port.out.UserEventPort;
 import com.kustacks.kuring.user.application.port.out.UserQueryPort;
@@ -44,6 +45,9 @@ class ClubCommandServiceTest {
     private ClubQueryPort clubQueryPort;
 
     @Mock
+    private ServerProperties serverProperties;
+
+    @Mock
     private ClubSubscriptionCommandPort clubSubscriptionCommandPort;
 
     @Mock
@@ -72,10 +76,11 @@ class ClubCommandServiceTest {
     @Test
     void add_subscription_success() {
         //given
-        when(club.getId()).thenReturn(1L);
         User user1 = new User("token-1");
         User user2 = new User("token-2");
 
+        when(club.getId()).thenReturn(1L);
+        when(serverProperties.ifDevThenAddSuffix(anyString())).thenReturn("club.1");
         when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
                 .thenReturn(Optional.of(rootUser));
         when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
@@ -98,7 +103,6 @@ class ClubCommandServiceTest {
     void add_subscription_fail_when_already_subscribed() {
         //given
         when(club.getId()).thenReturn(1L);
-
         when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
                 .thenReturn(Optional.of(rootUser));
         when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
@@ -118,9 +122,10 @@ class ClubCommandServiceTest {
     @Test
     void remove_subscription_success() {
         //given
-        when(club.getId()).thenReturn(1L);
         User user1 = new User("token-1");
 
+        when(club.getId()).thenReturn(1L);
+        when(serverProperties.ifDevThenAddSuffix(anyString())).thenReturn("club.1");
         when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
                 .thenReturn(Optional.of(rootUser));
         when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubNotificationServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubNotificationServiceTest.java
@@ -5,7 +5,6 @@ import com.kustacks.kuring.club.application.port.out.ClubQueryPort;
 import com.kustacks.kuring.club.domain.Club;
 import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.message.application.port.out.FirebaseMessagingPort;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -73,7 +73,7 @@ class ClubNotificationServiceTest {
         String topic = (String) ReflectionTestUtils.getField(sent, "topic");
 
         Map<String, String> data = (Map<String, String>) ReflectionTestUtils.getField(sent, "data");
-        Assertions.assertAll(
+        assertAll(
                 () -> assertThat(topic).isEqualTo("club.1.dev"),
                 () -> assertThat(data).containsEntry("clubId", "1"),
                 () -> assertThat(data).containsEntry("messageType", "club")

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubNotificationServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubNotificationServiceTest.java
@@ -1,0 +1,99 @@
+package com.kustacks.kuring.club.application.service;
+
+import com.google.firebase.messaging.Message;
+import com.kustacks.kuring.club.application.port.out.ClubQueryPort;
+import com.kustacks.kuring.club.domain.Club;
+import com.kustacks.kuring.common.properties.ServerProperties;
+import com.kustacks.kuring.message.application.port.out.FirebaseMessagingPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ClubNotificationService")
+class ClubNotificationServiceTest {
+
+    @Mock
+    private ClubQueryPort clubQueryPort;
+
+    @Mock
+    private FirebaseMessagingPort firebaseMessagingPort;
+
+    @DisplayName("내일 마감 대상 목록을 모두 발송한다")
+    @Test
+    void send_deadline_notifications_only_for_targets() throws Exception {
+        Club target = club(1L, "쿠링");
+        Club target2 = club(2L, "리드미");
+
+        when(clubQueryPort.findNextDayRecruitEndClubs(any(LocalDateTime.class)))
+                .thenReturn(List.of(target, target2));
+
+        ClubNotificationService service = new ClubNotificationService(clubQueryPort, firebaseMessagingPort, new ServerProperties("dev"));
+        service.sendDeadlineNotifications();
+
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(firebaseMessagingPort, times(2)).send(captor.capture());
+
+        Message sent = captor.getAllValues().get(0);
+        String topic = (String) ReflectionTestUtils.getField(sent, "topic");
+        @SuppressWarnings("unchecked")
+        Map<String, String> data = (Map<String, String>) ReflectionTestUtils.getField(sent, "data");
+        assertThat(topic).isEqualTo("club.1.dev");
+        assertThat(data).containsEntry("clubId", "1");
+        assertThat(data).containsEntry("messageType", "club");
+    }
+
+    @DisplayName("내일 마감 대상은 adapter 전용 메서드로 조회한다")
+    @Test
+    void should_query_by_adapter_method() {
+        when(clubQueryPort.findNextDayRecruitEndClubs(any(LocalDateTime.class)))
+                .thenReturn(List.of());
+
+        ClubNotificationService service = new ClubNotificationService(clubQueryPort, firebaseMessagingPort, new ServerProperties("dev"));
+        service.sendDeadlineNotifications();
+
+        verify(clubQueryPort).findNextDayRecruitEndClubs(any(LocalDateTime.class));
+    }
+
+    @DisplayName("발송 실패가 발생해도 다른 대상은 계속 발송")
+    @Test
+    void should_continue_even_if_one_send_fails() throws Exception {
+        Club first = club(1L, "첫번째");
+        Club second = club(2L, "두번째");
+
+        when(clubQueryPort.findNextDayRecruitEndClubs(any(LocalDateTime.class)))
+                .thenReturn(List.of(first, second));
+        doThrow(new RuntimeException("send fail"))
+                .doNothing()
+                .when(firebaseMessagingPort)
+                .send(any(Message.class));
+
+        ClubNotificationService service = new ClubNotificationService(clubQueryPort, firebaseMessagingPort, new ServerProperties("dev"));
+        service.sendDeadlineNotifications();
+
+        verify(firebaseMessagingPort, times(2)).send(any(Message.class));
+    }
+
+    private Club club(Long id, String name) {
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn(id);
+        when(club.getName()).thenReturn(name);
+        return club;
+    }
+}

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubNotificationServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubNotificationServiceTest.java
@@ -5,10 +5,13 @@ import com.kustacks.kuring.club.application.port.out.ClubQueryPort;
 import com.kustacks.kuring.club.domain.Club;
 import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.message.application.port.out.FirebaseMessagingPort;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -29,64 +32,67 @@ import static org.mockito.Mockito.when;
 @DisplayName("ClubNotificationService")
 class ClubNotificationServiceTest {
 
+    @InjectMocks
+    private ClubNotificationService service;
+
     @Mock
     private ClubQueryPort clubQueryPort;
 
     @Mock
     private FirebaseMessagingPort firebaseMessagingPort;
 
+    @Mock
+    private ServerProperties serverProperties;
+
+    private Club club1;
+
+    private Club club2;
+
+    @BeforeEach
+    void setUp() {
+        club1 = club(1L, "쿠링");
+        club2 = club(2L, "리드미");
+
+        when(serverProperties.ifDevThenAddSuffix("club.1")).thenReturn("club.1.dev");
+        when(serverProperties.ifDevThenAddSuffix("club.2")).thenReturn("club.2.dev");
+        when(clubQueryPort.findNextDayRecruitEndClubs(any(LocalDateTime.class)))
+                .thenReturn(List.of(club1, club2));
+    }
+
     @DisplayName("내일 마감 대상 목록을 모두 발송한다")
     @Test
     void send_deadline_notifications_only_for_targets() throws Exception {
-        Club target = club(1L, "쿠링");
-        Club target2 = club(2L, "리드미");
-
-        when(clubQueryPort.findNextDayRecruitEndClubs(any(LocalDateTime.class)))
-                .thenReturn(List.of(target, target2));
-
-        ClubNotificationService service = new ClubNotificationService(clubQueryPort, firebaseMessagingPort, new ServerProperties("dev"));
+        //when
         service.sendDeadlineNotifications();
 
+        //then
         ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
         verify(firebaseMessagingPort, times(2)).send(captor.capture());
 
-        Message sent = captor.getAllValues().get(0);
+        Message sent = captor.getAllValues().get(0); // 1번 ID에 대한 Club 메시지
         String topic = (String) ReflectionTestUtils.getField(sent, "topic");
-        @SuppressWarnings("unchecked")
+
         Map<String, String> data = (Map<String, String>) ReflectionTestUtils.getField(sent, "data");
-        assertThat(topic).isEqualTo("club.1.dev");
-        assertThat(data).containsEntry("clubId", "1");
-        assertThat(data).containsEntry("messageType", "club");
-    }
-
-    @DisplayName("내일 마감 대상은 adapter 전용 메서드로 조회한다")
-    @Test
-    void should_query_by_adapter_method() {
-        when(clubQueryPort.findNextDayRecruitEndClubs(any(LocalDateTime.class)))
-                .thenReturn(List.of());
-
-        ClubNotificationService service = new ClubNotificationService(clubQueryPort, firebaseMessagingPort, new ServerProperties("dev"));
-        service.sendDeadlineNotifications();
-
-        verify(clubQueryPort).findNextDayRecruitEndClubs(any(LocalDateTime.class));
+        Assertions.assertAll(
+                () -> assertThat(topic).isEqualTo("club.1.dev"),
+                () -> assertThat(data).containsEntry("clubId", "1"),
+                () -> assertThat(data).containsEntry("messageType", "club")
+        );
     }
 
     @DisplayName("발송 실패가 발생해도 다른 대상은 계속 발송")
     @Test
     void should_continue_even_if_one_send_fails() throws Exception {
-        Club first = club(1L, "첫번째");
-        Club second = club(2L, "두번째");
-
-        when(clubQueryPort.findNextDayRecruitEndClubs(any(LocalDateTime.class)))
-                .thenReturn(List.of(first, second));
+        //given
         doThrow(new RuntimeException("send fail"))
                 .doNothing()
                 .when(firebaseMessagingPort)
                 .send(any(Message.class));
 
-        ClubNotificationService service = new ClubNotificationService(clubQueryPort, firebaseMessagingPort, new ServerProperties("dev"));
+        //when
         service.sendDeadlineNotifications();
 
+        //then
         verify(firebaseMessagingPort, times(2)).send(any(Message.class));
     }
 

--- a/src/test/java/com/kustacks/kuring/support/DatabaseConfigurator.java
+++ b/src/test/java/com/kustacks/kuring/support/DatabaseConfigurator.java
@@ -116,6 +116,7 @@ public class DatabaseConfigurator implements InitializingBean {
         log.info("[DatabaseConfigurator] init start");
 
         initAdmin();
+        initClub();
         initUser();
         initRootUser();
         initUserCategory();
@@ -128,6 +129,17 @@ public class DatabaseConfigurator implements InitializingBean {
         initWhitelistWords();
 
         log.info("[DatabaseConfigurator] init complete");
+    }
+
+    private void initClub() {
+        jdbcTemplate.update(
+                "INSERT INTO club (name, summary, category, division, is_always) VALUES (?, ?, ?, ?, ?)",
+                "테스트동아리1",
+                "테스트 요약",
+                "ACADEMIC",
+                "CENTRAL",
+                false
+        );
     }
 
     private void setCharsetAllTable() {

--- a/src/test/java/com/kustacks/kuring/worker/notification/ClubNotificationSchedulerTest.java
+++ b/src/test/java/com/kustacks/kuring/worker/notification/ClubNotificationSchedulerTest.java
@@ -1,0 +1,46 @@
+package com.kustacks.kuring.worker.notification;
+
+import com.kustacks.kuring.club.application.port.in.ClubNotificationUseCase;
+import com.kustacks.kuring.common.featureflag.KuringFeatures;
+import com.kustacks.kuring.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("통합 테스트 : ClubNotificationScheduler")
+class ClubNotificationSchedulerTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ClubNotificationScheduler scheduler;
+
+    @SpyBean
+    private ClubNotificationUseCase clubNotificationUseCase;
+
+    @DisplayName("Feature Flag가 OFF이면 동아리 알림을 발송하지 않는다")
+    @Test
+    void should_not_send_notification_when_feature_flag_disabled() {
+        featureFlagsSupport.setMapProperty(KuringFeatures.NOTIFY_CLUB_DEADLINE.getFeature().value(), false);
+
+        assertThatCode(() -> scheduler.sendClubDeadlineNotifications())
+                .doesNotThrowAnyException();
+
+        verify(clubNotificationUseCase, never()).sendDeadlineNotifications();
+    }
+
+    @DisplayName("Feature Flag가 ON이면 동아리 알림 발송 유즈케이스를 호출한다")
+    @Test
+    void should_call_use_case_when_feature_flag_enabled() {
+        featureFlagsSupport.setMapProperty(KuringFeatures.NOTIFY_CLUB_DEADLINE.getFeature().value(), true);
+
+        assertThatCode(() -> scheduler.sendClubDeadlineNotifications())
+                .doesNotThrowAnyException();
+
+        verify(clubNotificationUseCase, times(1)).sendDeadlineNotifications();
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈
- #336
- #337 

## 📌 요약
- 동아리 구독(즐겨찾기) 기능을 `root_user` 기준으로 구현했습니다.
- 동아리 마감 D-1(내일 마감) 알림 스케줄링을 추가하고 Feature Flag로 제어하도록 반영했습니다.
- 구독/알림 관련 테스트(서비스/스케줄러/어댑터/인수/아키텍처)를 추가했습니다.

## 🛠️ 상세
- API
  - `POST /api/v2/users/subscriptions/clubs`
  - `DELETE /api/v2/users/subscriptions/clubs`
  - `Bearer JWT + User-Token` 필수

- DB/Flyway
  - `V260217__Alter_club_subscribe_to_root_user.sql`
  - `club_subscribe.user_id` -> `root_user_id` FK 전환
  - `(club_id, root_user_id)` unique 및 cascade 정책 유지

- Repository & PersistenceAdapter 구조
  - Querydsl 기반 `ClubQueryRepositoryImpl` 추가
  - 범용 Repository 메서드: 기간 내 마감 동아리 조회
  - 목적형 Adapter 메서드: `findNextDayRecruitEndClubs(now)`에서 `[내일 00:00, 내일모레 00:00)` 계산 후 조회
  - 구독 존재 확인/카운트/저장/삭제를 `club_subscribe` 직접 조회 방식으로 구성

- 알림/스케줄러
  - `ClubNotificationService`, `ClubNotificationScheduler` 추가
  - 스케줄: 매일 18:00 (`Asia/Seoul`)
  - Feature Flag: `KuringFeatures.NOTIFY_CLUB_DEADLINE`
  - 토픽: `club.{clubId}` or `club.{clubId}.dev`

- 테스트
  - 인수: `UserAcceptanceTest`, `UserStep`에 동아리 구독 시나리오 통합
  - 서비스: `ClubCommandServiceTest`, `ClubNotificationServiceTest`
  - 어댑터: `ClubPersistenceAdapterTest`
  - 스케줄러: `ClubNotificationSchedulerTest`
  - ArchUnit: `club.domain` 의존성 규칙 검증 추가
  - 테스트 데이터: `DatabaseConfigurator`에 club 시드 1건 추가

## 💬 기타
- PR이 상당히 두꺼워졌는데,, 동아리 구독 추가/삭제/알림 세가지가 큰 내용입니다,,
- Codex가 좋군요,,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 동아리 구독 v2 REST API(구독/구독취소, 구독수 반환) 및 구독 Persistence/서비스 추가.
  * 동아리 모집 마감 하루 전 구독자 대상 푸시 알림 자동 발송(주제 토픽 및 기능 플래그 제어), 스케줄러 추가.

* **테스트**
  * 구독·알림 관련 단위·통합·인수 테스트 대폭 추가.

* **기타**
  * 응답 코드·에러 코드·메시지 타입·피처플래그 추가 및 관련 DB 마이그레이션 포함.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->