### PR TITLE
Fix: 동아리 구독, 구독 해제 시 리턴값 오류 수정

### DIFF
--- a/src/main/java/com/kustacks/kuring/club/application/service/ClubCommandService.java
+++ b/src/main/java/com/kustacks/kuring/club/application/service/ClubCommandService.java
@@ -44,7 +44,7 @@ public class ClubCommandService implements ClubSubscriptionUseCase {
         clubSubscriptionCommandPort.saveSubscription(rootUser, club);
         subscribeAllLoggedInDevices(rootUser.getId(), makeTopic(club));
 
-        return clubSubscriptionQueryPort.countSubscriptions(rootUser.getId());
+        return clubSubscriptionQueryPort.countSubscribers(club.getId());
     }
 
     @Override
@@ -58,7 +58,7 @@ public class ClubCommandService implements ClubSubscriptionUseCase {
         clubSubscriptionCommandPort.deleteSubscription(rootUser, club);
         unsubscribeAllLoggedInDevices(rootUser.getId(), makeTopic(club));
 
-        return clubSubscriptionQueryPort.countSubscriptions(rootUser.getId());
+        return clubSubscriptionQueryPort.countSubscribers(club.getId());
     }
 
     private boolean isAlreadySubscription(RootUser rootUser, Club club) {

--- a/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/UserAcceptanceTest.java
@@ -536,6 +536,31 @@ class UserAcceptanceTest extends IntegrationTestSupport {
         동아리_구독_제거_성공_응답_확인(response, 0L);
     }
 
+    @DisplayName("[v2] 서로 다른 동아리를 구독해도 응답 카운트는 각 동아리 기준으로 반환한다")
+    @Test
+    void add_club_subscription_returns_updated_count_for_each_club() {
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        var firstResponse = 동아리_구독_추가_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID);
+        var secondResponse = 동아리_구독_추가_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID_2);
+
+        동아리_구독_추가_성공_응답_확인(firstResponse, 1L);
+        동아리_구독_추가_성공_응답_확인(secondResponse, 1L);
+    }
+
+    @DisplayName("[v2] 특정 동아리 구독을 취소하면 해당 동아리의 최신 구독자 수를 반환한다")
+    @Test
+    void remove_club_subscription_returns_updated_count_for_target_club() {
+        String accessToken = 사용자_로그인_되어_있음(USER_FCM_TOKEN, USER_EMAIL, USER_PASSWORD);
+
+        동아리_구독_추가_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID);
+        동아리_구독_추가_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID_2);
+
+        var response = 동아리_구독_제거_요청(USER_FCM_TOKEN, accessToken, TEST_CLUB_ID);
+
+        동아리_구독_제거_성공_응답_확인(response, 0L);
+    }
+
     @DisplayName("[v2] 구독하지 않은 동아리 취소는 실패한다")
     @Test
     void remove_club_subscription_fail_when_not_subscribed() {

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubCommandServiceTest.java
@@ -80,7 +80,7 @@ class ClubCommandServiceTest {
                 .thenReturn(Optional.of(rootUser));
         when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
         when(userQueryPort.findByLoggedInUserId(1L)).thenReturn(List.of(user1, user2));
-        when(clubSubscriptionQueryPort.countSubscriptions(1L)).thenReturn(1L);
+        when(clubSubscriptionQueryPort.countSubscribers(1L)).thenReturn(1L);
 
         //when
         long count = service.addSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L));
@@ -89,7 +89,8 @@ class ClubCommandServiceTest {
         assertAll(
                 () -> assertThat(count).isEqualTo(1L),
                 () -> verify(userEventPort).subscribeEvent("token-1", "club.1"),
-                () -> verify(userEventPort).subscribeEvent("token-2", "club.1")
+                () -> verify(userEventPort).subscribeEvent("token-2", "club.1"),
+                () -> verify(clubSubscriptionQueryPort).countSubscribers(1L)
         );
     }
 
@@ -125,6 +126,7 @@ class ClubCommandServiceTest {
         when(clubQueryPort.findClubById(1L)).thenReturn(Optional.of(club));
         when(clubSubscriptionQueryPort.existsSubscription(1L, club.getId())).thenReturn(Boolean.TRUE);
         when(userQueryPort.findByLoggedInUserId(1L)).thenReturn(List.of(user1));
+        when(clubSubscriptionQueryPort.countSubscribers(1L)).thenReturn(0L);
 
         //when
         long count = service.removeSubscription(new ClubSubscriptionCommand("client@konkuk.ac.kr", 1L));
@@ -132,7 +134,8 @@ class ClubCommandServiceTest {
         //then
         assertAll(
                 () -> assertThat(count).isEqualTo(0L),
-                () -> verify(userEventPort).unsubscribeEvent("token-1", "club.1")
+                () -> verify(userEventPort).unsubscribeEvent("token-1", "club.1"),
+                () -> verify(clubSubscriptionQueryPort).countSubscribers(1L)
         );
     }
 


### PR DESCRIPTION
##  📌 요약
  - 동아리 구독 추가/삭제 응답 간 동아리 id대신 사용자 id가 들어가서 잘못 조회되는 현상을 수정했습니다.
  - 이제 요청한 대상 동아리의 최신 구독자 수를 응답하도록 변경했습니다.
  - 관련 단위 테스트와 인수 테스트를 보강했습니다.

## 🛠️ 상세
  - `ClubCommandService`에서 구독 추가/삭제 후 `countSubscriptions(rootUserId)` 대신 `countSubscribers(clubId)`를 반환하도록 수정했습니다.
  - 동아리 구독 응답이 서로 다른 동아리 간에도 각 동아리 기준 카운트를 반환하는 시나리오를 검증하도록 테스트를 추가했습니다.
  - 구독 취소 시에도 대상 동아리의 최신 구독자 수가 반환되는지 확인하는 테스트를 추가했습니다.

##   💬 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 클럽 구독자 수 계산 로직을 개선하여 각 클럽별 구독자 수를 정확하게 추적하도록 수정했습니다.

* **테스트**
  * 클럽 구독 및 구독 해제 시 정확한 구독자 수 반영을 검증하는 테스트 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->