### PR TITLE
[fix]: 동아리 목록 조회 api 응답에 recruitmentStatus 필드 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/club/adapter/out/persistence/ClubQueryRepositoryImpl.java
@@ -60,7 +60,8 @@ class ClubQueryRepositoryImpl implements ClubQueryRepository {
                         club.category,
                         club.division,
                         club.recruitStartAt,
-                        club.recruitEndAt
+                        club.recruitEndAt,
+                        club.isAlways
                 ))
                 .from(club)
                 .where(
@@ -82,7 +83,8 @@ class ClubQueryRepositoryImpl implements ClubQueryRepository {
                         club.category,
                         club.division,
                         club.recruitStartAt,
-                        club.recruitEndAt
+                        club.recruitEndAt,
+                        club.isAlways
                 ))
                 .from(club)
                 .where(club.id.in(ids))

--- a/src/main/java/com/kustacks/kuring/club/application/port/in/dto/ClubItemResult.java
+++ b/src/main/java/com/kustacks/kuring/club/application/port/in/dto/ClubItemResult.java
@@ -12,6 +12,7 @@ public record ClubItemResult(
         boolean isSubscribed,
         Long subscriberCount,
         LocalDateTime recruitStartDate,
-        LocalDateTime recruitEndDate
+        LocalDateTime recruitEndDate,
+        String recruitmentStatus
 ) {
 }

