### PR TITLE
Feat: 알림 payload 정리 및 iOS NSE 지원

### DIFF
--- a/src/main/java/com/kustacks/kuring/admin/adapter/in/web/dto/TestNotificationRequest.java
+++ b/src/main/java/com/kustacks/kuring/admin/adapter/in/web/dto/TestNotificationRequest.java
@@ -5,10 +5,11 @@ import com.kustacks.kuring.admin.application.port.in.dto.TestNotificationCommand
 public record TestNotificationRequest(
         String category,
         String subject,
+        String noticeId,
         String articleId
 ) {
 
     public TestNotificationCommand toCommand() {
-        return new TestNotificationCommand(category, subject, articleId);
+        return new TestNotificationCommand(category, subject, noticeId, articleId);
     }
 }

--- a/src/main/java/com/kustacks/kuring/admin/adapter/out/event/AdminFirebaseMessageAdapter.java
+++ b/src/main/java/com/kustacks/kuring/admin/adapter/out/event/AdminFirebaseMessageAdapter.java
@@ -20,6 +20,7 @@ public class AdminFirebaseMessageAdapter implements AdminEventPort {
 
     @Override
     public void sendTestNotificationByAdmin(
+            String noticeId,
             String articleId,
             String postedDate,
             String categoryName,
@@ -29,6 +30,7 @@ public class AdminFirebaseMessageAdapter implements AdminEventPort {
     ) throws FirebaseMessageSendException {
         Events.raise(
                 AdminTestNotificationEvent.builder()
+                        .noticeId(noticeId)
                         .articleId(articleId)
                         .postedDate(postedDate)
                         .category(categoryName)

--- a/src/main/java/com/kustacks/kuring/admin/application/port/in/dto/TestNotificationCommand.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/port/in/dto/TestNotificationCommand.java
@@ -3,6 +3,7 @@ package com.kustacks.kuring.admin.application.port.in.dto;
 public record TestNotificationCommand(
         String category,
         String subject,
+        String noticeId,
         String articleId
 ) {
 }

--- a/src/main/java/com/kustacks/kuring/admin/application/port/out/AdminEventPort.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/port/out/AdminEventPort.java
@@ -6,6 +6,7 @@ public interface AdminEventPort {
     void sendNotificationByAdmin(String title, String body, String url);
 
     void sendTestNotificationByAdmin(
+            String noticeId,
             String articleId,
             String postedDate,
             String categoryName,

--- a/src/main/java/com/kustacks/kuring/admin/application/service/AdminCommandService.java
+++ b/src/main/java/com/kustacks/kuring/admin/application/service/AdminCommandService.java
@@ -59,6 +59,7 @@ public class AdminCommandService implements AdminCommandUseCase {
         CategoryName testCategoryName = CategoryName.fromStringName(command.category());
 
         adminEventPort.sendTestNotificationByAdmin(
+                command.noticeId(),
                 command.articleId(),
                 testNoticePostedDate,
                 testCategoryName.getName(),

--- a/src/main/java/com/kustacks/kuring/auth/AuthConfig.java
+++ b/src/main/java/com/kustacks/kuring/auth/AuthConfig.java
@@ -15,7 +15,6 @@ import com.kustacks.kuring.auth.interceptor.BearerTokenAuthenticationFilter;
 import com.kustacks.kuring.auth.interceptor.FirebaseTokenAuthenticationFilter;
 import com.kustacks.kuring.auth.interceptor.UserRegisterNonChainingFilter;
 import com.kustacks.kuring.auth.token.JwtTokenProvider;
-import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.message.application.port.in.FirebaseWithUserUseCase;
 import com.kustacks.kuring.user.adapter.out.persistence.UserPersistenceAdapter;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +42,6 @@ public class AuthConfig implements WebMvcConfigurer {
     private final AdminDetailsService adminDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
-    private final ServerProperties serverProperties;
     private final FirebaseWithUserUseCase firebaseService;
     private final UserPersistenceAdapter userPersistenceAdapter;
 
@@ -88,7 +86,7 @@ public class AuthConfig implements WebMvcConfigurer {
                 .addPathPatterns("/api/v2/admin/login");
 
         registry.addInterceptor(new UserRegisterNonChainingFilter(
-                        serverProperties, firebaseService, userPersistenceAdapter, objectMapper,
+                        firebaseService, userPersistenceAdapter, objectMapper,
                         userRegisterSuccessHandler(), userRegisterFailureHandler()))
                 .addPathPatterns("/api/v2/users");
 

--- a/src/main/java/com/kustacks/kuring/auth/interceptor/UserRegisterNonChainingFilter.java
+++ b/src/main/java/com/kustacks/kuring/auth/interceptor/UserRegisterNonChainingFilter.java
@@ -29,6 +29,7 @@ public class UserRegisterNonChainingFilter implements HandlerInterceptor {
 
     private static final String REGISTER_HTTP_METHOD = "POST";
 
+    @SuppressWarnings("unused")
     private final ServerProperties serverProperties;
     private final FirebaseWithUserUseCase firebaseService;
     private final UserCommandPort userCommandPort;
@@ -76,7 +77,7 @@ public class UserRegisterNonChainingFilter implements HandlerInterceptor {
     private UserSubscribeCommand makeSubscribeCommand(String userFcmToken, String topic) {
         return new UserSubscribeCommand(
                 userFcmToken,
-                serverProperties.ifDevThenAddSuffix(topic)
+                topic
         );
     }
 

--- a/src/main/java/com/kustacks/kuring/auth/interceptor/UserRegisterNonChainingFilter.java
+++ b/src/main/java/com/kustacks/kuring/auth/interceptor/UserRegisterNonChainingFilter.java
@@ -5,7 +5,6 @@ import com.kustacks.kuring.auth.dto.UserRegisterRequest;
 import com.kustacks.kuring.auth.exception.RegisterException;
 import com.kustacks.kuring.auth.handler.AuthenticationFailureHandler;
 import com.kustacks.kuring.auth.handler.AuthenticationSuccessHandler;
-import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.message.application.port.in.FirebaseWithUserUseCase;
 import com.kustacks.kuring.message.application.port.in.dto.UserSubscribeCommand;
 import com.kustacks.kuring.user.application.port.out.UserCommandPort;
@@ -29,8 +28,6 @@ public class UserRegisterNonChainingFilter implements HandlerInterceptor {
 
     private static final String REGISTER_HTTP_METHOD = "POST";
 
-    @SuppressWarnings("unused")
-    private final ServerProperties serverProperties;
     private final FirebaseWithUserUseCase firebaseService;
     private final UserCommandPort userCommandPort;
     private final ObjectMapper objectMapper;

--- a/src/main/java/com/kustacks/kuring/calendar/application/service/AcademicEventNotificationService.java
+++ b/src/main/java/com/kustacks/kuring/calendar/application/service/AcademicEventNotificationService.java
@@ -2,18 +2,19 @@ package com.kustacks.kuring.calendar.application.service;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import com.kustacks.kuring.calendar.application.port.in.AcademicEventNotificationUseCase;
 import com.kustacks.kuring.calendar.application.port.out.AcademicEventQueryPort;
 import com.kustacks.kuring.calendar.application.port.out.dto.AcademicEventReadModel;
 import com.kustacks.kuring.common.annotation.UseCase;
 import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.message.application.port.out.FirebaseMessagingPort;
+import com.kustacks.kuring.message.application.support.FirebaseMessageFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 import static com.kustacks.kuring.message.application.service.FirebaseSubscribeService.ACADEMIC_EVENT_TOPIC;
 import static com.kustacks.kuring.message.domain.MessageType.ACADEMIC;
@@ -92,15 +93,12 @@ public class AcademicEventNotificationService implements AcademicEventNotificati
     }
 
     private Message makeMessage(String title, String body) {
-        return Message.builder()
-                .setNotification(Notification.builder()
-                        .setTitle(title)
-                        .setBody(body)
-                        .build())
-                .setTopic(serverProperties.ifDevThenAddSuffix(ACADEMIC_EVENT_TOPIC))
-                .putData("title", title)
-                .putData("body", body)
-                .putData("messageType", ACADEMIC.getValue())
-                .build();
+        return FirebaseMessageFactory.create(
+                serverProperties.ifDevThenAddSuffix(ACADEMIC_EVENT_TOPIC),
+                ACADEMIC.getValue(),
+                title,
+                body,
+                Map.of()
+        );
     }
 }

--- a/src/main/java/com/kustacks/kuring/club/application/service/ClubCommandService.java
+++ b/src/main/java/com/kustacks/kuring/club/application/service/ClubCommandService.java
@@ -9,7 +9,6 @@ import com.kustacks.kuring.club.domain.Club;
 import com.kustacks.kuring.common.annotation.UseCase;
 import com.kustacks.kuring.common.exception.InvalidStateException;
 import com.kustacks.kuring.common.exception.code.ErrorCode;
-import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.user.application.port.out.RootUserQueryPort;
 import com.kustacks.kuring.user.application.port.out.UserEventPort;
 import com.kustacks.kuring.user.application.port.out.UserQueryPort;
@@ -26,7 +25,6 @@ public class ClubCommandService implements ClubSubscriptionUseCase {
 
     private static final String CLUB_TOPIC_PREFIX = "club.";
 
-    private final ServerProperties serverProperties;
     private final ClubQueryPort clubQueryPort;
     private final ClubSubscriptionCommandPort clubSubscriptionCommandPort;
     private final ClubSubscriptionQueryPort countSubscriptionsQueryPort;
@@ -92,6 +90,6 @@ public class ClubCommandService implements ClubSubscriptionUseCase {
     }
 
     private String makeTopic(Club club) {
-        return serverProperties.ifDevThenAddSuffix(CLUB_TOPIC_PREFIX + club.getId());
+        return CLUB_TOPIC_PREFIX + club.getId();
     }
 }

--- a/src/main/java/com/kustacks/kuring/club/application/service/ClubNotificationService.java
+++ b/src/main/java/com/kustacks/kuring/club/application/service/ClubNotificationService.java
@@ -1,13 +1,13 @@
 package com.kustacks.kuring.club.application.service;
 
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import com.kustacks.kuring.club.application.port.in.ClubNotificationUseCase;
 import com.kustacks.kuring.club.application.port.out.ClubQueryPort;
 import com.kustacks.kuring.club.domain.Club;
 import com.kustacks.kuring.common.annotation.UseCase;
 import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.message.application.port.out.FirebaseMessagingPort;
+import com.kustacks.kuring.message.application.support.FirebaseMessageFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -53,30 +53,22 @@ public class ClubNotificationService implements ClubNotificationUseCase {
     private Message buildMessage(Club club) {
         String messageTitle = String.format(D_DAY_1_TITLE, club.getName());
 
-        return Message.builder()
-                .setNotification(buildNotification(messageTitle, D_DAY_1_BODY))
-                .setTopic(buildTopic(club))
-                .putAllData(buildMessageData(messageTitle, D_DAY_1_BODY, club))
-                .build();
+        return FirebaseMessageFactory.create(
+                buildTopic(club),
+                CLUB.getValue(),
+                messageTitle,
+                D_DAY_1_BODY,
+                buildMessageData(club)
+        );
     }
 
-    private Map<String, String> buildMessageData(String title, String body, Club club) {
+    private Map<String, String> buildMessageData(Club club) {
         return Map.of(
-                "clubId", String.valueOf(club.getId()),
-                "title", title,
-                "body", body,
-                "messageType", CLUB.getValue()
+                "clubId", String.valueOf(club.getId())
         );
     }
 
     private String buildTopic(Club club) {
         return serverProperties.ifDevThenAddSuffix(CLUB_TOPIC_PREFIX + club.getId());
-    }
-
-    private Notification buildNotification(String title, String body) {
-        return Notification.builder()
-                .setTitle(title)
-                .setBody(body)
-                .build();
     }
 }

--- a/src/main/java/com/kustacks/kuring/message/adapter/in/event/dto/AdminNotificationEvent.java
+++ b/src/main/java/com/kustacks/kuring/message/adapter/in/event/dto/AdminNotificationEvent.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.message.adapter.in.event.dto;
 
 import com.kustacks.kuring.message.application.port.in.dto.AdminNotificationCommand;
+import com.kustacks.kuring.message.domain.MessageType;
 
 public record AdminNotificationEvent(
         String type,
@@ -9,7 +10,7 @@ public record AdminNotificationEvent(
         String url
 ) {
     public AdminNotificationEvent(String title, String body, String url) {
-        this("admin", title, body, url);
+        this(MessageType.ADMIN.getValue(), title, body, url);
     }
 
     public AdminNotificationCommand toCommand() {

--- a/src/main/java/com/kustacks/kuring/message/adapter/in/event/dto/AdminTestNotificationEvent.java
+++ b/src/main/java/com/kustacks/kuring/message/adapter/in/event/dto/AdminTestNotificationEvent.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record AdminTestNotificationEvent(
+         String noticeId,
          String type,
          String articleId,
          String postedDate,
@@ -15,6 +16,7 @@ public record AdminTestNotificationEvent(
 ) {
     public AdminTestNotificationCommand toCommand() {
         return new AdminTestNotificationCommand(
+                noticeId,
                 articleId,
                 postedDate,
                 category,

--- a/src/main/java/com/kustacks/kuring/message/application/port/in/dto/AdminNotificationCommand.java
+++ b/src/main/java/com/kustacks/kuring/message/application/port/in/dto/AdminNotificationCommand.java
@@ -1,5 +1,7 @@
 package com.kustacks.kuring.message.application.port.in.dto;
 
+import com.kustacks.kuring.message.domain.MessageType;
+
 public record AdminNotificationCommand(
         String type,
         String title,
@@ -7,6 +9,6 @@ public record AdminNotificationCommand(
         String url
 ) {
     public AdminNotificationCommand(String title, String body, String url) {
-        this("admin", title, body, url);
+        this(MessageType.ADMIN.getValue(), title, body, url);
     }
 }

--- a/src/main/java/com/kustacks/kuring/message/application/port/in/dto/AdminTestNotificationCommand.java
+++ b/src/main/java/com/kustacks/kuring/message/application/port/in/dto/AdminTestNotificationCommand.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.message.application.port.in.dto;
 
 public record AdminTestNotificationCommand(
+        String noticeId,
         String articleId,
         String postedDate,
         String categoryName,

--- a/src/main/java/com/kustacks/kuring/message/application/port/out/dto/NoticeMessageDto.java
+++ b/src/main/java/com/kustacks/kuring/message/application/port/out/dto/NoticeMessageDto.java
@@ -1,5 +1,6 @@
 package com.kustacks.kuring.message.application.port.out.dto;
 
+import com.kustacks.kuring.message.domain.MessageType;
 import com.kustacks.kuring.notice.domain.DepartmentNotice;
 import com.kustacks.kuring.notice.domain.Notice;
 import lombok.AccessLevel;
@@ -38,7 +39,7 @@ public class NoticeMessageDto {
         Assert.notNull(categoryKorName, "categoryKorName must not be null");
         Assert.notNull(baseUrl, "baseUrl must not be null");
 
-        this.type = "notice";
+        this.type = MessageType.NOTICE.getValue();
         this.id = id;
         this.articleId = articleId;
         this.postedDate = postedDate;
@@ -72,4 +73,3 @@ public class NoticeMessageDto {
                 .build();
     }
 }
-

--- a/src/main/java/com/kustacks/kuring/message/application/service/FirebaseNotificationService.java
+++ b/src/main/java/com/kustacks/kuring/message/application/service/FirebaseNotificationService.java
@@ -74,8 +74,7 @@ public class FirebaseNotificationService implements FirebaseWithAdminUseCase {
                     serverProperties.addDevSuffix(ACADEMIC_EVENT_TOPIC),
                     ACADEMIC.getValue(),
                     command.title(),
-                    command.body(),
-                    null
+                    command.body()
             );
 
             firebaseMessagingPort.send(newMessage);
@@ -187,7 +186,7 @@ public class FirebaseNotificationService implements FirebaseWithAdminUseCase {
 
     private static NoticeMessageDto convertDtoFromCommand(AdminTestNotificationCommand command) {
         return NoticeMessageDto.builder()
-                .id(command.articleId())
+                .id(command.noticeId())
                 .articleId(command.articleId())
                 .postedDate(command.postedDate())
                 .category(command.categoryName())

--- a/src/main/java/com/kustacks/kuring/message/application/service/FirebaseNotificationService.java
+++ b/src/main/java/com/kustacks/kuring/message/application/service/FirebaseNotificationService.java
@@ -3,7 +3,6 @@ package com.kustacks.kuring.message.application.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import com.kustacks.kuring.common.annotation.UseCase;
 import com.kustacks.kuring.common.exception.InternalLogicException;
 import com.kustacks.kuring.common.exception.code.ErrorCode;
@@ -15,6 +14,7 @@ import com.kustacks.kuring.message.application.port.in.dto.AdminTestNotification
 import com.kustacks.kuring.message.application.port.out.FirebaseMessagingPort;
 import com.kustacks.kuring.message.application.port.out.dto.NoticeMessageDto;
 import com.kustacks.kuring.message.application.service.exception.FirebaseMessageSendException;
+import com.kustacks.kuring.message.application.support.FirebaseMessageFactory;
 import com.kustacks.kuring.notice.domain.Notice;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -70,18 +70,13 @@ public class FirebaseNotificationService implements FirebaseWithAdminUseCase {
     @Override
     public void sendAcademicTestNotification(AcademicTestNotificationCommand command) {
         try {
-            Message newMessage = Message.builder()
-                    .setNotification(Notification.builder()
-                            .setTitle(command.title())
-                            .setBody(command.body())
-                            .build())
-                    .putAllData(Map.of(
-                            "title", command.title(),
-                            "body", command.body(),
-                            "messageType", ACADEMIC.getValue()
-                    ))
-                    .setTopic(serverProperties.addDevSuffix(ACADEMIC_EVENT_TOPIC))
-                    .build();
+            Message newMessage = FirebaseMessageFactory.create(
+                    serverProperties.addDevSuffix(ACADEMIC_EVENT_TOPIC),
+                    ACADEMIC.getValue(),
+                    command.title(),
+                    command.body(),
+                    null
+            );
 
             firebaseMessagingPort.send(newMessage);
         } catch (FirebaseMessagingException exception) {
@@ -149,29 +144,27 @@ public class FirebaseNotificationService implements FirebaseWithAdminUseCase {
     }
 
     private Message createMessageFromCommand(AdminNotificationCommand command) {
-        return Message.builder()
-                .setNotification(Notification
-                        .builder()
-                        .setTitle(command.title())
-                        .setBody(command.body())
-                        .build())
-                .putAllData(objectMapper.convertValue(command, Map.class))
-                .putData("messageType", ADMIN.getValue())
-                .setTopic(serverProperties.ifDevThenAddSuffix(ALL_DEVICE_SUBSCRIBED_TOPIC))
-                .build();
+        Map<String, String> data = objectMapper.convertValue(command, Map.class);
+        return FirebaseMessageFactory.create(
+                serverProperties.ifDevThenAddSuffix(ALL_DEVICE_SUBSCRIBED_TOPIC),
+                ADMIN.getValue(),
+                command.title(),
+                command.body(),
+                data
+        );
     }
 
     private Message createMessageFromDto(NoticeMessageDto messageDto, UnaryOperator<String> suffixUtil) {
-        return Message.builder()
-                .setNotification(Notification
-                        .builder()
-                        .setTitle(buildTitle(messageDto.getCategoryKorName()))
-                        .setBody(messageDto.getSubject())
-                        .build())
-                .putAllData(objectMapper.convertValue(messageDto, Map.class))
-                .putData("messageType", NOTICE.getValue())
-                .setTopic(suffixUtil.apply(messageDto.getCategory()))
-                .build();
+        String title = buildTitle(messageDto.getCategoryKorName());
+        String body = messageDto.getSubject();
+        Map<String, String> data = objectMapper.convertValue(messageDto, Map.class);
+        return FirebaseMessageFactory.create(
+                suffixUtil.apply(messageDto.getCategory()),
+                NOTICE.getValue(),
+                title,
+                body,
+                data
+        );
     }
 
     private List<NoticeMessageDto> createNotification(List<? extends Notice> willBeNotiNotices) {
@@ -194,6 +187,7 @@ public class FirebaseNotificationService implements FirebaseWithAdminUseCase {
 
     private static NoticeMessageDto convertDtoFromCommand(AdminTestNotificationCommand command) {
         return NoticeMessageDto.builder()
+                .id(command.articleId())
                 .articleId(command.articleId())
                 .postedDate(command.postedDate())
                 .category(command.categoryName())

--- a/src/main/java/com/kustacks/kuring/message/application/support/FirebaseMessageFactory.java
+++ b/src/main/java/com/kustacks/kuring/message/application/support/FirebaseMessageFactory.java
@@ -1,0 +1,76 @@
+package com.kustacks.kuring.message.application.support;
+
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class FirebaseMessageFactory {
+
+    public static Message create(
+            String topic,
+            String type,
+            String title,
+            String body
+    ) {
+        return create(topic, type, title, body, Map.of());
+    }
+
+    public static Message create(
+            String topic,
+            String type,
+            String title,
+            String body,
+            Map<String, String> extraData
+    ) {
+        return baseBuilder(topic, title, body)
+                .putAllData(buildData(type, title, body, extraData))
+                .build();
+    }
+
+    private static Message.Builder baseBuilder(String topic, String title, String body) {
+        return Message.builder()
+                .setTopic(topic)
+                .setNotification(buildNotification(title, body))
+                .setApnsConfig(buildApnsConfig());
+    }
+
+    private static Notification buildNotification(String title, String body) {
+        return Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+    }
+
+    private static ApnsConfig buildApnsConfig() {
+        return ApnsConfig.builder()
+                .setAps(Aps.builder()
+                        .setMutableContent(true)
+                        .build())
+                .build();
+    }
+
+    private static Map<String, String> buildData(
+            String type,
+            String title,
+            String body,
+            Map<String, String> extraData
+    ) {
+        Map<String, String> data = new HashMap<>();
+        data.put("type", type);
+        data.put("title", title);
+        data.put("body", body);
+
+        if (extraData != null && !extraData.isEmpty()) {
+            data.putAll(extraData);
+        }
+
+        return data;
+    }
+}

--- a/src/main/java/com/kustacks/kuring/user/application/service/UserCommandService.java
+++ b/src/main/java/com/kustacks/kuring/user/application/service/UserCommandService.java
@@ -5,7 +5,6 @@ import com.kustacks.kuring.common.annotation.UseCase;
 import com.kustacks.kuring.common.exception.InvalidStateException;
 import com.kustacks.kuring.common.exception.NotFoundException;
 import com.kustacks.kuring.common.exception.code.ErrorCode;
-import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.common.utils.generator.NicknameGenerator;
 import com.kustacks.kuring.message.application.service.exception.FirebaseSubscribeException;
 import com.kustacks.kuring.message.application.service.exception.FirebaseUnSubscribeException;
@@ -56,7 +55,6 @@ class UserCommandService implements UserCommandUseCase {
     private final RootUserCommandPort rootUserCommandPort;
     private final RootUserQueryPort rootUserQueryPort;
     private final UserEventPort userEventPort;
-    private final ServerProperties serverProperties;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -378,12 +376,10 @@ class UserCommandService implements UserCommandUseCase {
     private void editAcademicEventNotificationEnabled(String userToken, boolean enabled) {
         if (enabled) {
             // 알림 활성화 -> 토픽 구독
-            userEventPort.subscribeEvent(userToken,
-                    serverProperties.ifDevThenAddSuffix(ACADEMIC_EVENT_TOPIC));
+            userEventPort.subscribeEvent(userToken, ACADEMIC_EVENT_TOPIC);
         } else {
             // 알림 비활성화 -> 토픽 구독 해제
-            userEventPort.unsubscribeEvent(userToken,
-                    serverProperties.ifDevThenAddSuffix(ACADEMIC_EVENT_TOPIC));
+            userEventPort.unsubscribeEvent(userToken, ACADEMIC_EVENT_TOPIC);
         }
     }
 
@@ -392,8 +388,8 @@ class UserCommandService implements UserCommandUseCase {
         if (optionalUser.isEmpty()) {
             User newUser = new User(token);
             optionalUser = Optional.of(userCommandPort.save(newUser));
-            userEventPort.subscribeEvent(token, serverProperties.ifDevThenAddSuffix(ALL_DEVICE_SUBSCRIBED_TOPIC));
-            userEventPort.subscribeEvent(token, serverProperties.ifDevThenAddSuffix(ACADEMIC_EVENT_TOPIC));
+            userEventPort.subscribeEvent(token, ALL_DEVICE_SUBSCRIBED_TOPIC);
+            userEventPort.subscribeEvent(token, ACADEMIC_EVENT_TOPIC);
         }
 
         return optionalUser.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/kustacks/kuring/user/application/service/UserQueryService.java
+++ b/src/main/java/com/kustacks/kuring/user/application/service/UserQueryService.java
@@ -4,7 +4,6 @@ import com.kustacks.kuring.common.annotation.UseCase;
 import com.kustacks.kuring.common.exception.InvalidStateException;
 import com.kustacks.kuring.common.exception.NotFoundException;
 import com.kustacks.kuring.common.exception.code.ErrorCode;
-import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.notice.application.port.out.NoticeQueryPort;
 import com.kustacks.kuring.notice.domain.CategoryName;
 import com.kustacks.kuring.notice.domain.DepartmentName;
@@ -41,8 +40,6 @@ class UserQueryService implements UserQueryUseCase {
     private final RootUserQueryPort rootUserQueryPort;
     private final NoticeQueryPort noticeQueryPort;
     private final UserEventPort userEventPort;
-    private final ServerProperties serverProperties;
-
     @Override
     public List<UserCategoryNameResult> lookupSubscribeCategories(String userToken) {
         User findUser = findUserByToken(userToken);
@@ -107,8 +104,8 @@ class UserQueryService implements UserQueryUseCase {
         Optional<User> optionalUser = userQueryPort.findByToken(token);
         if (optionalUser.isEmpty()) {
             optionalUser = Optional.of(userCommandPort.save(new User(token)));
-            userEventPort.subscribeEvent(token, serverProperties.ifDevThenAddSuffix(ALL_DEVICE_SUBSCRIBED_TOPIC));
-            userEventPort.subscribeEvent(token, serverProperties.ifDevThenAddSuffix(ACADEMIC_EVENT_TOPIC));
+            userEventPort.subscribeEvent(token, ALL_DEVICE_SUBSCRIBED_TOPIC);
+            userEventPort.subscribeEvent(token, ACADEMIC_EVENT_TOPIC);
         }
 
         return optionalUser.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));

--- a/src/test/java/com/kustacks/kuring/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/AdminAcceptanceTest.java
@@ -107,7 +107,7 @@ class AdminAcceptanceTest extends IntegrationTestSupport {
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
-                .body(new TestNotificationRequest("bachelor", "테스트 공지입니다", "1234"))
+                .body(new TestNotificationRequest("bachelor", "테스트 공지입니다", "1234","1234"))
                 .when().post("/api/v2/admin/notices/dev")
                 .then().log().all()
                 .extract();

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
@@ -7,7 +7,6 @@ import com.kustacks.kuring.club.application.port.out.ClubSubscriptionQueryPort;
 import com.kustacks.kuring.club.domain.Club;
 import com.kustacks.kuring.common.exception.InvalidStateException;
 import com.kustacks.kuring.common.exception.code.ErrorCode;
-import com.kustacks.kuring.common.properties.ServerProperties;
 import com.kustacks.kuring.user.application.port.out.RootUserQueryPort;
 import com.kustacks.kuring.user.application.port.out.UserEventPort;
 import com.kustacks.kuring.user.application.port.out.UserQueryPort;
@@ -45,9 +44,6 @@ class ClubCommandServiceTest {
     private ClubQueryPort clubQueryPort;
 
     @Mock
-    private ServerProperties serverProperties;
-
-    @Mock
     private ClubSubscriptionCommandPort clubSubscriptionCommandPort;
 
     @Mock
@@ -80,7 +76,6 @@ class ClubCommandServiceTest {
         User user2 = new User("token-2");
 
         when(club.getId()).thenReturn(1L);
-        when(serverProperties.ifDevThenAddSuffix(anyString())).thenReturn("club.1");
         when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
                 .thenReturn(Optional.of(rootUser));
         when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
@@ -125,7 +120,6 @@ class ClubCommandServiceTest {
         User user1 = new User("token-1");
 
         when(club.getId()).thenReturn(1L);
-        when(serverProperties.ifDevThenAddSuffix(anyString())).thenReturn("club.1");
         when(rootUserQueryPort.findRootUserByEmail("client@konkuk.ac.kr"))
                 .thenReturn(Optional.of(rootUser));
         when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubNotificationServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubNotificationServiceTest.java
@@ -71,12 +71,18 @@ class ClubNotificationServiceTest {
 
         Message sent = captor.getAllValues().get(0); // 1번 ID에 대한 Club 메시지
         String topic = (String) ReflectionTestUtils.getField(sent, "topic");
+        Map<String, Object> apnsPayload = (Map<String, Object>) ReflectionTestUtils.getField(
+                ReflectionTestUtils.getField(sent, "apnsConfig"),
+                "payload"
+        );
 
         Map<String, String> data = (Map<String, String>) ReflectionTestUtils.getField(sent, "data");
         assertAll(
                 () -> assertThat(topic).isEqualTo("club.1.dev"),
                 () -> assertThat(data).containsEntry("clubId", "1"),
-                () -> assertThat(data).containsEntry("messageType", "club")
+                () -> assertThat(data).containsEntry("type", "club"),
+                () -> assertThat(apnsPayload).containsKey("aps"),
+                () -> assertThat((Map<String, Object>) apnsPayload.get("aps")).containsEntry("mutable-content", 1)
         );
     }
 

--- a/src/test/java/com/kustacks/kuring/message/adapter/in/event/MessageAdminEventListenerTest.java
+++ b/src/test/java/com/kustacks/kuring/message/adapter/in/event/MessageAdminEventListenerTest.java
@@ -52,6 +52,7 @@ class MessageAdminEventListenerTest extends IntegrationTestSupport {
         TestNotificationCommand command = new TestNotificationCommand(
                 CategoryName.STUDENT.getName(),
                 "test body",
+                "1234",
                 "test url"
         );
 

--- a/src/test/java/com/kustacks/kuring/message/application/service/FirebaseNotificationServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/message/application/service/FirebaseNotificationServiceTest.java
@@ -1,0 +1,163 @@
+package com.kustacks.kuring.message.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.firebase.messaging.Message;
+import com.kustacks.kuring.common.properties.ServerProperties;
+import com.kustacks.kuring.message.application.port.in.dto.AcademicTestNotificationCommand;
+import com.kustacks.kuring.message.application.port.in.dto.AdminNotificationCommand;
+import com.kustacks.kuring.message.application.port.in.dto.AdminTestNotificationCommand;
+import com.kustacks.kuring.message.application.port.out.FirebaseMessagingPort;
+import com.kustacks.kuring.notice.domain.Notice;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FirebaseNotificationService")
+class FirebaseNotificationServiceTest {
+
+    @InjectMocks
+    private FirebaseNotificationService service;
+
+    @Mock
+    private FirebaseMessagingPort firebaseMessagingPort;
+
+    @Mock
+    private ServerProperties serverProperties;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @DisplayName("관리자 알림은 type과 mutable-content를 포함한다")
+    @Test
+    void should_include_type_and_mutable_content_for_admin_notification() throws Exception {
+        when(serverProperties.ifDevThenAddSuffix("allDevice")).thenReturn("allDevice.dev");
+
+        service.sendNotificationByAdmin(new AdminNotificationCommand("점검", "오늘 점검이 있습니다.", "https://kuring.com"));
+
+        Message sent = captureSentMessage();
+        Map<String, String> data = getData(sent);
+
+        assertAll(
+                () -> assertThat(getTopic(sent)).isEqualTo("allDevice.dev"),
+                () -> assertThat(data).containsEntry("type", "admin"),
+                () -> assertThat(data).containsEntry("title", "점검"),
+                () -> assertThat(data).containsEntry("body", "오늘 점검이 있습니다."),
+                () -> assertThat(data).containsEntry("url", "https://kuring.com"),
+                () -> assertThat(getAps(sent)).containsEntry("mutable-content", 1)
+        );
+    }
+
+    @DisplayName("테스트 공지 알림은 type과 mutable-content를 포함한다")
+    @Test
+    void should_include_type_and_mutable_content_for_test_notice_notification() throws Exception {
+        when(serverProperties.addDevSuffix("student")).thenReturn("student.dev");
+
+        service.sendTestNotificationByAdmin(new AdminTestNotificationCommand(
+                "1234",
+                "2026-03-17 12:00:00",
+                "student",
+                "테스트 공지입니다.",
+                "학생",
+                "https://kuring.com/notices/1234"
+        ));
+
+        Message sent = captureSentMessage();
+        Map<String, String> data = getData(sent);
+
+        assertAll(
+                () -> assertThat(getTopic(sent)).isEqualTo("student.dev"),
+                () -> assertThat(data).containsEntry("type", "notice"),
+                () -> assertThat(data).containsEntry("articleId", "1234"),
+                () -> assertThat(data).containsEntry("category", "student"),
+                () -> assertThat(data).containsEntry("subject", "테스트 공지입니다."),
+                () -> assertThat(getAps(sent)).containsEntry("mutable-content", 1)
+        );
+    }
+
+    @DisplayName("학사일정 테스트 알림은 type과 mutable-content를 포함한다")
+    @Test
+    void should_include_type_and_mutable_content_for_academic_test_notification() throws Exception {
+        when(serverProperties.addDevSuffix("academicEvent")).thenReturn("academicEvent.dev");
+
+        service.sendAcademicTestNotification(new AcademicTestNotificationCommand("개강", "오늘은 개강 일정이 있어요"));
+
+        Message sent = captureSentMessage();
+        Map<String, String> data = getData(sent);
+
+        assertAll(
+                () -> assertThat(getTopic(sent)).isEqualTo("academicEvent.dev"),
+                () -> assertThat(data).containsEntry("type", "academic"),
+                () -> assertThat(data).containsEntry("title", "개강"),
+                () -> assertThat(data).containsEntry("body", "오늘은 개강 일정이 있어요"),
+                () -> assertThat(getAps(sent)).containsEntry("mutable-content", 1)
+        );
+    }
+
+    @DisplayName("자동 공지 알림은 type과 mutable-content를 포함한다")
+    @Test
+    void should_include_type_and_mutable_content_for_notice_notification() throws Exception {
+        Notice notice = mock(Notice.class);
+        when(notice.getId()).thenReturn(1L);
+        when(notice.getArticleId()).thenReturn("1234");
+        when(notice.getPostedDate()).thenReturn("2026-03-17 12:00:00");
+        when(notice.getSubject()).thenReturn("자동 공지입니다.");
+        when(notice.getCategoryName()).thenReturn("student");
+        when(notice.getCategoryKoreaName()).thenReturn("학생");
+        when(notice.getUrl()).thenReturn("https://kuring.com/notices/1234");
+        when(serverProperties.ifDevThenAddSuffix("student")).thenReturn("student.dev");
+
+        service.sendNotifications(List.of(notice));
+
+        Message sent = captureSentMessage();
+        Map<String, String> data = getData(sent);
+
+        assertAll(
+                () -> assertThat(getTopic(sent)).isEqualTo("student.dev"),
+                () -> assertThat(data).containsEntry("type", "notice"),
+                () -> assertThat(data).containsEntry("id", "1"),
+                () -> assertThat(data).containsEntry("articleId", "1234"),
+                () -> assertThat(data).containsEntry("category", "student"),
+                () -> assertThat(getAps(sent)).containsEntry("mutable-content", 1)
+        );
+    }
+
+    private Message captureSentMessage() throws Exception {
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(firebaseMessagingPort).send(captor.capture());
+        return captor.getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> getData(Message sent) {
+        return (Map<String, String>) ReflectionTestUtils.getField(sent, "data");
+    }
+
+    private String getTopic(Message sent) {
+        return (String) ReflectionTestUtils.getField(sent, "topic");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getAps(Message sent) {
+        Map<String, Object> apnsPayload = (Map<String, Object>) ReflectionTestUtils.getField(
+                ReflectionTestUtils.getField(sent, "apnsConfig"),
+                "payload"
+        );
+        return (Map<String, Object>) apnsPayload.get("aps");
+    }
+}

--- a/src/test/java/com/kustacks/kuring/message/application/service/FirebaseNotificationServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/message/application/service/FirebaseNotificationServiceTest.java
@@ -70,6 +70,7 @@ class FirebaseNotificationServiceTest {
 
         service.sendTestNotificationByAdmin(new AdminTestNotificationCommand(
                 "1234",
+                "1234",
                 "2026-03-17 12:00:00",
                 "student",
                 "테스트 공지입니다.",

--- a/src/test/java/com/kustacks/kuring/message/application/service/FirebaseNotificationServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/message/application/service/FirebaseNotificationServiceTest.java
@@ -84,6 +84,7 @@ class FirebaseNotificationServiceTest {
         assertAll(
                 () -> assertThat(getTopic(sent)).isEqualTo("student.dev"),
                 () -> assertThat(data).containsEntry("type", "notice"),
+                () -> assertThat(data).containsEntry("id", "1234"),
                 () -> assertThat(data).containsEntry("articleId", "1234"),
                 () -> assertThat(data).containsEntry("category", "student"),
                 () -> assertThat(data).containsEntry("subject", "테스트 공지입니다."),


### PR DESCRIPTION
### 이슈
  - #360 
  - #361 
  - #362 

###   📌 요약
  - 알림 payload의 분류 키를 `messageType`에서 `type`으로 통합했습니다.
  - iOS Notification Service Extension 대응을 위해 APNs `mutable-content`를 추가했습니다.
  - 구독 시 topic suffix가 중복 적용될 수 있던 흐름을 정리했습니다.
  - 테스트 공지 알림이 실제 공지와 동일한 식별자 구조를 갖도록 `noticeId`를 반영했습니다.

###   🛠️ 상세
  - 알림 payload 정리
    - `messageType`을 제거하고 `type`으로 통일했습니다.
    - `MessageType` 기준으로 알림 종류 값을 관리하도록 정리했습니다.
    - 테스트 공지 알림에서도 `id`와 `articleId`를 구분하도록 `noticeId`를 추가했습니다.

  - Firebase 메시지 공통화
    - `FirebaseMessageFactory`를 도입해 공통 message 조립 로직을 정리했습니다.
    - 공통 data payload(`type`, `title`, `body`)와 APNs 설정을 한 곳에서 생성하도록 변경했습니다.

  - iOS NSE 대응
    - 모든 알림 메시지에 APNs `mutable-content`를 추가했습니다.
    - iOS NSE가 알림을 인터셉트할 수 있는 형태로 payload를 맞췄습니다.
    - FCM에서 iOS 유저 대상으로만 자동으로 적용됩니다.

  - 구독 토픽 suffix 정리
    - 상위 서비스/필터는 raw topic만 넘기도록 수정했습니다.
    - 최종 suffix 적용은 `FirebaseSubscribeService`에서만 처리하도록 정리했습니다.
    - `.dev.dev`가 될 수 있던 구독 흐름을 제거했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **리팩토링**
  * 알림 메시지 생성 로직을 중앙 팩토리로 통합하여 일관성 및 APNs 설정(mutable-content) 적용 통합
  * 환경별 토픽 처리 단순화로 설정 의존도 축소

* **새로운 기능**
  * 관리자/테스트 알림에 공지 식별자(noticeId) 지원 추가

* **테스트**
  * Firebase 메시지 데이터 및 APNs mutable-content 검증용 단위/통합 테스트 추가 및 기존 테스트 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->