### PR TITLE
fix : NoticeMessageDto ID 형식 String으로 변경

### DIFF
--- a/src/main/java/com/kustacks/kuring/message/application/port/out/dto/NoticeMessageDto.java
+++ b/src/main/java/com/kustacks/kuring/message/application/port/out/dto/NoticeMessageDto.java
@@ -1,14 +1,18 @@
 package com.kustacks.kuring.message.application.port.out.dto;
 
-import com.kustacks.kuring.notice.domain.*;
-import lombok.*;
+import com.kustacks.kuring.notice.domain.DepartmentNotice;
+import com.kustacks.kuring.notice.domain.Notice;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NoticeMessageDto {
 
-    private Long id;
+    private String id;
 
     private String type;
 
@@ -25,7 +29,7 @@ public class NoticeMessageDto {
     private String baseUrl;
 
     @Builder
-    private NoticeMessageDto(Long id, String articleId, String postedDate, String subject, String category, String categoryKorName, String baseUrl) {
+    private NoticeMessageDto(String id, String articleId, String postedDate, String subject, String category, String categoryKorName, String baseUrl) {
         Assert.notNull(id, "id must not be empty");
         Assert.notNull(articleId, "articleId must not be null");
         Assert.notNull(postedDate, "postedDate must not be null");
@@ -46,7 +50,7 @@ public class NoticeMessageDto {
 
     public static NoticeMessageDto from(Notice notice) {
         return NoticeMessageDto.builder()
-                .id(notice.getId())
+                .id(String.valueOf(notice.getId()))
                 .articleId(notice.getArticleId())
                 .postedDate(notice.getPostedDate())
                 .subject(notice.getSubject())
@@ -58,7 +62,7 @@ public class NoticeMessageDto {
 
     public static NoticeMessageDto from(DepartmentNotice departmentNotice) {
         return NoticeMessageDto.builder()
-                .id(departmentNotice.getId())
+                .id(String.valueOf(departmentNotice.getId()))
                 .articleId(departmentNotice.getArticleId())
                 .postedDate(departmentNotice.getPostedDate())
                 .subject(departmentNotice.getSubject())


### PR DESCRIPTION
## #️⃣ 이슈

## 📌 요약
- 알림 전송 간 data에 Long값 사용으로 알림이 발송되지 않는 문제를 발견하여 수정했습니다.

## 🛠️ 상세
- FCM Message는 Map<String, String>만 지원합니다.
- Jackson을 사용하면 Map<String, Object>로 반환됩니다.
- 이에 Jackson을 사용하여 만든 data Map을 FCM Message Builder의 putAllData로 넣으면 예외 발생하여 알림이 보내지지 않는 것으로 원인을 진단했습니다.

## 💬 기타