### PR TITLE
Fix: CodeDeploy 로그 출력 경로 명시

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,6 +3,7 @@
 PROJECT_ROOT="/home/ec2-user/app"
 JAR_FILE="$PROJECT_ROOT/spring-webapp.jar"
 DEPLOY_LOG="$PROJECT_ROOT/deploy.log"
+APP_LOG="$PROJECT_ROOT/application.log"
 
 TIME_NOW=$(date +%c)
 
@@ -18,7 +19,7 @@ cd $PROJECT_ROOT
 # jar 파일 실행
 chmod 755 $JAR_FILE
 echo "$TIME_NOW > $JAR_FILE 파일 실행" >> $DEPLOY_LOG
-nohup java -jar -Dspring.profiles.active=prod -Xms256m -Xmx256m $JAR_FILE &
+nohup java -jar -Dspring.profiles.active=prod -Xms256m -Xmx256m $JAR_FILE > "$APP_LOG" 2>&1 < /dev/null &
 
 CURRENT_PID=$(pgrep -f $JAR_FILE)
 echo "$TIME_NOW > 실행된 프로세스 아이디 $CURRENT_PID 입니다." >> $DEPLOY_LOG


### PR DESCRIPTION
## #️⃣ 이슈

- #289 CodeDeploy 배포 후 애플리케이션 로그 위치 명시화

## 📌 요약

- 배포 스크립트에서 애플리케이션 stdout/stderr 출력 파일을 명시적으로 지정했습니다.
- 배포 후 런타임 로그가 기본 nohup.out에 암묵적으로 쌓이던 상태를 application.log로 고정해 운영 중 로그 확인 경로를 분명히 했습니다.

## 🛠️ 상세

- scripts/start.sh에 APP_LOG=/home/ec2-user/app/application.log 변수를 추가했습니다.
- nohup java -jar ... 실행 시 stdout/stderr를 application.log로 리다이렉트하도록 변경했습니다.
- deploy.log는 배포 단계 로그로 유지하고, 애플리케이션 실행 로그는 별도 파일로 분리했습니다.

## 💬 기타

- 테스트는 실행하지 않았습니다. 쉘 스크립트 변경만 포함됩니다.
- 이 변경은 로그 출력 위치를 명시적으로 고정하는 수정입니다. CodeDeploy 실패 원인 자체를 직접 해결하는지 여부는 배포 환경 로그로 추가 확인이 필요합니다.
- 기존 nohup.out 대신 application.log를 확인해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 애플리케이션 시작 시 표준 출력과 오류를 `application.log` 파일로 리다이렉트하도록 업데이트했습니다. 이를 통해 애플리케이션 로그가 파일에 저장되어 더욱 체계적인 로그 관리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->