### PR TITLE
Chore: club legacy 위치 컬럼 제거

### DIFF
--- a/src/main/resources/db/migration/V260521__Drop_club_legacy_location_columns.sql
+++ b/src/main/resources/db/migration/V260521__Drop_club_legacy_location_columns.sql
@@ -1,0 +1,5 @@
+-- club 상세 위치 조회가 building_id 참조로 전환되고 backfill이 완료된 후 legacy 위치 컬럼을 제거한다.
+ALTER TABLE club
+    DROP COLUMN IF EXISTS building,
+    DROP COLUMN IF EXISTS lat,
+    DROP COLUMN IF EXISTS lon;


### PR DESCRIPTION
## #️⃣ 이슈

- #372

## 📌 요약

- building backfill 완료 이후 더 이상 사용하지 않는 club legacy 위치 컬럼을 제거합니다.

## 🛠️ 상세

- Flyway migration을 추가해 club.building, club.lat, club.lon 컬럼을 제거합니다.
- 환경별 스키마 차이를 고려해 DROP COLUMN IF EXISTS를 사용합니다.
- club.room과 building.name/lat/lon은 유지합니다.
- place, facility, 건물 부속시설 모델링은 포함하지 않습니다.

## 💬 기타

- dev/main 상세 조회 smoke 확인: club id 1~5 응답 정상
- 관련 테스트 통과: ClubQueryServiceTest, BuildingTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 클럽 데이터베이스 스키마 최적화: 레거시 위치 정보 저장 방식을 정리하여 데이터베이스 효율성을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ku-ring/ku-ring-backend-web/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->