### PR TITLE
Feat: 캠퍼스맵 장소 및 운영시간 도메인 구현

### DIFF
--- a/src/main/java/com/kustacks/kuring/building/domain/Building.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/Building.java
@@ -1,20 +1,34 @@
 package com.kustacks.kuring.building.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
 @Table(name = "building")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Building {
+
+    private static final String DEFAULT_ADDRESS = "서울특별시 광진구 능동로 120";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,13 +37,92 @@ public class Building {
     @Column(length = 30, nullable = false)
     private String name;
 
+    @Column(length = 100, nullable = false)
+    private String address;
+
     private Double lat;
 
     private Double lon;
 
+    @Column(name = "image_path")
+    private String imagePath;
+
+    @OneToMany(
+            mappedBy = "building",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    private List<BuildingSearchKeyword> keywords = new ArrayList<>();
+
+    @OneToMany(
+            mappedBy = "building",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    @OrderBy("displayOrder ASC, id ASC")
+    private List<CampusPlace> campusPlaces = new ArrayList<>();
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "building_operating_hours",
+            joinColumns = @JoinColumn(name = "building_id")
+    )
+    private Set<OperatingHours> operatingHours = new HashSet<>();
+
     public Building(String name, Double lat, Double lon) {
+        this(name, DEFAULT_ADDRESS, lat, lon, null);
+    }
+
+    public Building(String name, String address, Double lat, Double lon, String imagePath) {
+        validateRequiredFields(name, address);
+
         this.name = name;
+        this.address = address;
         this.lat = lat;
         this.lon = lon;
+        this.imagePath = imagePath;
+    }
+
+    public void addSearchKeyword(String keyword) {
+        keywords.add(new BuildingSearchKeyword(this, keyword));
+    }
+
+    public void addCampusPlace(CampusPlace campusPlace) {
+        if (campusPlace == null) {
+            throw new IllegalArgumentException("캠퍼스 시설은 필수입니다.");
+        }
+        campusPlaces.add(campusPlace);
+    }
+
+    public void addOperatingHours(OperatingHours hours) {
+        validateOperatingHours(hours);
+        operatingHours.add(hours);
+    }
+
+    private void validateOperatingHours(OperatingHours hours) {
+        if (hours == null) {
+            throw new IllegalArgumentException("운영시간은 필수입니다.");
+        }
+
+        boolean alreadyExists = operatingHours.stream()
+                .anyMatch(existing -> existing.matches(
+                        hours.getPeriod(),
+                        hours.getDayGroup()
+                ));
+
+        if (alreadyExists) {
+            throw new IllegalArgumentException(
+                    "같은 기간과 요일의 운영시간은 중복될 수 없습니다."
+            );
+        }
+    }
+
+    private static void validateRequiredFields(String name, String address) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("건물명은 필수입니다.");
+        }
+        if (address == null || address.isBlank()) {
+            throw new IllegalArgumentException("건물 주소는 필수입니다.");
+        }
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/domain/Building.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/Building.java
@@ -91,6 +91,9 @@ public class Building {
         if (campusPlace == null) {
             throw new IllegalArgumentException("캠퍼스 시설은 필수입니다.");
         }
+        if (campusPlace.getBuilding() != this) {
+            throw new IllegalArgumentException("다른 건물의 캠퍼스 시설은 추가할 수 없습니다.");
+        }
         campusPlaces.add(campusPlace);
     }
 

--- a/src/main/java/com/kustacks/kuring/building/domain/Building.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/Building.java
@@ -1,5 +1,6 @@
 package com.kustacks.kuring.building.domain;
 
+import com.kustacks.kuring.common.exception.code.ErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -89,10 +90,10 @@ public class Building {
 
     public void addCampusPlace(CampusPlace campusPlace) {
         if (campusPlace == null) {
-            throw new IllegalArgumentException("캠퍼스 시설은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_REQUIRED.getMessage());
         }
         if (campusPlace.getBuilding() != this) {
-            throw new IllegalArgumentException("다른 건물의 캠퍼스 시설은 추가할 수 없습니다.");
+            throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_BUILDING_MISMATCH.getMessage());
         }
         campusPlaces.add(campusPlace);
     }
@@ -104,7 +105,7 @@ public class Building {
 
     private void validateOperatingHours(OperatingHours hours) {
         if (hours == null) {
-            throw new IllegalArgumentException("운영시간은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.OPERATING_HOURS_REQUIRED.getMessage());
         }
 
         boolean alreadyExists = operatingHours.stream()
@@ -114,18 +115,16 @@ public class Building {
                 ));
 
         if (alreadyExists) {
-            throw new IllegalArgumentException(
-                    "같은 기간과 요일의 운영시간은 중복될 수 없습니다."
-            );
+            throw new IllegalArgumentException(ErrorCode.OPERATING_HOURS_DUPLICATED.getMessage());
         }
     }
 
     private static void validateRequiredFields(String name, String address) {
         if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("건물명은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.BUILDING_NAME_REQUIRED.getMessage());
         }
         if (address == null || address.isBlank()) {
-            throw new IllegalArgumentException("건물 주소는 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.BUILDING_ADDRESS_REQUIRED.getMessage());
         }
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/domain/BuildingSearchKeyword.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/BuildingSearchKeyword.java
@@ -1,0 +1,44 @@
+package com.kustacks.kuring.building.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "building_search_keyword")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BuildingSearchKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id", nullable = false)
+    private Building building;
+
+    @Column(length = 50, nullable = false)
+    private String keyword;
+
+    BuildingSearchKeyword(Building building, String keyword) {
+        if (building == null) {
+            throw new IllegalArgumentException("건물은 필수입니다.");
+        }
+        if (keyword == null || keyword.isBlank()) {
+            throw new IllegalArgumentException("건물 검색어는 필수입니다.");
+        }
+
+        this.building = building;
+        this.keyword = keyword.trim();
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/domain/BuildingSearchKeyword.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/BuildingSearchKeyword.java
@@ -1,5 +1,6 @@
 package com.kustacks.kuring.building.domain;
 
+import com.kustacks.kuring.common.exception.code.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -32,10 +33,10 @@ public class BuildingSearchKeyword {
 
     BuildingSearchKeyword(Building building, String keyword) {
         if (building == null) {
-            throw new IllegalArgumentException("건물은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.BUILDING_REQUIRED.getMessage());
         }
         if (keyword == null || keyword.isBlank()) {
-            throw new IllegalArgumentException("건물 검색어는 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.BUILDING_SEARCH_KEYWORD_REQUIRED.getMessage());
         }
 
         this.building = building;

--- a/src/main/java/com/kustacks/kuring/building/domain/CampusPlace.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/CampusPlace.java
@@ -1,0 +1,147 @@
+package com.kustacks.kuring.building.domain;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@Table(name = "campus_place")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CampusPlace {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id", nullable = false)
+    private Building building;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private CampusPlaceCategory category;
+
+    @Column(length = 100, nullable = false)
+    private String name;
+
+    @Column(name = "image_path")
+    private String imagePath;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "location_type", length = 20, nullable = false)
+    private CampusPlaceLocationType locationType;
+
+    @Column(length = 20)
+    private String floor;
+
+    @Column(name = "location_detail")
+    private String locationDetail;
+
+    private Integer quantity;
+
+    @Column(name = "external_url", length = 500)
+    private String externalUrl;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "campus_place_operating_hours",
+            joinColumns = @JoinColumn(name = "campus_place_id")
+    )
+    private Set<OperatingHours> operatingHours = new HashSet<>();
+
+    public CampusPlace(
+            Building building,
+            CampusPlaceCategory category,
+            String name,
+            String imagePath,
+            CampusPlaceLocationType locationType,
+            String floor,
+            String locationDetail,
+            Integer quantity,
+            String externalUrl,
+            int displayOrder
+    ) {
+        validateRequiredFields(building, category, name, locationType);
+        validateQuantity(quantity);
+
+        this.building = building;
+        this.category = category;
+        this.name = name;
+        this.imagePath = imagePath;
+        this.locationType = locationType;
+        this.floor = floor;
+        this.locationDetail = locationDetail;
+        this.quantity = quantity;
+        this.externalUrl = externalUrl;
+        this.displayOrder = displayOrder;
+    }
+
+    public void addOperatingHours(OperatingHours hours) {
+        validateOperatingHours(hours);
+        operatingHours.add(hours);
+    }
+
+    private static void validateRequiredFields(
+            Building building,
+            CampusPlaceCategory category,
+            String name,
+            CampusPlaceLocationType locationType
+    ) {
+        if (building == null) {
+            throw new IllegalArgumentException("건물은 필수입니다.");
+        }
+        if (category == null) {
+            throw new IllegalArgumentException("캠퍼스 시설 카테고리는 필수입니다.");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("캠퍼스 시설명은 필수입니다.");
+        }
+        if (locationType == null) {
+            throw new IllegalArgumentException("캠퍼스 시설 위치 유형은 필수입니다.");
+        }
+    }
+
+    private static void validateQuantity(Integer quantity) {
+        if (quantity != null && quantity <= 0) {
+            throw new IllegalArgumentException("캠퍼스 시설 수량은 양수여야 합니다.");
+        }
+    }
+
+    private void validateOperatingHours(OperatingHours hours) {
+        if (hours == null) {
+            throw new IllegalArgumentException("운영시간은 필수입니다.");
+        }
+
+        boolean alreadyExists = operatingHours.stream()
+                .anyMatch(existing -> existing.matches(
+                        hours.getPeriod(),
+                        hours.getDayGroup()
+                ));
+
+        if (alreadyExists) {
+            throw new IllegalArgumentException(
+                    "같은 기간과 요일의 운영시간은 중복될 수 없습니다."
+            );
+        }
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/domain/CampusPlace.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/CampusPlace.java
@@ -1,5 +1,6 @@
 package com.kustacks.kuring.building.domain;
 
+import com.kustacks.kuring.common.exception.code.ErrorCode;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -108,28 +109,28 @@ public class CampusPlace {
             CampusPlaceLocationType locationType
     ) {
         if (building == null) {
-            throw new IllegalArgumentException("건물은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.BUILDING_REQUIRED.getMessage());
         }
         if (category == null) {
-            throw new IllegalArgumentException("캠퍼스 시설 카테고리는 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_CATEGORY_REQUIRED.getMessage());
         }
         if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("캠퍼스 시설명은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_NAME_REQUIRED.getMessage());
         }
         if (locationType == null) {
-            throw new IllegalArgumentException("캠퍼스 시설 위치 유형은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_LOCATION_TYPE_REQUIRED.getMessage());
         }
     }
 
     private static void validateQuantity(Integer quantity) {
         if (quantity != null && quantity <= 0) {
-            throw new IllegalArgumentException("캠퍼스 시설 수량은 양수여야 합니다.");
+            throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_QUANTITY_INVALID.getMessage());
         }
     }
 
     private void validateOperatingHours(OperatingHours hours) {
         if (hours == null) {
-            throw new IllegalArgumentException("운영시간은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.OPERATING_HOURS_REQUIRED.getMessage());
         }
 
         boolean alreadyExists = operatingHours.stream()
@@ -139,9 +140,7 @@ public class CampusPlace {
                 ));
 
         if (alreadyExists) {
-            throw new IllegalArgumentException(
-                    "같은 기간과 요일의 운영시간은 중복될 수 없습니다."
-            );
+            throw new IllegalArgumentException(ErrorCode.OPERATING_HOURS_DUPLICATED.getMessage());
         }
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/domain/CampusPlace.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/CampusPlace.java
@@ -82,7 +82,7 @@ public class CampusPlace {
             String externalUrl,
             int displayOrder
     ) {
-        validateRequiredFields(building, category, name, locationType);
+        validateRequiredFields(building, category, name, locationType, displayOrder);
         validateQuantity(quantity);
 
         this.building = building;
@@ -106,7 +106,8 @@ public class CampusPlace {
             Building building,
             CampusPlaceCategory category,
             String name,
-            CampusPlaceLocationType locationType
+            CampusPlaceLocationType locationType,
+            int displayOrder
     ) {
         if (building == null) {
             throw new IllegalArgumentException(ErrorCode.BUILDING_REQUIRED.getMessage());
@@ -119,6 +120,9 @@ public class CampusPlace {
         }
         if (locationType == null) {
             throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_LOCATION_TYPE_REQUIRED.getMessage());
+        }
+        if (displayOrder <= 0) {
+            throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_DISPLAY_ORDER_INVALID.getMessage());
         }
     }
 

--- a/src/main/java/com/kustacks/kuring/building/domain/CampusPlaceCategory.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/CampusPlaceCategory.java
@@ -1,0 +1,57 @@
+package com.kustacks.kuring.building.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Locale;
+
+@Entity
+@Getter
+@Table(name = "campus_place_category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CampusPlaceCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50, nullable = false, unique = true)
+    private String code;
+
+    @Column(name = "kor_name", length = 50, nullable = false)
+    private String korName;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    @Column(name = "filter_enabled", nullable = false)
+    private boolean filterEnabled;
+
+    public CampusPlaceCategory(String code, String korName, int displayOrder, boolean filterEnabled) {
+        validate(code, korName, displayOrder);
+
+        this.code = code.trim().toLowerCase(Locale.ROOT);
+        this.korName = korName.trim();
+        this.displayOrder = displayOrder;
+        this.filterEnabled = filterEnabled;
+    }
+
+    private static void validate(String code, String korName, int displayOrder) {
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("캠퍼스 시설 카테고리 코드는 필수입니다.");
+        }
+        if (korName == null || korName.isBlank()) {
+            throw new IllegalArgumentException("캠퍼스 시설 카테고리 한글명은 필수입니다.");
+        }
+        if (displayOrder <= 0) {
+            throw new IllegalArgumentException("카테고리 노출 순서는 양수여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/domain/CampusPlaceCategory.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/CampusPlaceCategory.java
@@ -1,5 +1,6 @@
 package com.kustacks.kuring.building.domain;
 
+import com.kustacks.kuring.common.exception.code.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -45,13 +46,13 @@ public class CampusPlaceCategory {
 
     private static void validate(String code, String korName, int displayOrder) {
         if (code == null || code.isBlank()) {
-            throw new IllegalArgumentException("캠퍼스 시설 카테고리 코드는 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_CATEGORY_CODE_REQUIRED.getMessage());
         }
         if (korName == null || korName.isBlank()) {
-            throw new IllegalArgumentException("캠퍼스 시설 카테고리 한글명은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_CATEGORY_KOREAN_NAME_REQUIRED.getMessage());
         }
         if (displayOrder <= 0) {
-            throw new IllegalArgumentException("카테고리 노출 순서는 양수여야 합니다.");
+            throw new IllegalArgumentException(ErrorCode.CAMPUS_PLACE_CATEGORY_DISPLAY_ORDER_INVALID.getMessage());
         }
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/domain/OperatingHours.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/OperatingHours.java
@@ -1,0 +1,97 @@
+package com.kustacks.kuring.building.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OperatingHours {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "period", length = 20, nullable = false)
+    private OperatingPeriod period;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_group", length = 20, nullable = false)
+    private OperatingDayGroup dayGroup;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 30, nullable = false)
+    private OperatingHoursStatus status;
+
+    @Column(name = "opens_at")
+    private LocalTime opensAt;
+
+    @Column(name = "closes_at")
+    private LocalTime closesAt;
+
+    public OperatingHours(
+            OperatingPeriod period,
+            OperatingDayGroup dayGroup,
+            OperatingHoursStatus status,
+            LocalTime opensAt,
+            LocalTime closesAt
+    ) {
+        validateRequiredFields(period, dayGroup, status);
+        validateTimes(status, opensAt, closesAt);
+
+        this.period = period;
+        this.dayGroup = dayGroup;
+        this.status = status;
+        this.opensAt = opensAt;
+        this.closesAt = closesAt;
+    }
+
+    public boolean matches(OperatingPeriod period, OperatingDayGroup dayGroup) {
+        return this.period == period && this.dayGroup == dayGroup;
+    }
+
+    private static void validateRequiredFields(
+            OperatingPeriod period,
+            OperatingDayGroup dayGroup,
+            OperatingHoursStatus status
+    ) {
+        if (period == null) {
+            throw new IllegalArgumentException("운영 기간은 필수입니다.");
+        }
+        if (dayGroup == null) {
+            throw new IllegalArgumentException("운영 요일 구분은 필수입니다.");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("운영시간 상태는 필수입니다.");
+        }
+    }
+
+    private static void validateTimes(
+            OperatingHoursStatus status,
+            LocalTime opensAt,
+            LocalTime closesAt
+    ) {
+        if (status == OperatingHoursStatus.SCHEDULED) {
+            if (opensAt == null) {
+                throw new IllegalArgumentException("지정 운영시간에는 시작 시간이 필요합니다.");
+            }
+            if (closesAt == null) {
+                throw new IllegalArgumentException("지정 운영시간에는 종료 시간이 필요합니다.");
+            }
+            return;
+        }
+
+        if (opensAt != null) {
+            throw new IllegalArgumentException("지정 운영시간이 아닌 경우 시작 시간을 입력할 수 없습니다.");
+        }
+        if (closesAt != null) {
+            throw new IllegalArgumentException("지정 운영시간이 아닌 경우 종료 시간을 입력할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/domain/OperatingHours.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/OperatingHours.java
@@ -1,5 +1,6 @@
 package com.kustacks.kuring.building.domain;
 
+import com.kustacks.kuring.common.exception.code.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
@@ -62,13 +63,13 @@ public class OperatingHours {
             OperatingHoursStatus status
     ) {
         if (period == null) {
-            throw new IllegalArgumentException("운영 기간은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.OPERATING_PERIOD_REQUIRED.getMessage());
         }
         if (dayGroup == null) {
-            throw new IllegalArgumentException("운영 요일 구분은 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.OPERATING_DAY_GROUP_REQUIRED.getMessage());
         }
         if (status == null) {
-            throw new IllegalArgumentException("운영시간 상태는 필수입니다.");
+            throw new IllegalArgumentException(ErrorCode.OPERATING_HOURS_STATUS_REQUIRED.getMessage());
         }
     }
 
@@ -79,19 +80,19 @@ public class OperatingHours {
     ) {
         if (status == OperatingHoursStatus.SCHEDULED) {
             if (opensAt == null) {
-                throw new IllegalArgumentException("지정 운영시간에는 시작 시간이 필요합니다.");
+                throw new IllegalArgumentException(ErrorCode.OPERATING_HOURS_OPEN_TIME_REQUIRED.getMessage());
             }
             if (closesAt == null) {
-                throw new IllegalArgumentException("지정 운영시간에는 종료 시간이 필요합니다.");
+                throw new IllegalArgumentException(ErrorCode.OPERATING_HOURS_CLOSE_TIME_REQUIRED.getMessage());
             }
             return;
         }
 
         if (opensAt != null) {
-            throw new IllegalArgumentException("지정 운영시간이 아닌 경우 시작 시간을 입력할 수 없습니다.");
+            throw new IllegalArgumentException(ErrorCode.OPERATING_HOURS_OPEN_TIME_NOT_ALLOWED.getMessage());
         }
         if (closesAt != null) {
-            throw new IllegalArgumentException("지정 운영시간이 아닌 경우 종료 시간을 입력할 수 없습니다.");
+            throw new IllegalArgumentException(ErrorCode.OPERATING_HOURS_CLOSE_TIME_NOT_ALLOWED.getMessage());
         }
     }
 }

--- a/src/main/java/com/kustacks/kuring/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/kustacks/kuring/common/exception/code/ErrorCode.java
@@ -65,6 +65,32 @@ public enum ErrorCode {
     CLUB_NOT_SUBSCRIBED(HttpStatus.BAD_REQUEST, "구독하지 않은 동아리입니다."),
 
     BUILDING_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 건물을 찾을 수 없습니다."),
+    BUILDING_REQUIRED(HttpStatus.BAD_REQUEST, "건물은 필수입니다."),
+    BUILDING_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "건물명은 필수입니다."),
+    BUILDING_ADDRESS_REQUIRED(HttpStatus.BAD_REQUEST, "건물 주소는 필수입니다."),
+    BUILDING_SEARCH_KEYWORD_REQUIRED(HttpStatus.BAD_REQUEST, "건물 검색어는 필수입니다."),
+
+    CAMPUS_PLACE_REQUIRED(HttpStatus.BAD_REQUEST, "캠퍼스 시설은 필수입니다."),
+    CAMPUS_PLACE_BUILDING_MISMATCH(HttpStatus.BAD_REQUEST, "다른 건물의 캠퍼스 시설은 추가할 수 없습니다."),
+    CAMPUS_PLACE_CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, "캠퍼스 시설 카테고리는 필수입니다."),
+    CAMPUS_PLACE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "캠퍼스 시설명은 필수입니다."),
+    CAMPUS_PLACE_LOCATION_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "캠퍼스 시설 위치 유형은 필수입니다."),
+    CAMPUS_PLACE_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "캠퍼스 시설 수량은 양수여야 합니다."),
+    CAMPUS_PLACE_DISPLAY_ORDER_INVALID(HttpStatus.BAD_REQUEST, "캠퍼스 시설 노출 순서는 양수여야 합니다."),
+
+    CAMPUS_PLACE_CATEGORY_CODE_REQUIRED(HttpStatus.BAD_REQUEST, "캠퍼스 시설 카테고리 코드는 필수입니다."),
+    CAMPUS_PLACE_CATEGORY_KOREAN_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "캠퍼스 시설 카테고리 한글명은 필수입니다."),
+    CAMPUS_PLACE_CATEGORY_DISPLAY_ORDER_INVALID(HttpStatus.BAD_REQUEST, "카테고리 노출 순서는 양수여야 합니다."),
+
+    OPERATING_HOURS_REQUIRED(HttpStatus.BAD_REQUEST, "운영시간은 필수입니다."),
+    OPERATING_HOURS_DUPLICATED(HttpStatus.BAD_REQUEST, "같은 기간과 요일의 운영시간은 중복될 수 없습니다."),
+    OPERATING_PERIOD_REQUIRED(HttpStatus.BAD_REQUEST, "운영 기간은 필수입니다."),
+    OPERATING_DAY_GROUP_REQUIRED(HttpStatus.BAD_REQUEST, "운영 요일 구분은 필수입니다."),
+    OPERATING_HOURS_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, "운영시간 상태는 필수입니다."),
+    OPERATING_HOURS_OPEN_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "지정 운영시간에는 시작 시간이 필요합니다."),
+    OPERATING_HOURS_CLOSE_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "지정 운영시간에는 종료 시간이 필요합니다."),
+    OPERATING_HOURS_OPEN_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "지정 운영시간이 아닌 경우 시작 시간을 입력할 수 없습니다."),
+    OPERATING_HOURS_CLOSE_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "지정 운영시간이 아닌 경우 종료 시간을 입력할 수 없습니다."),
 
 
     STAFF_SCRAPER_EXCEED_RETRY_LIMIT("교직원 업데이트 재시도 횟수를 초과했습니다."),

--- a/src/main/resources/db/migration/V260719__Create_campus_map_tables.sql
+++ b/src/main/resources/db/migration/V260719__Create_campus_map_tables.sql
@@ -1,0 +1,90 @@
+ALTER TABLE building
+    ADD COLUMN address VARCHAR(100) NULL AFTER name,
+    ADD COLUMN image_path VARCHAR(255) NULL AFTER lon;
+
+UPDATE building
+SET address = '서울특별시 광진구 능동로 120'
+WHERE address IS NULL;
+
+ALTER TABLE building
+    MODIFY COLUMN address VARCHAR(100) NOT NULL;
+
+CREATE TABLE building_search_keyword
+(
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    building_id BIGINT      NOT NULL,
+    keyword     VARCHAR(50) NOT NULL,
+    CONSTRAINT uk_building_search_keyword UNIQUE (building_id, keyword),
+    CONSTRAINT fk_building_search_keyword_building
+        FOREIGN KEY (building_id) REFERENCES building (id) ON DELETE CASCADE,
+    INDEX idx_building_search_keyword_keyword (keyword)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE campus_place_category
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    code           VARCHAR(50) NOT NULL,
+    kor_name       VARCHAR(50) NOT NULL,
+    display_order  INT         NOT NULL,
+    filter_enabled BOOLEAN     NOT NULL DEFAULT FALSE,
+    CONSTRAINT uk_campus_place_category_code UNIQUE (code),
+    INDEX idx_campus_place_category_filter_order (filter_enabled, display_order)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE campus_place
+(
+    id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    building_id     BIGINT       NOT NULL,
+    category_id     BIGINT       NOT NULL,
+    name            VARCHAR(100) NOT NULL,
+    image_path      VARCHAR(255) NULL,
+    location_type   VARCHAR(20)  NOT NULL,
+    floor           VARCHAR(20)  NULL,
+    location_detail VARCHAR(255) NULL,
+    quantity        INT          NULL,
+    external_url    VARCHAR(500) NULL,
+    display_order   INT          NOT NULL DEFAULT 0,
+    CONSTRAINT fk_campus_place_building
+        FOREIGN KEY (building_id) REFERENCES building (id) ON DELETE CASCADE,
+    CONSTRAINT fk_campus_place_category
+        FOREIGN KEY (category_id) REFERENCES campus_place_category (id),
+    CONSTRAINT ck_campus_place_quantity CHECK (quantity IS NULL OR quantity > 0),
+    INDEX idx_campus_place_building_order (building_id, display_order),
+    INDEX idx_campus_place_category (category_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE building_operating_hours
+(
+    building_id BIGINT      NOT NULL,
+    period      VARCHAR(20) NOT NULL,
+    day_group   VARCHAR(20) NOT NULL,
+    status      VARCHAR(30) NOT NULL,
+    opens_at    TIME        NULL,
+    closes_at   TIME        NULL,
+    CONSTRAINT uk_building_operating_hours UNIQUE (building_id, period, day_group),
+    CONSTRAINT fk_building_operating_hours_building
+        FOREIGN KEY (building_id) REFERENCES building (id) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE campus_place_operating_hours
+(
+    campus_place_id BIGINT      NOT NULL,
+    period          VARCHAR(20) NOT NULL,
+    day_group       VARCHAR(20) NOT NULL,
+    status          VARCHAR(30) NOT NULL,
+    opens_at        TIME        NULL,
+    closes_at       TIME        NULL,
+    CONSTRAINT uk_campus_place_operating_hours UNIQUE (campus_place_id, period, day_group),
+    CONSTRAINT fk_campus_place_operating_hours_place
+        FOREIGN KEY (campus_place_id) REFERENCES campus_place (id) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/test/java/com/kustacks/kuring/building/domain/BuildingTest.java
+++ b/src/test/java/com/kustacks/kuring/building/domain/BuildingTest.java
@@ -3,7 +3,10 @@ package com.kustacks.kuring.building.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("도메인 : Building")
@@ -23,8 +26,139 @@ class BuildingTest {
         // then
         assertAll(
                 () -> assertThat(building.getName()).isEqualTo(name),
+                () -> assertThat(building.getAddress()).isEqualTo("서울특별시 광진구 능동로 120"),
                 () -> assertThat(building.getLat()).isEqualTo(lat),
                 () -> assertThat(building.getLon()).isEqualTo(lon)
+        );
+    }
+
+    @Test
+    @DisplayName("건물명과 주소는 필수이다")
+    void reject_building_without_required_fields() {
+        assertAll(
+                () -> assertThatIllegalArgumentException().isThrownBy(() -> new Building(
+                        " ",
+                        "서울특별시 광진구 능동로 120",
+                        37.5412,
+                        127.0784,
+                        null
+                )),
+                () -> assertThatIllegalArgumentException().isThrownBy(() -> new Building(
+                        "학생회관",
+                        " ",
+                        37.5412,
+                        127.0784,
+                        null
+                ))
+        );
+    }
+
+    @Test
+    @DisplayName("건물 검색어를 추가할 수 있다")
+    void add_search_keyword() {
+        // given
+        Building building = createBuilding();
+
+        // when
+        building.addSearchKeyword("  학관  ");
+
+        // then
+        assertThat(building.getKeywords())
+                .singleElement()
+                .extracting(BuildingSearchKeyword::getKeyword)
+                .isEqualTo("학관");
+    }
+
+    @Test
+    @DisplayName("건물 검색어가 없으면 추가할 수 없다")
+    void reject_empty_search_keyword() {
+        Building building = createBuilding();
+
+        assertThatIllegalArgumentException().isThrownBy(() -> building.addSearchKeyword(" "));
+    }
+
+    @Test
+    @DisplayName("캠퍼스 시설을 추가할 수 있다")
+    void add_campus_place() {
+        // given
+        Building building = createBuilding();
+        CampusPlace campusPlace = createCampusPlace(building);
+
+        // when
+        building.addCampusPlace(campusPlace);
+
+        // then
+        assertThat(building.getCampusPlaces()).containsExactly(campusPlace);
+    }
+
+    @Test
+    @DisplayName("캠퍼스 시설이 없으면 추가할 수 없다")
+    void reject_null_campus_place() {
+        Building building = createBuilding();
+
+        assertThatIllegalArgumentException().isThrownBy(() -> building.addCampusPlace(null));
+    }
+
+    @Test
+    @DisplayName("운영시간을 추가할 수 있다")
+    void add_operating_hours() {
+        // given
+        Building building = createBuilding();
+        OperatingHours operatingHours = createOperatingHours();
+
+        // when
+        building.addOperatingHours(operatingHours);
+
+        // then
+        assertThat(building.getOperatingHours()).containsExactly(operatingHours);
+    }
+
+    @Test
+    @DisplayName("같은 기간과 요일의 운영시간은 중복으로 추가할 수 없다")
+    void reject_duplicated_operating_hours() {
+        // given
+        Building building = createBuilding();
+        building.addOperatingHours(createOperatingHours());
+        OperatingHours duplicatedHours = new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.OPEN_24_HOURS,
+                null,
+                null
+        );
+
+        // when, then
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> building.addOperatingHours(duplicatedHours)
+        );
+    }
+
+    private Building createBuilding() {
+        return new Building("학생회관", 37.5412, 127.0784);
+    }
+
+    private CampusPlace createCampusPlace(Building building) {
+        return new CampusPlace(
+                building,
+                new CampusPlaceCategory("printer", "프린터", 1, true),
+                "학생회관 1층 프린터",
+                null,
+                CampusPlaceLocationType.INDOOR,
+                "1F",
+                "라운지 안쪽",
+                3,
+                null,
+                1
+        );
+    }
+
+    private OperatingHours createOperatingHours() {
+        return new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.SCHEDULED,
+                LocalTime.of(9, 0),
+                LocalTime.of(18, 0)
         );
     }
 }

--- a/src/test/java/com/kustacks/kuring/building/domain/CampusPlaceCategoryTest.java
+++ b/src/test/java/com/kustacks/kuring/building/domain/CampusPlaceCategoryTest.java
@@ -1,0 +1,56 @@
+package com.kustacks.kuring.building.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("도메인 : CampusPlaceCategory")
+class CampusPlaceCategoryTest {
+
+    @Test
+    @DisplayName("캠퍼스 시설 카테고리를 생성할 수 있다")
+    void create_campus_place_category() {
+        // when
+        CampusPlaceCategory category = new CampusPlaceCategory(
+                "  CONVENIENCE_STORE  ",
+                "  편의점  ",
+                1,
+                true
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(category.getCode()).isEqualTo("convenience_store"),
+                () -> assertThat(category.getKorName()).isEqualTo("편의점"),
+                () -> assertThat(category.getDisplayOrder()).isEqualTo(1),
+                () -> assertThat(category.isFilterEnabled()).isTrue()
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리 코드가 없으면 생성할 수 없다")
+    void reject_category_without_code() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new CampusPlaceCategory(" ", "편의점", 1, true)
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리 한글명이 없으면 생성할 수 없다")
+    void reject_category_without_korean_name() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new CampusPlaceCategory("convenience_store", " ", 1, true)
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리 노출 순서가 양수가 아니면 생성할 수 없다")
+    void reject_category_with_invalid_display_order() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new CampusPlaceCategory("convenience_store", "편의점", 0, true)
+        );
+    }
+}

--- a/src/test/java/com/kustacks/kuring/building/domain/CampusPlaceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/domain/CampusPlaceTest.java
@@ -1,0 +1,148 @@
+package com.kustacks.kuring.building.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("도메인 : CampusPlace")
+class CampusPlaceTest {
+
+    @Test
+    @DisplayName("캠퍼스 시설을 생성할 수 있다")
+    void create_campus_place() {
+        // given
+        Building building = createBuilding();
+        CampusPlaceCategory category = createCategory();
+
+        // when
+        CampusPlace campusPlace = createCampusPlace(building, category, 3);
+
+        // then
+        assertAll(
+                () -> assertThat(campusPlace.getBuilding()).isEqualTo(building),
+                () -> assertThat(campusPlace.getCategory()).isEqualTo(category),
+                () -> assertThat(campusPlace.getName()).isEqualTo("학생회관 1층 프린터"),
+                () -> assertThat(campusPlace.getLocationType()).isEqualTo(CampusPlaceLocationType.INDOOR),
+                () -> assertThat(campusPlace.getFloor()).isEqualTo("1F"),
+                () -> assertThat(campusPlace.getQuantity()).isEqualTo(3),
+                () -> assertThat(campusPlace.getDisplayOrder()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    @DisplayName("건물이 없으면 캠퍼스 시설을 생성할 수 없다")
+    void reject_campus_place_without_building() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> createCampusPlace(null, createCategory(), 3)
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리가 없으면 캠퍼스 시설을 생성할 수 없다")
+    void reject_campus_place_without_category() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> createCampusPlace(createBuilding(), null, 3)
+        );
+    }
+
+    @Test
+    @DisplayName("시설명이 없으면 캠퍼스 시설을 생성할 수 없다")
+    void reject_campus_place_without_name() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new CampusPlace(
+                createBuilding(),
+                createCategory(),
+                " ",
+                null,
+                CampusPlaceLocationType.INDOOR,
+                "1F",
+                "라운지 안쪽",
+                3,
+                null,
+                1
+        ));
+    }
+
+    @Test
+    @DisplayName("시설 수량이 양수가 아니면 캠퍼스 시설을 생성할 수 없다")
+    void reject_campus_place_with_invalid_quantity() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> createCampusPlace(createBuilding(), createCategory(), 0)
+        );
+    }
+
+    @Test
+    @DisplayName("운영시간을 추가할 수 있다")
+    void add_operating_hours() {
+        // given
+        CampusPlace campusPlace = createCampusPlace(createBuilding(), createCategory(), 3);
+        OperatingHours operatingHours = createOperatingHours();
+
+        // when
+        campusPlace.addOperatingHours(operatingHours);
+
+        // then
+        assertThat(campusPlace.getOperatingHours()).containsExactly(operatingHours);
+    }
+
+    @Test
+    @DisplayName("같은 기간과 요일의 운영시간은 중복으로 추가할 수 없다")
+    void reject_duplicated_operating_hours() {
+        // given
+        CampusPlace campusPlace = createCampusPlace(createBuilding(), createCategory(), 3);
+        campusPlace.addOperatingHours(createOperatingHours());
+        OperatingHours duplicatedHours = new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.OPEN_24_HOURS,
+                null,
+                null
+        );
+
+        // when, then
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> campusPlace.addOperatingHours(duplicatedHours)
+        );
+    }
+
+    private Building createBuilding() {
+        return new Building("학생회관", 37.5412, 127.0784);
+    }
+
+    private CampusPlaceCategory createCategory() {
+        return new CampusPlaceCategory("printer", "프린터", 1, true);
+    }
+
+    private CampusPlace createCampusPlace(
+            Building building,
+            CampusPlaceCategory category,
+            Integer quantity
+    ) {
+        return new CampusPlace(
+                building,
+                category,
+                "학생회관 1층 프린터",
+                "campus-map/place-1.jpg",
+                CampusPlaceLocationType.INDOOR,
+                "1F",
+                "라운지 안쪽",
+                quantity,
+                "https://example.com",
+                1
+        );
+    }
+
+    private OperatingHours createOperatingHours() {
+        return new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.SCHEDULED,
+                LocalTime.of(9, 0),
+                LocalTime.of(18, 0)
+        );
+    }
+}

--- a/src/test/java/com/kustacks/kuring/building/domain/OperatingHoursTest.java
+++ b/src/test/java/com/kustacks/kuring/building/domain/OperatingHoursTest.java
@@ -1,0 +1,60 @@
+package com.kustacks.kuring.building.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+@DisplayName("도메인 : OperatingHours")
+class OperatingHoursTest {
+
+    @Test
+    @DisplayName("지정 운영시간은 시작과 종료 시각을 가진다")
+    void create_scheduled_operating_hours() {
+        // when
+        OperatingHours hours = new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.SCHEDULED,
+                LocalTime.of(9, 0),
+                LocalTime.of(18, 0)
+        );
+
+        // then
+        assertThat(hours.getOpensAt()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(hours.getClosesAt()).isEqualTo(LocalTime.of(18, 0));
+    }
+
+    @Test
+    @DisplayName("지정 운영시간에 시각이 없으면 생성할 수 없다")
+    void reject_scheduled_operating_hours_without_times() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.SCHEDULED,
+                null,
+                null
+        ));
+    }
+
+    @Test
+    @DisplayName("24시간 운영은 시작과 종료 시각을 저장하지 않는다")
+    void create_open_24_hours_without_times() {
+        // when
+        OperatingHours hours = new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.OPEN_24_HOURS,
+                null,
+                null
+        );
+
+        // then
+        assertThat(hours.getStatus()).isEqualTo(OperatingHoursStatus.OPEN_24_HOURS);
+        assertThat(hours.getOpensAt()).isNull();
+        assertThat(hours.getClosesAt()).isNull();
+    }
+}

--- a/src/test/java/com/kustacks/kuring/building/domain/OperatingHoursTest.java
+++ b/src/test/java/com/kustacks/kuring/building/domain/OperatingHoursTest.java
@@ -7,6 +7,7 @@ import java.time.LocalTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("도메인 : OperatingHours")
 class OperatingHoursTest {
@@ -29,15 +30,19 @@ class OperatingHoursTest {
     }
 
     @Test
-    @DisplayName("지정 운영시간에 시각이 없으면 생성할 수 없다")
-    void reject_scheduled_operating_hours_without_times() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new OperatingHours(
-                OperatingPeriod.SEMESTER,
-                OperatingDayGroup.WEEKDAY,
-                OperatingHoursStatus.SCHEDULED,
-                null,
-                null
-        ));
+    @DisplayName("지정 운영시간에 시작 시각이 없으면 생성할 수 없다")
+    void reject_scheduled_operating_hours_without_opening_time() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> createOperatingHours(OperatingHoursStatus.SCHEDULED, null, LocalTime.of(18, 0))
+        );
+    }
+
+    @Test
+    @DisplayName("지정 운영시간에 종료 시각이 없으면 생성할 수 없다")
+    void reject_scheduled_operating_hours_without_closing_time() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> createOperatingHours(OperatingHoursStatus.SCHEDULED, LocalTime.of(9, 0), null)
+        );
     }
 
     @Test
