### PR TITLE
Chore: Renovate와 CI Canary 설정 추가

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,67 @@
+name: CI Canary
+
+# 이 워크플로는 Github Actions에서 CI/CD 과정 수행 전에 조기에 문제를 감지하기 위한 용도다.
+on:
+  workflow_dispatch:
+  schedule:
+    # 매주 월요일 오전 9시 (KST)
+    - cron: '0 0 * * 1'
+
+env:
+  GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+jobs:
+  canary:
+    name: Run tests on ubuntu-latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Decrypt secrets
+        id: decrypt
+        run: sh .github/workflows/decrypt.sh
+
+      - name: Run test task
+        id: test_task
+        run: ./gradlew test --info
+
+      - name: Notify Discord on failure
+        id: notify
+        if: failure()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SHORT_SHA="$(printf '%s' "${GITHUB_SHA}" | cut -c1-7)"
+          FAILED_STEP="unknown"
+
+          if [ "${{ steps.decrypt.outcome }}" = "failure" ]; then
+            FAILED_STEP="Decrypt secrets"
+          elif [ "${{ steps.test_task.outcome }}" = "failure" ]; then
+            FAILED_STEP="Run test task"
+          fi
+
+          MESSAGE="$(
+            printf '%s\n' \
+              'CI Canary failed' \
+              '- Repo: ${{ github.repository }}' \
+              '- Ref: ${{ github.ref_name }}' \
+              '- Trigger: ${{ github.event_name }}' \
+              '- Actor: ${{ github.actor }}' \
+              "- Failed step: ${FAILED_STEP}" \
+              "- Commit: ${SHORT_SHA}" \
+              "- Run: ${RUN_URL}"
+          )"
+
+          PAYLOAD="$(MESSAGE="${MESSAGE}" python3 -c 'import json, os; print(json.dumps({"content": os.environ["MESSAGE"]}))')"
+          curl \
+            -H "Content-Type: application/json" \
+            -d "${PAYLOAD}" \
+            "$DISCORD_WEBHOOK_URL"

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "baseBranchPatterns": ["develop"],
   "enabledManagers": ["gradle", "gradle-wrapper", "github-actions"],
   "dependencyDashboard": true,
+  "vulnerabilityAlerts": true,
   "prConcurrentLimit": 2,
   "prHourlyLimit": 1,
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranchPatterns": ["develop"],
+  "enabledManagers": ["gradle", "gradle-wrapper", "github-actions"],
+  "dependencyDashboard": true,
+  "prConcurrentLimit": 2,
+  "prHourlyLimit": 1,
+  "packageRules": [
+    {
+      "description": "아래에서 명시적으로 다시 허용한 항목 외에는 일반 Gradle 의존성 업데이트를 비활성화한다.",
+      "matchManagers": ["gradle"],
+      "enabled": false
+    },
+    {
+      "description": "Gradle wrapper와 GitHub Actions는 major가 아닌 업데이트를 무시한다.",
+      "matchManagers": ["gradle-wrapper", "github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "enabled": false
+    },
+    {
+      "description": "Spring Boot는 major 업데이트만 허용한다.",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["org.springframework.boot"],
+      "matchUpdateTypes": ["major"],
+      "enabled": true,
+      "groupName": "spring-boot-major"
+    },
+    {
+      "description": "Testcontainers는 major 업데이트만 허용한다.",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["/^org\\.testcontainers:/"],
+      "matchUpdateTypes": ["major"],
+      "enabled": true,
+      "groupName": "testcontainers-major"
+    },
+    {
+      "description": "Gradle wrapper는 major 업데이트만 허용한다.",
+      "matchManagers": ["gradle-wrapper"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "gradle-wrapper-major"
+    },
+    {
+      "description": "GitHub Actions는 major 업데이트만 허용한다.",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "github-actions-major"
+    }
+  ]
+}


### PR DESCRIPTION
## #️⃣ 이슈
- #375

## 📌 요약
- Renovate major 업데이트 정책 파일을 추가합니다.
- ubuntu-latest 기반 CI Canary 워크플로를 추가합니다.
- canary 실패 시 Discord 알림을 멀티라인 요약으로 전송하도록 구성합니다.

## 🛠️ 상세
- `renovate.json` 추가
  - base branch를 `develop`으로 지정
  - `gradle`, `gradle-wrapper`, `github-actions`만 활성화
  - Spring Boot, Testcontainers, Gradle wrapper, GitHub Actions의 major 업데이트만 허용
  - Dependency Dashboard 활성화
  - 동시 open PR 2개, 시간당 PR 1개로 제한
- `.github/workflows/canary.yml` 추가
  - 매주 월요일 오전 9시(KST) 및 수동 실행 지원
  - `ubuntu-latest`에서 `./gradlew test --info` 수행
  - Firebase 리소스 파일 복호화 step 포함
  - 실패 시 Discord webhook으로 저장소/브랜치/트리거/실패 단계/run URL 요약 전송
- 설명성 주석과 Renovate rule description을 한국어로 정리

## 💬 기타
- `renovate.json` JSON 파싱과 `canary.yml` YAML 파싱을 확인했습니다.
- 로컬 `./gradlew test --info`는 Firebase 리소스 파일 부재로 다수 테스트가 실패해 전체 통과를 확인하지 못했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 프로젝트 의존성 자동관리(Renovate)가 도입되어 주요 라이브러리·빌드 도구·액션의 업데이트를 체계적으로 처리합니다.
  * 정기 및 수동 트리거되는 캔러리 CI 파이프라인이 추가되어 자동 테스트가 정기 실행되며, 실패 시 Discord 알림으로 빠르게 통보됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->