### PR TITLE
Fix: dev 배포 SSH timeout 방지

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       # (1) 코드 체크아웃
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # (2) JDK 21 설치
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -68,5 +68,7 @@ jobs:
             echo "[2] 새 JAR 실행"
             cd /home/ubuntu/dev-app
             JAR_FILE=$(ls -t build/libs/*.jar | grep -m1 -v 'plain')
-            source ~/.bash_profile && nohup java -jar "$JAR_FILE" --spring.profiles.active=dev > /home/ubuntu/dev-app.log 2>&1 &
+            source ~/.bash_profile
+            nohup java -jar "$JAR_FILE" --spring.profiles.active=dev > /home/ubuntu/dev-app.log 2>&1 < /dev/null &
+            disown || true
             echo "✅ 개발 서버 재시작 완료!"


### PR DESCRIPTION
## #️⃣ 이슈

## 📌 요약

dev 배포 workflow에서 SSH action이 애플리케이션 재시작 후 종료되지 않아 timeout으로 실패하던 문제를 수정합니다.

## 🛠️ 상세

- `actions/checkout`, `actions/setup-java`를 Node.js 24 런타임 기반의 `v5`로 업데이트했습니다.
- dev 서버 재시작 스크립트에서 `source ~/.bash_profile`과 Java 실행을 분리했습니다.
- `nohup java ... < /dev/null &`와 `disown || true`를 적용해 장시간 실행되는 Spring Boot 프로세스가 SSH 세션을 붙잡지 않도록 했습니다.
- Java 애플리케이션 stdout/stderr는 기존과 동일하게 `/home/ubuntu/dev-app.log`로 기록됩니다.

## 💬 기타

- 검증: `.github/workflows/dev.yml` Ruby YAML 파싱 확인
- 미검증: GitHub Actions dev 배포 workflow 실실행
