### PR TITLE
Feat: building 도메인 분리 및 club 위치 참조 전환

### DIFF
--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingRepository.java
@@ -1,0 +1,7 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.domain.Building;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BuildingRepository extends JpaRepository<Building, Long> {
+}

--- a/src/main/java/com/kustacks/kuring/building/domain/Building.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/Building.java
@@ -1,0 +1,35 @@
+package com.kustacks.kuring.building.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "building")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Building {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 30, nullable = false)
+    private String name;
+
+    private Double lat;
+
+    private Double lon;
+
+    public Building(String name, Double lat, Double lon) {
+        this.name = name;
+        this.lat = lat;
+        this.lon = lon;
+    }
+}

--- a/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubQueryRepositoryImpl.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.kustacks.kuring.building.domain.QBuilding.building;
 import static com.kustacks.kuring.club.domain.QClub.club;
 import static com.kustacks.kuring.club.domain.QClubSns.clubSns;
 
@@ -91,7 +92,6 @@ class ClubQueryRepositoryImpl implements ClubQueryRepository {
     @Override
     @Transactional(readOnly = true)
     public Optional<ClubDetailReadModel> findClubDetailById(Long id) {
-
         List<Tuple> tuples = queryFactory
                 .select(
                         club.id,
@@ -106,14 +106,15 @@ class ClubQueryRepositoryImpl implements ClubQueryRepository {
                         club.isAlways,
                         club.applyUrl,
                         club.posterImagePath,
-                        club.building,
+                        building.name,
                         club.room,
-                        club.lon,
-                        club.lat,
+                        building.lon,
+                        building.lat,
                         clubSns.type,
                         clubSns.url
                 )
                 .from(club)
+                .leftJoin(club.building, building)
                 .leftJoin(club.homepageUrls, clubSns)
                 .where(club.id.eq(id))
                 .fetch();
@@ -158,10 +159,10 @@ class ClubQueryRepositoryImpl implements ClubQueryRepository {
                         first.get(club.isAlways),
                         first.get(club.applyUrl),
                         first.get(club.posterImagePath),
-                        first.get(club.building),
+                        first.get(building.name),
                         first.get(club.room),
-                        first.get(club.lon),
-                        first.get(club.lat)
+                        first.get(building.lon),
+                        first.get(building.lat)
                 )
         );
     }

--- a/src/main/java/com/kustacks/kuring/club/domain/Club.java
+++ b/src/main/java/com/kustacks/kuring/club/domain/Club.java
@@ -1,13 +1,17 @@
 package com.kustacks.kuring.club.domain;
 
+import com.kustacks.kuring.building.domain.Building;
 import jakarta.persistence.Column;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -54,15 +58,12 @@ public class Club {
     @Column(name = "icon_image_path", length = 255)
     private String iconImagePath;
 
-    @Column(length = 30)
-    private String building;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id")
+    private Building building;
 
     @Column(length = 30)
     private String room;
-
-    private Double lat;
-
-    private Double lon;
 
     @Column(name = "recruit_start_at")
     private LocalDateTime recruitStartAt;

--- a/src/main/resources/db/migration/V260412__Create_building_and_backfill_club.sql
+++ b/src/main/resources/db/migration/V260412__Create_building_and_backfill_club.sql
@@ -1,0 +1,18 @@
+-- building 마스터 테이블 생성
+CREATE TABLE building
+(
+    id   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(30) NOT NULL,
+    lat  DOUBLE,
+    lon  DOUBLE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+-- club이 building을 참조할 수 있도록 FK 컬럼 추가
+ALTER TABLE club
+    ADD COLUMN building_id BIGINT NULL;
+
+ALTER TABLE club
+    ADD CONSTRAINT fk_club_building
+        FOREIGN KEY (building_id) REFERENCES building (id);

--- a/src/main/resources/db/migration/V260412__Create_building_and_backfill_club.sql
+++ b/src/main/resources/db/migration/V260412__Create_building_and_backfill_club.sql
@@ -4,7 +4,8 @@ CREATE TABLE building
     id   BIGINT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(30) NOT NULL,
     lat  DOUBLE,
-    lon  DOUBLE
+    lon  DOUBLE,
+    CONSTRAINT uk_building_name UNIQUE (name)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci;

--- a/src/test/java/com/kustacks/kuring/building/domain/BuildingTest.java
+++ b/src/test/java/com/kustacks/kuring/building/domain/BuildingTest.java
@@ -1,0 +1,30 @@
+package com.kustacks.kuring.building.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("도메인 : Building")
+class BuildingTest {
+
+    @Test
+    @DisplayName("Building을 생성할 수 있다")
+    void create_building() {
+        // given
+        String name = "공학관";
+        Double lat = 37.5401;
+        Double lon = 127.0784;
+
+        // when
+        Building building = new Building(name, lat, lon);
+
+        // then
+        assertAll(
+                () -> assertThat(building.getName()).isEqualTo(name),
+                () -> assertThat(building.getLat()).isEqualTo(lat),
+                () -> assertThat(building.getLon()).isEqualTo(lon)
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈
Closes #372

## 📌 요약
- building 도메인을 추가하고 club이 building_id로 참조하도록 전환합니다.
- club 상세 조회가 building join 기반으로 위치 정보를 읽도록 변경합니다.
- building 관련 도메인 테스트를 추가하고 given-when-then 스타일로 정리했습니다.

## 🛠️ 상세
- building 엔티티와 repository를 추가했습니다.
- Club 엔티티에서 building_id 기반 연관관계를 사용하도록 변경했습니다.
- ClubQueryRepositoryImpl 상세 조회를 building join 기반으로 전환했습니다.
- expand 단계 migration만 포함했습니다.
- backfill, old schema drop, facility 관련 작업은 이번 PR 범위에서 제외했습니다.

## 💬 기타
- backfill은 별도 운영 SQL로 수행할 예정입니다.
- old schema drop은 후속 브랜치와 배포 단계에서 진행합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 건물 정보 관리 기능이 추가되었습니다.
  * 건물명, 위도, 경도 정보를 별도로 저장할 수 있습니다.

* **개선**
  * 데이터베이스 구조가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->