--- a/src/main/java/com/kustacks/kuring/club/application/port/out/dto/ClubReadModel.java
+++ b/src/main/java/com/kustacks/kuring/club/application/port/out/dto/ClubReadModel.java
@@ -18,6 +18,7 @@ public class ClubReadModel {
     private final ClubDivision division;
     private final LocalDateTime recruitStartDate;
     private final LocalDateTime recruitEndDate;
+    private final Boolean isAlways;
 
     @QueryProjection
     public ClubReadModel(
@@ -28,7 +29,8 @@ public class ClubReadModel {
             ClubCategory category,
             ClubDivision division,
             LocalDateTime recruitStartDate,
-            LocalDateTime recruitEndDate
+            LocalDateTime recruitEndDate,
+            Boolean isAlways
     ) {
         this.id = id;
         this.name = name;
@@ -38,5 +40,6 @@ public class ClubReadModel {
         this.division = division;
         this.recruitStartDate = recruitStartDate;
         this.recruitEndDate = recruitEndDate;
+        this.isAlways = isAlways;
     }
 }

--- a/src/main/java/com/kustacks/kuring/club/application/service/ClubQueryService.java
+++ b/src/main/java/com/kustacks/kuring/club/application/service/ClubQueryService.java
@@ -166,6 +166,14 @@ public class ClubQueryService implements ClubQueryUseCase {
             iconImageUrl = storagePort.getPresignedUrl(iconImagePath);
         }
 
+        ClubRecruitmentStatus recruitmentStatus = ClubRecruitmentStatus.from(
+                clubReadModel.getRecruitStartDate(),
+                clubReadModel.getRecruitEndDate(),
+                clubReadModel.getIsAlways(),
+                LocalDateTime.now()
+        );
+
+
         return new ClubItemResult(
                 clubReadModel.getId(),
                 clubReadModel.getName(),
@@ -176,7 +184,8 @@ public class ClubQueryService implements ClubQueryUseCase {
                 isSubscribed,
                 subscriberCount,
                 clubReadModel.getRecruitStartDate(),
-                clubReadModel.getRecruitEndDate()
+                clubReadModel.getRecruitEndDate(),
+                recruitmentStatus.getValue()
         );
     }
 

--- a/src/main/java/com/kustacks/kuring/club/application/service/ClubQueryService.java
+++ b/src/main/java/com/kustacks/kuring/club/application/service/ClubQueryService.java
@@ -77,7 +77,8 @@ public class ClubQueryService implements ClubQueryUseCase {
 
         Map<Long, Boolean> subscribedMap = getSubscribedMap(clubIds, rootUser);
 
-        List<ClubItemResult> clubItemResults = toClubItemResults(clubReadModels, subscribedMap, subscriberCountMap);
+        LocalDateTime now = LocalDateTime.now();
+        List<ClubItemResult> clubItemResults = toClubItemResults(clubReadModels, subscribedMap, subscriberCountMap, now);
 
         return new ClubListResult(clubItemResults);
     }
@@ -129,7 +130,8 @@ public class ClubQueryService implements ClubQueryUseCase {
 
         Map<Long, Long> subscriberCountMap = clubSubscriptionQueryPort.countSubscribersByClubIds(subscribedClubIds);
 
-        List<ClubItemResult> clubItemResults = toSubscribedClubItemResults(clubReadModels, subscriberCountMap);
+        LocalDateTime now = LocalDateTime.now();
+        List<ClubItemResult> clubItemResults = toSubscribedClubItemResults(clubReadModels, subscriberCountMap, now);
 
         return new ClubListResult(clubItemResults);
     }
@@ -156,7 +158,8 @@ public class ClubQueryService implements ClubQueryUseCase {
     private ClubItemResult convertClubItemResult(
             ClubReadModel clubReadModel,
             boolean isSubscribed,
-            Long subscriberCount
+            Long subscriberCount,
+            LocalDateTime now
     ) {
 
         String iconImageUrl = null;
@@ -170,7 +173,7 @@ public class ClubQueryService implements ClubQueryUseCase {
                 clubReadModel.getRecruitStartDate(),
                 clubReadModel.getRecruitEndDate(),
                 clubReadModel.getIsAlways(),
-                LocalDateTime.now()
+                now
         );
 
 
@@ -237,26 +240,30 @@ public class ClubQueryService implements ClubQueryUseCase {
     private List<ClubItemResult> toClubItemResults(
             List<ClubReadModel> clubReadModels,
             Map<Long, Boolean> subscribedMap,
-            Map<Long, Long> subscriberCountMap
+            Map<Long, Long> subscriberCountMap,
+            LocalDateTime now
     ) {
         return clubReadModels.stream()
                 .map(r -> convertClubItemResult(
                         r,
                         subscribedMap.getOrDefault(r.getId(), false),
-                        subscriberCountMap.getOrDefault(r.getId(), 0L)
+                        subscriberCountMap.getOrDefault(r.getId(), 0L),
+                        now
                 ))
                 .toList();
     }
 
     private List<ClubItemResult> toSubscribedClubItemResults(
             List<ClubReadModel> clubReadModels,
-            Map<Long, Long> subscriberCountMap
+            Map<Long, Long> subscriberCountMap,
+            LocalDateTime now
     ) {
         return clubReadModels.stream()
                 .map(r -> convertClubItemResult(
                         r,
                         true,
-                        subscriberCountMap.getOrDefault(r.getId(), 0L)
+                        subscriberCountMap.getOrDefault(r.getId(), 0L),
+                        now
                 ))
                 .toList();
     }

--- a/src/test/java/com/kustacks/kuring/acceptance/ClubStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/ClubStep.java
@@ -50,7 +50,8 @@ public class ClubStep {
                 () -> assertThat(response.jsonPath().getString("data.clubs[0].category")).isNotBlank(),
                 () -> assertThat(response.jsonPath().getString("data.clubs[0].division")).isNotBlank(),
                 () -> assertThat(response.jsonPath().getBoolean("data.clubs[0].isSubscribed")).isInstanceOf(Boolean.class),
-                () -> assertThat(response.jsonPath().getLong("data.clubs[0].subscriberCount")).isGreaterThanOrEqualTo(0)
+                () -> assertThat(response.jsonPath().getLong("data.clubs[0].subscriberCount")).isGreaterThanOrEqualTo(0),
+                () -> assertThat(response.jsonPath().getString("data.clubs[0].recruitmentStatus")).isNotBlank()
         );
     }
 

--- a/src/test/java/com/kustacks/kuring/club/application/service/ClubQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/club/application/service/ClubQueryServiceTest.java
@@ -73,7 +73,8 @@ class ClubQueryServiceTest {
                             ClubCategory.ACADEMIC,
                             ClubDivision.CENTRAL,
                             LocalDateTime.of(2026, 3, 1, 0, 0),
-                            LocalDateTime.of(2026, 3, 31, 23, 59)
+                            LocalDateTime.of(2026, 3, 31, 23, 59),
+                            false
                     ),
                     new ClubReadModel(
                             2L,
@@ -83,7 +84,8 @@ class ClubQueryServiceTest {
                             ClubCategory.ACADEMIC,
                             ClubDivision.ENGINEERING,
                             LocalDateTime.of(2026, 3, 1, 0, 0),
-                            LocalDateTime.of(2026, 3, 31, 23, 59)
+                            LocalDateTime.of(2026, 3, 31, 23, 59),
+                            false
                     ),
                     new ClubReadModel(
                             3L,
@@ -93,7 +95,8 @@ class ClubQueryServiceTest {
                             ClubCategory.CULTURE_ART,
                             ClubDivision.ENGINEERING,
                             LocalDateTime.of(2026, 2, 10, 0, 0),
-                            LocalDateTime.of(2026, 2, 25, 23, 59)
+                            LocalDateTime.of(2026, 2, 25, 23, 59),
+                            false
                     )
             );
 
@@ -163,6 +166,7 @@ class ClubQueryServiceTest {
         assertThat(result.clubs()).hasSize(3);
         assertThat(result.clubs().get(0).subscriberCount()).isEqualTo(10);
         assertThat(result.clubs().get(0).isSubscribed()).isTrue();
+        assertThat(result.clubs().get(0).recruitmentStatus()).isNotNull();
 
         verify(rootUserQueryPort).findRootUserByEmail(email);
         verify(clubQueryPort).searchClubs(


### PR DESCRIPTION
## #️⃣ 이슈
#383 

## 📌 요약                                                                                                                                                                
- 동아리 목록 조회 API 응답 항목에 recruitmentStatus 필드 추가
- 기존 상세 조회 API에만 있던 모집 상태 정보를 목록에서도 확인할 수 있도록 개선    

## 🛠️ 상세
ClubItemResult                                                                                                                                                     
- ClubRecruitmentStatus 추가
                                                                                                         
ClubQueryService                                                                                                                                                   
- convertClubItemResult()에서 ClubRecruitmentStatus.from()으로 상태 계산 후 .getValue() 호출하여 ClubItemResult 생성                                               
                                                                                                                                                                   
테스트                                                                                                                                                             
- ClubQueryServiceTest: ClubReadModel 픽스처에 누락된 isAlways 파라미터 추가 (컴파일 오류 수정)                                                                    
- ClubQueryServiceTest.getClubs_success(): recruitmentStatus not-null 검증 추가                                                                                    
- ClubStep.동아리_목록_조회_응답_확인(): data.clubs[0].recruitmentStatus not-blank 검증 추가


## 💬 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 동아리 목록 조회 응답에 각 동아리의 모집 상태 정보가 추가되었습니다.

* **Tests**
  * 모집 상태 정보 검증을 위한 테스트 어설션이 강화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ku-ring/ku-ring-backend-web/pull/384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->