@@ -56,5 +61,43 @@ class OperatingHoursTest {
         assertThat(hours.getStatus()).isEqualTo(OperatingHoursStatus.OPEN_24_HOURS);
         assertThat(hours.getOpensAt()).isNull();
         assertThat(hours.getClosesAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("지정 운영시간이 아니면 시작 시각을 입력할 수 없다")
+    void reject_opening_time_when_status_is_not_scheduled() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> createOperatingHours(OperatingHoursStatus.OPEN_24_HOURS, LocalTime.of(9, 0), null)
+        );
+    }
+
+    @Test
+    @DisplayName("운영 기간과 요일 구분이 같은지 확인할 수 있다")
+    void match_period_and_day_group() {
+        OperatingHours hours = createOperatingHours(
+                OperatingHoursStatus.OPEN_24_HOURS,
+                null,
+                null
+        );
+
+        assertAll(
+                () -> assertThat(hours.matches(OperatingPeriod.SEMESTER, OperatingDayGroup.WEEKDAY)).isTrue(),
+                () -> assertThat(hours.matches(OperatingPeriod.VACATION, OperatingDayGroup.WEEKDAY)).isFalse(),
+                () -> assertThat(hours.matches(OperatingPeriod.SEMESTER, OperatingDayGroup.WEEKEND)).isFalse()
+        );
+    }
+
+    private OperatingHours createOperatingHours(
+            OperatingHoursStatus status,
+            LocalTime opensAt,
+            LocalTime closesAt
+    ) {
+        return new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                status,
+                opensAt,
+                closesAt
+        );
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈
#392 
## 📌 요약
- 캠퍼스맵 API에서 공통으로 사용하는 장소 및 운영시간 도메인을 구현했습니다.
## 🛠️ 상세
- 기존 `Building` 엔티티에 캠퍼스맵 정보를 추가했습니다.
- 건물별 검색어를 관리하는 `BuildingSearchKeyword`를 추가했습니다.
- 건물 내부 주요시설 및 편의시설을 표현하는 `CampusPlace`를 추가했습니다.
- 시설 카테고리를 관리하는 `CampusPlaceCategory`를 추가했습니다.
- 건물 및 시설의 운영시간을 관리하는 `OperatingHours`를 추가했습니다.
- 캠퍼스맵 관련 테이블 생성 마이그레이션을 추가했습니다.
- 운영시간 도메인 테스트를 추가했습니다.
## 💬 기타
이번 PR 머지 후 카테고리 목록 조회부터 API 엔드포인트 단위로 순차적으로 PR 올리겠습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 건물에 주소와 이미지 정보를 추가하고, 건물별 검색 키워드를 관리합니다.
  - 캠퍼스 시설의 위치/층/상세/수량/외부 링크를 제공하며, 시설 운영 기간·요일·상태 및 운영시간을 함께 관리합니다.
  - 시설 카테고리별 코드/정렬 및 필터링 옵션을 지원합니다.
- **개선 사항**
  - 필수 입력 누락과 운영시간·시설 운영 정보 중복을 사전에 차단해 데이터 정확성을 높였습니다.
- **테스트/DB**
  - 운영시간/시설/카테고리 관련 도메인 검증 테스트와 DB 마이그레이션을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->