### PR TITLE
[feat] club에 icon_image_path 컬럼 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubQueryRepositoryImpl.java
@@ -55,7 +55,7 @@ class ClubQueryRepositoryImpl implements ClubQueryRepository {
                         club.id,
                         club.name,
                         club.summary,
-                        club.posterImagePath,
+                        club.iconImagePath,
                         club.category,
                         club.division,
                         club.recruitStartAt,

--- a/src/main/java/com/kustacks/kuring/club/application/port/out/dto/ClubReadModel.java
+++ b/src/main/java/com/kustacks/kuring/club/application/port/out/dto/ClubReadModel.java
@@ -13,7 +13,7 @@ public class ClubReadModel {
     private final Long id;
     private final String name;
     private final String summary;
-    private final String iconImageUrl;
+    private final String iconImagePath;
     private final ClubCategory category;
     private final ClubDivision division;
     private final LocalDateTime recruitStartDate;
@@ -24,7 +24,7 @@ public class ClubReadModel {
             Long id,
             String name,
             String summary,
-            String iconImageUrl,
+            String iconImagePath,
             ClubCategory category,
             ClubDivision division,
             LocalDateTime recruitStartDate,
@@ -33,7 +33,7 @@ public class ClubReadModel {
         this.id = id;
         this.name = name;
         this.summary = summary;
-        this.iconImageUrl = iconImageUrl;
+        this.iconImagePath = iconImagePath;
         this.category = category;
         this.division = division;
         this.recruitStartDate = recruitStartDate;

--- a/src/main/java/com/kustacks/kuring/club/application/service/ClubQueryService.java
+++ b/src/main/java/com/kustacks/kuring/club/application/service/ClubQueryService.java
@@ -137,7 +137,7 @@ public class ClubQueryService implements ClubQueryUseCase {
     ) {
 
         String iconImageUrl = null;
-        String iconImagePath = clubReadModel.getIconImageUrl();
+        String iconImagePath = clubReadModel.getIconImagePath();
 
         if (iconImagePath != null && !iconImagePath.isBlank()) {
             iconImageUrl = storagePort.getPresignedUrl(iconImagePath);

--- a/src/main/java/com/kustacks/kuring/club/domain/Club.java
+++ b/src/main/java/com/kustacks/kuring/club/domain/Club.java
@@ -50,6 +50,9 @@ public class Club {
     @Column(name = "poster_image_path", length = 255)
     private String posterImagePath;
 
+    @Column(name = "icon_image_path", length = 255)
+    private String iconImagePath;
+
     @Column(length = 30)
     private String building;
 

--- a/src/main/resources/db/migration/V260304__Add_icon_image_path_to_club.sql
+++ b/src/main/resources/db/migration/V260304__Add_icon_image_path_to_club.sql
@@ -1,0 +1,2 @@
+ALTER TABLE club
+    ADD COLUMN icon_image_path VARCHAR(255) NULL;


### PR DESCRIPTION
## #️⃣ 이슈
#355 
## 📌 요약
Club 도메인에 icon_image_path 컬럼을 추가하여 동아리 목록 조회 시 아이콘 이미지를 조회할 수 있도록 하였습니다. 
## 🛠️ 상세
1. Flyway migration 파일 추가 
- V260304__Add_icon_image_path_to_club.sql

2. Club Entity, ClubReadModel에 iconImagePath 필드 추가 

3. ClubQueryRepositoryImpl에 ClubReadModel 생성 시 iconImagePath 전달하도록 반영 

4. ClubQueryService에 iconImagePath 적용

## 💬 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **개선사항**
  * 클럽 아이콘 이미지의 저장 및 관리 방식이 최적화되었습니다. 시스템이 이미지 경로 기반 처리로 업데이트되어 클럽 아이콘을 더 효율적으로 관리할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->