### PR TITLE
Refactor: 캠퍼스맵 응답 구조 개선 및 mock 데이터 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
@@ -33,7 +33,7 @@ public class CampusMapQueryApiV2 {
     public ResponseEntity<BaseResponse<CategoryListResponse>> getCategories() {
         return ok(
                 "장소 카테고리 목록 조회에 성공하였습니다",
-                CampusMapMockFixture.categories()
+                CampusMapMockFixture.mockCategories()
         );
     }
 
@@ -42,7 +42,7 @@ public class CampusMapQueryApiV2 {
     public ResponseEntity<BaseResponse<BuildingListResponse>> getBuildings() {
         return ok(
                 "캠퍼스 건물 목록 조회에 성공하였습니다",
-                CampusMapMockFixture.buildings()
+                CampusMapMockFixture.mockBuildings()
         );
     }
 
@@ -54,7 +54,7 @@ public class CampusMapQueryApiV2 {
     ) {
         return ok(
                 "캠퍼스 건물 검색에 성공하였습니다",
-                CampusMapMockFixture.searchBuildings(keyword)
+                CampusMapMockFixture.mockBuildingSearchResult(keyword)
         );
     }
 
@@ -62,11 +62,11 @@ public class CampusMapQueryApiV2 {
     @GetMapping("/campus-places")
     public ResponseEntity<BaseResponse<CampusPlaceListResponse>> getCampusPlaces(
             @Parameter(description = "쉼표로 구분된 시설 카테고리")
-            @RequestParam(name = "categories") @NotEmpty List<String> categories
+            @RequestParam(name = "categories") @NotEmpty List<@NotBlank String> categories
     ) {
         return ok(
                 "카테고리 기반 시설 목록 조회에 성공하였습니다",
-                CampusMapMockFixture.campusPlaces(categories)
+                CampusMapMockFixture.mockCampusPlaces(categories)
         );
     }
 
@@ -75,7 +75,7 @@ public class CampusMapQueryApiV2 {
     public ResponseEntity<BaseResponse<BuildingDetailResponse>> getBuildingDetail(
             @PathVariable Long buildingId
     ) {
-        var response = CampusMapMockFixture.findBuildingDetail(buildingId);
+        var response = CampusMapMockFixture.findMockBuildingDetail(buildingId);
 
         return response.map(buildingDetailResponse
                 -> ok("캠퍼스 건물 상세 조회에 성공하였습니다", buildingDetailResponse))

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/BuildingDetailResponse.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/BuildingDetailResponse.java
@@ -1,7 +1,7 @@
 package com.kustacks.kuring.building.adapter.in.web.dto;
 
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CampusPlaceDetail;
-import com.kustacks.kuring.building.adapter.in.web.dto.model.CurrentOperatingHours;
+import com.kustacks.kuring.building.adapter.in.web.dto.model.OperatingHoursDto;
 
 import java.util.List;
 
@@ -12,7 +12,7 @@ public record BuildingDetailResponse(
         Double latitude,
         Double longitude,
         String imageUrl,
-        CurrentOperatingHours currentOperatingHours,
+        List<OperatingHoursDto> operatingHours,
         List<CampusPlaceDetail> campusPlaces
 ) {
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/CampusPlaceDetail.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/CampusPlaceDetail.java
@@ -1,5 +1,7 @@
 package com.kustacks.kuring.building.adapter.in.web.dto.model;
 
+import java.util.List;
+
 public record CampusPlaceDetail(
         Long id,
         String name,
@@ -10,7 +12,7 @@ public record CampusPlaceDetail(
         String floor,
         String locationDetail,
         Integer quantity,
-        CurrentOperatingHours currentOperatingHours,
+        List<OperatingHoursDto> operatingHours,
         String externalUrl
 ) {
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/CampusPlaceItem.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/CampusPlaceItem.java
@@ -1,5 +1,7 @@
 package com.kustacks.kuring.building.adapter.in.web.dto.model;
 
+import java.util.List;
+
 public record CampusPlaceItem(
         Long id,
         String name,
@@ -10,7 +12,7 @@ public record CampusPlaceItem(
         String floor,
         String locationDetail,
         Integer quantity,
-        CurrentOperatingHours currentOperatingHours,
+        List<OperatingHoursDto> operatingHours,
         String externalUrl,
         BuildingSummary building
 ) {

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/OperatingHoursDto.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/OperatingHoursDto.java
@@ -1,10 +1,11 @@
 package com.kustacks.kuring.building.adapter.in.web.dto.model;
 
-public record CurrentOperatingHours(
+public record OperatingHoursDto(
         String period,
         String dayGroup,
         String status,
         String opensAt,
-        String closesAt
+        String closesAt,
+        boolean isCurrent
 ) {
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/mock/CampusMapMockFixture.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/mock/CampusMapMockFixture.java
@@ -9,11 +9,13 @@ import com.kustacks.kuring.building.adapter.in.web.dto.model.BuildingSummary;
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CampusPlaceDetail;
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CampusPlaceItem;
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CategoryDto;
-import com.kustacks.kuring.building.adapter.in.web.dto.model.CurrentOperatingHours;
+import com.kustacks.kuring.building.adapter.in.web.dto.model.OperatingHoursDto;
 import com.kustacks.kuring.building.domain.CampusPlaceLocationType;
 import com.kustacks.kuring.building.domain.OperatingDayGroup;
 import com.kustacks.kuring.building.domain.OperatingHoursStatus;
 import com.kustacks.kuring.building.domain.OperatingPeriod;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,297 +26,560 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-//TODO : 실제 데이터 기반 API 구현 완료 시 제거
+// TODO : 실제 데이터 기반 API 구현 완료 시 제거
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CampusMapMockFixture {
 
-    private CampusMapMockFixture() {
-    }
-
     private static final String ADDRESS = "서울특별시 광진구 능동로 120";
+    private static final String KCUBE_EXTERNAL_URL = "https://wein.konkuk.ac.kr/";
 
-    private static final CurrentOperatingHours STUDENT_CENTER_HOURS =
-            new CurrentOperatingHours(
+    private static final String MOCK_BUILDING_IMAGE_URL = "https://placehold.co/1200x800/png?text=Konkuk+University";
+    private static final String MOCK_CAFE_IMAGE_URL = "https://placehold.co/600x400/png?text=Cafe";
+    private static final String MOCK_RESTAURANT_IMAGE_URL = "https://placehold.co/600x400/png?text=Restaurant";
+    private static final String MOCK_PRINTER_IMAGE_URL = "https://placehold.co/600x400/png?text=Printer";
+    private static final String MOCK_CONVENIENCE_STORE_IMAGE_URL = "https://placehold.co/600x400/png?text=Convenience+Store";
+    private static final String MOCK_LOUNGE_IMAGE_URL = "https://placehold.co/600x400/png?text=Lounge";
+    private static final String MOCK_KCUBE_IMAGE_URL = "https://placehold.co/600x400/png?text=K-Cube";
+
+    private static final List<OperatingHoursDto> MOCK_BUILDING_HOURS = List.of(
+            new OperatingHoursDto(
                     OperatingPeriod.SEMESTER.toString(),
                     OperatingDayGroup.WEEKDAY.toString(),
                     OperatingHoursStatus.SCHEDULED.toString(),
                     "08:00",
-                    "22:00"
-            );
-
-    private static final CurrentOperatingHours BUSINESS_BUILDING_HOURS =
-            new CurrentOperatingHours(
+                    "22:00",
+                    false
+            ),
+            new OperatingHoursDto(
                     OperatingPeriod.SEMESTER.toString(),
+                    OperatingDayGroup.WEEKEND.toString(),
+                    OperatingHoursStatus.SCHEDULED.toString(),
+                    "09:00",
+                    "18:00",
+                    false
+            ),
+            new OperatingHoursDto(
+                    OperatingPeriod.VACATION.toString(),
                     OperatingDayGroup.WEEKDAY.toString(),
                     OperatingHoursStatus.SCHEDULED.toString(),
                     "09:00",
-                    "21:00"
-            );
-
-    private static final CurrentOperatingHours OPEN_24_HOURS =
-            new CurrentOperatingHours(
-                    OperatingPeriod.SEMESTER.toString(),
-                    OperatingDayGroup.WEEKDAY.toString(),
-                    OperatingHoursStatus.OPEN_24_HOURS.toString(),
-                    null,
-                    null
-            );
-
-    private static final CurrentOperatingHours RESTAURANT_HOURS =
-            new CurrentOperatingHours(
-                    OperatingPeriod.SEMESTER.toString(),
-                    OperatingDayGroup.WEEKDAY.toString(),
-                    OperatingHoursStatus.SCHEDULED.toString(),
-                    "10:30",
-                    "19:00"
-            );
-
-    private static final CurrentOperatingHours UNKNOWN_HOURS =
-            new CurrentOperatingHours(
+                    "18:00",
+                    true
+            ),
+            new OperatingHoursDto(
                     OperatingPeriod.VACATION.toString(),
                     OperatingDayGroup.WEEKEND.toString(),
                     OperatingHoursStatus.UNKNOWN.toString(),
                     null,
-                    null
-            );
+                    null,
+                    false
+            )
+    );
+
+    private static final List<OperatingHoursDto> MOCK_STORE_HOURS = List.of(
+            new OperatingHoursDto(
+                    OperatingPeriod.SEMESTER.toString(),
+                    OperatingDayGroup.WEEKDAY.toString(),
+                    OperatingHoursStatus.SCHEDULED.toString(),
+                    "08:00",
+                    "22:00",
+                    false
+            ),
+            new OperatingHoursDto(
+                    OperatingPeriod.SEMESTER.toString(),
+                    OperatingDayGroup.WEEKEND.toString(),
+                    OperatingHoursStatus.SCHEDULED.toString(),
+                    "09:00",
+                    "18:00",
+                    false
+            ),
+            new OperatingHoursDto(
+                    OperatingPeriod.VACATION.toString(),
+                    OperatingDayGroup.WEEKDAY.toString(),
+                    OperatingHoursStatus.SCHEDULED.toString(),
+                    "09:00",
+                    "18:00",
+                    true
+            ),
+            new OperatingHoursDto(
+                    OperatingPeriod.VACATION.toString(),
+                    OperatingDayGroup.WEEKEND.toString(),
+                    OperatingHoursStatus.UNKNOWN.toString(),
+                    null,
+                    null,
+                    false
+            )
+    );
+
+    private static final List<OperatingHoursDto> MOCK_RESTAURANT_HOURS = List.of(
+            new OperatingHoursDto(
+                    OperatingPeriod.SEMESTER.toString(),
+                    OperatingDayGroup.WEEKDAY.toString(),
+                    OperatingHoursStatus.SCHEDULED.toString(),
+                    "10:30",
+                    "19:00",
+                    false
+            ),
+            new OperatingHoursDto(
+                    OperatingPeriod.SEMESTER.toString(),
+                    OperatingDayGroup.WEEKEND.toString(),
+                    OperatingHoursStatus.UNKNOWN.toString(),
+                    null,
+                    null,
+                    false
+            ),
+            new OperatingHoursDto(
+                    OperatingPeriod.VACATION.toString(),
+                    OperatingDayGroup.WEEKDAY.toString(),
+                    OperatingHoursStatus.SCHEDULED.toString(),
+                    "11:00",
+                    "17:00",
+                    true
+            ),
+            new OperatingHoursDto(
+                    OperatingPeriod.VACATION.toString(),
+                    OperatingDayGroup.WEEKEND.toString(),
+                    OperatingHoursStatus.UNKNOWN.toString(),
+                    null,
+                    null,
+                    false
+            )
+    );
+
+    private static final List<OperatingHoursDto> MOCK_OPEN_24_HOURS = List.of(
+            new OperatingHoursDto(
+                    OperatingPeriod.SEMESTER.toString(),
+                    OperatingDayGroup.WEEKDAY.toString(),
+                    OperatingHoursStatus.OPEN_24_HOURS.toString(),
+                    null,
+                    null,
+                    false
+            ),
+            new OperatingHoursDto(
+                    OperatingPeriod.SEMESTER.toString(),
+                    OperatingDayGroup.WEEKEND.toString(),
+                    OperatingHoursStatus.OPEN_24_HOURS.toString(),
+                    null,
+                    null,
+                    false
+            ),
+            new OperatingHoursDto(
+                    OperatingPeriod.VACATION.toString(),
+                    OperatingDayGroup.WEEKDAY.toString(),
+                    OperatingHoursStatus.OPEN_24_HOURS.toString(),
+                    null,
+                    null,
+                    true
+            ),
+            new OperatingHoursDto(
+                    OperatingPeriod.VACATION.toString(),
+                    OperatingDayGroup.WEEKEND.toString(),
+                    OperatingHoursStatus.OPEN_24_HOURS.toString(),
+                    null,
+                    null,
+                    false
+            )
+    );
 
     private static final BuildingSummary ADMINISTRATION_BUILDING =
-            new BuildingSummary(1L, "행정관", ADDRESS, 37.54241, 127.07382);
-
+            new BuildingSummary(1L, "행정관", ADDRESS, 37.5444801, 127.0748518);
     private static final BuildingSummary BUSINESS_BUILDING =
-            new BuildingSummary(2L, "경영관", ADDRESS, 37.54196, 127.07531);
-
+            new BuildingSummary(2L, "경영관", ADDRESS, 37.5443474, 127.0761119);
     private static final BuildingSummary LAW_BUILDING =
-            new BuildingSummary(3L, "법학관", ADDRESS, 37.54174, 127.07649);
-
+            new BuildingSummary(3L, "법학관", ADDRESS, 37.5417036, 127.0750767);
     private static final BuildingSummary STUDENT_CENTER_BUILDING =
-            new BuildingSummary(4L, "학생회관", ADDRESS, 37.5412, 127.0784);
+            new BuildingSummary(4L, "학생회관", ADDRESS, 37.5418230, 127.0779007);
+    private static final BuildingSummary SANGHUH_RESEARCH_BUILDING =
+            new BuildingSummary(5L, "상허연구관", ADDRESS, 37.5441512, 127.0752711);
+    private static final BuildingSummary EDUCATION_SCIENCE_BUILDING =
+            new BuildingSummary(6L, "교육과학관", ADDRESS, 37.5440445, 127.0742795);
+    private static final BuildingSummary ARTS_AND_DESIGN_BUILDING =
+            new BuildingSummary(7L, "예술문화관", ADDRESS, 37.5428728, 127.0731471);
+    private static final BuildingSummary LANGUAGE_INSTITUTE_BUILDING =
+            new BuildingSummary(8L, "언어교육원", ADDRESS, 37.5425576, 127.0747825);
+    private static final BuildingSummary MUSEUM_BUILDING =
+            new BuildingSummary(9L, "박물관", ADDRESS, 37.5423644, 127.0756128);
+    private static final BuildingSummary SANGHUH_LIBRARY_BUILDING =
+            new BuildingSummary(10L, "상허기념도서관", ADDRESS, 37.5420474, 127.0738384);
+    private static final BuildingSummary BIOMEDICAL_SCIENCE_BUILDING =
+            new BuildingSummary(11L, "의생명과학연구관", ADDRESS, 37.5414668, 127.0723294);
+    private static final BuildingSummary LIFE_SCIENCES_BUILDING =
+            new BuildingSummary(12L, "생명과학관", ADDRESS, 37.5408856, 127.0742996);
+    private static final BuildingSummary ANIMAL_SCIENCES_BUILDING =
+            new BuildingSummary(13L, "동물생명과학관", ADDRESS, 37.5403172, 127.0743016);
+    private static final BuildingSummary ADMISSION_INFORMATION_BUILDING =
+            new BuildingSummary(14L, "입학정보관", ADDRESS, 37.5402602, 127.0735777);
+    private static final BuildingSummary INDUSTRY_COOPERATION_BUILDING =
+            new BuildingSummary(15L, "산학협동관", ADDRESS, 37.5397277, 127.0732197);
+    private static final BuildingSummary NEW_MILLENNIUM_BUILDING =
+            new BuildingSummary(16L, "새천년관", ADDRESS, 37.5435675, 127.0774647);
+    private static final BuildingSummary ARCHITECTURE_BUILDING =
+            new BuildingSummary(17L, "건축관", ADDRESS, 37.5434694, 127.0784422);
+    private static final BuildingSummary REAL_ESTATE_BUILDING =
+            new BuildingSummary(18L, "해봉부동산학관", ADDRESS, 37.5433334, 127.0782018);
+    private static final BuildingSummary LIBERAL_ARTS_BUILDING =
+            new BuildingSummary(19L, "인문학관", ADDRESS, 37.5427150, 127.0787664);
+    private static final BuildingSummary SCIENCE_BUILDING =
+            new BuildingSummary(20L, "과학관", ADDRESS, 37.5414670, 127.0805824);
 
     private static final List<CategoryDto> CATEGORIES = List.of(
             new CategoryDto("cafe", "카페", 1),
-            new CategoryDto("restaurant", "음식점", 2),
+            new CategoryDto("restaurant", "식당", 2),
             new CategoryDto("printer", "프린터", 3),
             new CategoryDto("smoking_booth", "흡연부스", 4),
             new CategoryDto("convenience_store", "편의점", 5),
-            new CategoryDto("lounge", "휴게공간", 6),
-            new CategoryDto("kcube", "K-Cube", 7)
+            new CategoryDto("lounge", "휴게실", 6),
+            new CategoryDto("kcube", "KCUBE", 7)
     );
 
     private static final List<BuildingSummary> BUILDINGS = List.of(
             ADMINISTRATION_BUILDING,
             BUSINESS_BUILDING,
             LAW_BUILDING,
-            STUDENT_CENTER_BUILDING
+            STUDENT_CENTER_BUILDING,
+            SANGHUH_RESEARCH_BUILDING,
+            EDUCATION_SCIENCE_BUILDING,
+            ARTS_AND_DESIGN_BUILDING,
+            LANGUAGE_INSTITUTE_BUILDING,
+            MUSEUM_BUILDING,
+            SANGHUH_LIBRARY_BUILDING,
+            BIOMEDICAL_SCIENCE_BUILDING,
+            LIFE_SCIENCES_BUILDING,
+            ANIMAL_SCIENCES_BUILDING,
+            ADMISSION_INFORMATION_BUILDING,
+            INDUSTRY_COOPERATION_BUILDING,
+            NEW_MILLENNIUM_BUILDING,
+            ARCHITECTURE_BUILDING,
+            REAL_ESTATE_BUILDING,
+            LIBERAL_ARTS_BUILDING,
+            SCIENCE_BUILDING
     );
 
-    private static final List<BuildingSummary> SEARCHABLE_BUILDINGS = BUILDINGS;
-
     private static final Map<Long, List<String>> BUILDING_SEARCH_KEYWORDS = Map.of(
-            3L, List.of("종강"),
-            4L, List.of("학관")
+            LAW_BUILDING.id(), List.of("종강", "종합강의동"),
+            STUDENT_CENTER_BUILDING.id(), List.of("학관", "제1학생회관")
     );
 
     private static final List<CampusPlaceItem> CAMPUS_PLACES = List.of(
-            new CampusPlaceItem(
-                    101L,
-                    "학생회관 편의점",
-                    "convenience_store",
-                    "편의점",
-                    "https://placehold.co/600x400/png?text=Convenience+Store",
-                    CampusPlaceLocationType.INDOOR.toString(),
-                    "1F",
-                    "학생회관 정문 오른쪽",
-                    null,
-                    STUDENT_CENTER_HOURS,
-                    null,
-                    STUDENT_CENTER_BUILDING
-            ),
-            new CampusPlaceItem(
-                    102L,
-                    "학생회관 1층 라운지 프린터",
-                    "printer",
-                    "프린터",
-                    "https://placehold.co/600x400/png?text=Printer",
-                    CampusPlaceLocationType.INDOOR.toString(),
-                    "1F",
-                    "라운지 안쪽",
-                    3,
-                    STUDENT_CENTER_HOURS,
-                    null,
-                    STUDENT_CENTER_BUILDING
-            ),
-            new CampusPlaceItem(
-                    104L,
-                    "학생회관 학생식당",
-                    "restaurant",
-                    "음식점",
-                    "https://placehold.co/600x400/png?text=Restaurant",
-                    CampusPlaceLocationType.INDOOR.toString(),
-                    "B1",
-                    "지하 1층 중앙",
-                    null,
-                    RESTAURANT_HOURS,
-                    null,
-                    STUDENT_CENTER_BUILDING
-            ),
-            new CampusPlaceItem(
-                    201L,
-                    "경영관 카페",
-                    "cafe",
-                    "카페",
-                    "https://placehold.co/600x400/png?text=Cafe",
-                    CampusPlaceLocationType.INDOOR.toString(),
-                    "1F",
-                    "정문 왼쪽",
-                    null,
-                    BUSINESS_BUILDING_HOURS,
-                    null,
-                    BUSINESS_BUILDING
-            ),
-            new CampusPlaceItem(
-                    202L,
-                    "경영관 2층 휴게공간",
-                    "lounge",
-                    "휴게공간",
-                    "https://placehold.co/600x400/png?text=Lounge",
-                    CampusPlaceLocationType.INDOOR.toString(),
-                    "2F",
-                    "중앙 계단 옆",
-                    null,
-                    UNKNOWN_HOURS,
-                    null,
-                    BUSINESS_BUILDING
-            ),
-            new CampusPlaceItem(
-                    203L,
-                    "경영관 지하 1층 프린터",
-                    "printer",
-                    "프린터",
-                    "https://placehold.co/600x400/png?text=Printer",
-                    CampusPlaceLocationType.INDOOR.toString(),
-                    "B1",
-                    "엘리베이터 맞은편",
-                    1,
-                    BUSINESS_BUILDING_HOURS,
-                    null,
-                    BUSINESS_BUILDING
-            ),
-            new CampusPlaceItem(
-                    301L,
-                    "법학관 K-Cube",
-                    "kcube",
-                    "K-Cube",
-                    "https://placehold.co/600x400/png?text=K-Cube",
-                    CampusPlaceLocationType.INDOOR.toString(),
-                    "1F",
-                    "1층 로비",
-                    null,
-                    BUSINESS_BUILDING_HOURS,
-                    "https://wein.konkuk.ac.kr/",
-                    LAW_BUILDING
-            ),
-            new CampusPlaceItem(
-                    401L,
-                    "행정관 외부 흡연부스",
-                    "smoking_booth",
-                    "흡연부스",
-                    "https://placehold.co/600x400/png?text=Smoking+Booth",
-                    CampusPlaceLocationType.OUTDOOR.toString(),
-                    "OUTDOOR",
-                    "행정관 후문 맞은편",
-                    1,
-                    OPEN_24_HOURS,
-                    null,
-                    ADMINISTRATION_BUILDING
-            )
+            cafe(201L, "카페 레스티오", "1F", "경영관 1층", BUSINESS_BUILDING),
+            convenienceStore(202L, "CU 경영관점", "1F", "경영관 1층", BUSINESS_BUILDING),
+            kcube(203L, "경영관 K-Hub", "1F", "경영관 1층", BUSINESS_BUILDING),
+            lounge(204L, "경영관 휴게실", null, "경영관 내부", BUSINESS_BUILDING),
+
+            printer(301L, "법학관 인쇄소", "B1", "법학관 지하 1층", LAW_BUILDING),
+            lounge(302L, "법학관 휴게실", null, "법학관 내부", LAW_BUILDING),
+
+            convenienceStore(401L, "CU 학생회관점", "1F", "학생회관 1층", STUDENT_CENTER_BUILDING),
+            printer(402L, "학생회관 복사실", "1F", "학생회관 1층", STUDENT_CENTER_BUILDING),
+            restaurant(403L, "KU's Kitchen", "1F", "학생회관 1층", STUDENT_CENTER_BUILDING),
+            restaurant(404L, "구시아 푸드마켓", "B1", "학생회관 지하 1층", STUDENT_CENTER_BUILDING),
+            cafe(405L, "1847 샐러드카페", "1F", "학생회관 1층", STUDENT_CENTER_BUILDING),
+
+            printer(501L, "상허연구관 복사실", "1F", "상허연구관 1층", SANGHUH_RESEARCH_BUILDING),
+            cafe(502L, "카페 블루포트", "1F", "상허연구관 1층", SANGHUH_RESEARCH_BUILDING),
+            kcube(503L, "상허연구관 K-Cube", "3F", "상허연구관 3층", SANGHUH_RESEARCH_BUILDING),
+
+            cafe(701L, "카페 레스티오", "B1", "예술문화관 지하 1층", ARTS_AND_DESIGN_BUILDING),
+
+            convenienceStore(1001L, "CU 상허기념도서관점", "3F", "상허기념도서관 3층", SANGHUH_LIBRARY_BUILDING),
+            restaurant(1002L, "구시아 푸드마켓", "B1", "상허기념도서관 지하 1층", SANGHUH_LIBRARY_BUILDING),
+            kcube(1003L, "상허기념도서관 K-Cube", "6F", "상허기념도서관 6층", SANGHUH_LIBRARY_BUILDING),
+
+            convenienceStore(1101L, "CU 의생명과학연구관점", "1F", "의생명과학연구관 1층", BIOMEDICAL_SCIENCE_BUILDING),
+
+            kcube(1201L, "생명과학관 K-Cube", "3F", "생명과학관 3층", LIFE_SCIENCES_BUILDING),
+
+            cafe(1301L, "카페 레스티오", "1F", "동물생명과학관 1층", ANIMAL_SCIENCES_BUILDING),
+            kcube(1302L, "동물생명과학관 K-Cube", "1F", "동물생명과학관 1층", ANIMAL_SCIENCES_BUILDING),
+
+            convenienceStore(1501L, "이마트24 산학협동관점", "1F", "산학협동관 1층", INDUSTRY_COOPERATION_BUILDING),
+            printer(1502L, "산학협동관 복사실", "2F", "산학협동관 2층", INDUSTRY_COOPERATION_BUILDING),
+
+            restaurant(1601L, "KU's Dining", "B1", "새천년관 지하 1층", NEW_MILLENNIUM_BUILDING),
+
+            kcube(1701L, "건축관 K-Hub", "1F", "건축관 1층", ARCHITECTURE_BUILDING),
+
+            cafe(1801L, "카페 ING", "1F", "해봉부동산학관 1층", REAL_ESTATE_BUILDING),
+
+            kcube(2001L, "과학관 K-Hub", "1F", "과학관 1층", SCIENCE_BUILDING)
     );
 
-    private static final CampusPlaceDetail STUDENT_CENTER_ATM =
-            new CampusPlaceDetail(
-                    103L,
-                    "신한은행 학생회관 ATM",
-                    "bank_atm",
-                    "은행·ATM",
-                    "https://placehold.co/600x400/png?text=ATM",
-                    CampusPlaceLocationType.INDOOR.toString(),
-                    "1F",
-                    "서측 출입구 옆",
-                    2,
-                    OPEN_24_HOURS,
-                    null
-            );
-
-    private static final BuildingDetailResponse ADMINISTRATION_BUILDING_DETAIL = buildingDetail(
-            ADMINISTRATION_BUILDING,
-            "https://placehold.co/1200x800/png?text=Administration+Building",
-            BUSINESS_BUILDING_HOURS
+    private static final CampusPlaceDetail STUDENT_CENTER_BANK = new CampusPlaceDetail(
+            406L,
+            "신한은행",
+            "bank_atm",
+            "은행·ATM",
+            "https://placehold.co/600x400/png?text=Shinhan+Bank",
+            CampusPlaceLocationType.INDOOR.toString(),
+            "1F",
+            "학생회관 1층",
+            null,
+            MOCK_STORE_HOURS,
+            null
     );
 
-    private static final BuildingDetailResponse BUSINESS_BUILDING_DETAIL = buildingDetail(
-            BUSINESS_BUILDING,
-            "https://placehold.co/1200x800/png?text=Business+Building",
-            BUSINESS_BUILDING_HOURS
+    private static final CampusPlaceDetail STUDENT_CENTER_POST_OFFICE = new CampusPlaceDetail(
+            407L,
+            "건국대학교 우편취급국",
+            "post_office",
+            "우편",
+            "https://placehold.co/600x400/png?text=Post+Office",
+            CampusPlaceLocationType.INDOOR.toString(),
+            "1F",
+            "학생회관 1층",
+            null,
+            MOCK_STORE_HOURS,
+            null
     );
 
-    private static final BuildingDetailResponse LAW_BUILDING_DETAIL = buildingDetail(
-            LAW_BUILDING,
-            "https://placehold.co/1200x800/png?text=Law+Building",
-            BUSINESS_BUILDING_HOURS
-    );
-
+    private static final BuildingDetailResponse ADMINISTRATION_BUILDING_DETAIL =
+            buildingDetail(ADMINISTRATION_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse BUSINESS_BUILDING_DETAIL =
+            buildingDetail(BUSINESS_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse LAW_BUILDING_DETAIL =
+            buildingDetail(LAW_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
     private static final BuildingDetailResponse STUDENT_CENTER_DETAIL = buildingDetail(
-            STUDENT_CENTER_BUILDING,
-            "https://placehold.co/1200x800/png?text=Student+Center",
-            STUDENT_CENTER_HOURS,
-            STUDENT_CENTER_ATM
+            STUDENT_CENTER_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS, STUDENT_CENTER_BANK, STUDENT_CENTER_POST_OFFICE);
+    private static final BuildingDetailResponse SANGHUH_RESEARCH_BUILDING_DETAIL =
+            buildingDetail(SANGHUH_RESEARCH_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse EDUCATION_SCIENCE_BUILDING_DETAIL =
+            buildingDetail(EDUCATION_SCIENCE_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse ARTS_AND_DESIGN_BUILDING_DETAIL =
+            buildingDetail(ARTS_AND_DESIGN_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse LANGUAGE_INSTITUTE_BUILDING_DETAIL =
+            buildingDetail(LANGUAGE_INSTITUTE_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse MUSEUM_BUILDING_DETAIL =
+            buildingDetail(MUSEUM_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse SANGHUH_LIBRARY_BUILDING_DETAIL =
+            buildingDetail(SANGHUH_LIBRARY_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse BIOMEDICAL_SCIENCE_BUILDING_DETAIL =
+            buildingDetail(BIOMEDICAL_SCIENCE_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse LIFE_SCIENCES_BUILDING_DETAIL =
+            buildingDetail(LIFE_SCIENCES_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse ANIMAL_SCIENCES_BUILDING_DETAIL =
+            buildingDetail(ANIMAL_SCIENCES_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse ADMISSION_INFORMATION_BUILDING_DETAIL =
+            buildingDetail(ADMISSION_INFORMATION_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse INDUSTRY_COOPERATION_BUILDING_DETAIL =
+            buildingDetail(INDUSTRY_COOPERATION_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse NEW_MILLENNIUM_BUILDING_DETAIL =
+            buildingDetail(NEW_MILLENNIUM_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse ARCHITECTURE_BUILDING_DETAIL =
+            buildingDetail(ARCHITECTURE_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse REAL_ESTATE_BUILDING_DETAIL =
+            buildingDetail(REAL_ESTATE_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse LIBERAL_ARTS_BUILDING_DETAIL =
+            buildingDetail(LIBERAL_ARTS_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+    private static final BuildingDetailResponse SCIENCE_BUILDING_DETAIL =
+            buildingDetail(SCIENCE_BUILDING, MOCK_BUILDING_IMAGE_URL, MOCK_BUILDING_HOURS);
+
+    private static final Map<Long, BuildingDetailResponse> BUILDING_DETAILS = Map.ofEntries(
+            Map.entry(ADMINISTRATION_BUILDING_DETAIL.id(), ADMINISTRATION_BUILDING_DETAIL),
+            Map.entry(BUSINESS_BUILDING_DETAIL.id(), BUSINESS_BUILDING_DETAIL),
+            Map.entry(LAW_BUILDING_DETAIL.id(), LAW_BUILDING_DETAIL),
+            Map.entry(STUDENT_CENTER_DETAIL.id(), STUDENT_CENTER_DETAIL),
+            Map.entry(SANGHUH_RESEARCH_BUILDING_DETAIL.id(), SANGHUH_RESEARCH_BUILDING_DETAIL),
+            Map.entry(EDUCATION_SCIENCE_BUILDING_DETAIL.id(), EDUCATION_SCIENCE_BUILDING_DETAIL),
+            Map.entry(ARTS_AND_DESIGN_BUILDING_DETAIL.id(), ARTS_AND_DESIGN_BUILDING_DETAIL),
+            Map.entry(LANGUAGE_INSTITUTE_BUILDING_DETAIL.id(), LANGUAGE_INSTITUTE_BUILDING_DETAIL),
+            Map.entry(MUSEUM_BUILDING_DETAIL.id(), MUSEUM_BUILDING_DETAIL),
+            Map.entry(SANGHUH_LIBRARY_BUILDING_DETAIL.id(), SANGHUH_LIBRARY_BUILDING_DETAIL),
+            Map.entry(BIOMEDICAL_SCIENCE_BUILDING_DETAIL.id(), BIOMEDICAL_SCIENCE_BUILDING_DETAIL),
+            Map.entry(LIFE_SCIENCES_BUILDING_DETAIL.id(), LIFE_SCIENCES_BUILDING_DETAIL),
+            Map.entry(ANIMAL_SCIENCES_BUILDING_DETAIL.id(), ANIMAL_SCIENCES_BUILDING_DETAIL),
+            Map.entry(ADMISSION_INFORMATION_BUILDING_DETAIL.id(), ADMISSION_INFORMATION_BUILDING_DETAIL),
+            Map.entry(INDUSTRY_COOPERATION_BUILDING_DETAIL.id(), INDUSTRY_COOPERATION_BUILDING_DETAIL),
+            Map.entry(NEW_MILLENNIUM_BUILDING_DETAIL.id(), NEW_MILLENNIUM_BUILDING_DETAIL),
+            Map.entry(ARCHITECTURE_BUILDING_DETAIL.id(), ARCHITECTURE_BUILDING_DETAIL),
+            Map.entry(REAL_ESTATE_BUILDING_DETAIL.id(), REAL_ESTATE_BUILDING_DETAIL),
+            Map.entry(LIBERAL_ARTS_BUILDING_DETAIL.id(), LIBERAL_ARTS_BUILDING_DETAIL),
+            Map.entry(SCIENCE_BUILDING_DETAIL.id(), SCIENCE_BUILDING_DETAIL)
     );
 
-    private static final Map<Long, BuildingDetailResponse> BUILDING_DETAILS = Map.of(
-            ADMINISTRATION_BUILDING_DETAIL.id(), ADMINISTRATION_BUILDING_DETAIL,
-            BUSINESS_BUILDING_DETAIL.id(), BUSINESS_BUILDING_DETAIL,
-            LAW_BUILDING_DETAIL.id(), LAW_BUILDING_DETAIL,
-            STUDENT_CENTER_DETAIL.id(), STUDENT_CENTER_DETAIL
-    );
-
-    public static CategoryListResponse categories() {
+    public static CategoryListResponse mockCategories() {
         return new CategoryListResponse(CATEGORIES);
     }
 
-    public static BuildingListResponse buildings() {
+    public static BuildingListResponse mockBuildings() {
         return new BuildingListResponse(BUILDINGS);
     }
 
-    public static BuildingSearchResponse searchBuildings(String keyword) {
-        String normalizedKeyword = normalize(keyword);
-
-        var buildings = SEARCHABLE_BUILDINGS.stream()
-                .filter(building -> matchesKeyword(building, normalizedKeyword))
+    public static BuildingSearchResponse mockBuildingSearchResult(String keyword) {
+        String normalizedKeyword = keyword.trim().toLowerCase(Locale.ROOT);
+        var buildings = BUILDINGS.stream()
+                .filter(building -> containsKeyword(building, normalizedKeyword))
                 .toList();
 
         return new BuildingSearchResponse(buildings);
     }
 
-    public static CampusPlaceListResponse campusPlaces(List<String> categories) {
-        Set<String> requestedCategories = categories.stream()
-                .flatMap(category -> Arrays.stream(category.split(",")))
-                .map(CampusMapMockFixture::normalize)
-                .filter(category -> !category.isBlank())
+    public static CampusPlaceListResponse mockCampusPlaces(List<String> categories) {
+        Set<String> normalizedCategories = categories.stream()
+                .map(category -> category.trim().toLowerCase(Locale.ROOT))
                 .collect(Collectors.toSet());
-
         var campusPlaces = CAMPUS_PLACES.stream()
-                .filter(place -> requestedCategories.contains(place.category()))
+                .filter(campusPlace -> normalizedCategories.contains(campusPlace.category()))
                 .toList();
 
         return new CampusPlaceListResponse(campusPlaces);
     }
 
-    public static Optional<BuildingDetailResponse> findBuildingDetail(Long buildingId) {
+    public static Optional<BuildingDetailResponse> findMockBuildingDetail(Long buildingId) {
         return Optional.ofNullable(BUILDING_DETAILS.get(buildingId));
+    }
+
+    private static boolean containsKeyword(BuildingSummary building, String keyword) {
+        if (building.name().toLowerCase(Locale.ROOT).contains(keyword)
+                || building.address().toLowerCase(Locale.ROOT).contains(keyword)) {
+            return true;
+        }
+
+        return BUILDING_SEARCH_KEYWORDS.getOrDefault(building.id(), List.of()).stream()
+                .anyMatch(searchKeyword -> searchKeyword.toLowerCase(Locale.ROOT).contains(keyword));
+    }
+
+    private static CampusPlaceItem cafe(
+            Long id,
+            String name,
+            String floor,
+            String locationDetail,
+            BuildingSummary building
+    ) {
+        return new CampusPlaceItem(
+                id,
+                name,
+                "cafe",
+                "카페",
+                MOCK_CAFE_IMAGE_URL,
+                CampusPlaceLocationType.INDOOR.toString(),
+                floor,
+                locationDetail,
+                null,
+                MOCK_STORE_HOURS,
+                null,
+                building
+        );
+    }
+
+    private static CampusPlaceItem restaurant(
+            Long id,
+            String name,
+            String floor,
+            String locationDetail,
+            BuildingSummary building
+    ) {
+        return new CampusPlaceItem(
+                id,
+                name,
+                "restaurant",
+                "식당",
+                MOCK_RESTAURANT_IMAGE_URL,
+                CampusPlaceLocationType.INDOOR.toString(),
+                floor,
+                locationDetail,
+                null,
+                MOCK_RESTAURANT_HOURS,
+                null,
+                building
+        );
+    }
+
+    private static CampusPlaceItem printer(
+            Long id,
+            String name,
+            String floor,
+            String locationDetail,
+            BuildingSummary building
+    ) {
+        return new CampusPlaceItem(
+                id,
+                name,
+                "printer",
+                "프린터",
+                MOCK_PRINTER_IMAGE_URL,
+                CampusPlaceLocationType.INDOOR.toString(),
+                floor,
+                locationDetail,
+                null,
+                MOCK_STORE_HOURS,
+                null,
+                building
+        );
+    }
+
+    private static CampusPlaceItem convenienceStore(
+            Long id,
+            String name,
+            String floor,
+            String locationDetail,
+            BuildingSummary building
+    ) {
+        return new CampusPlaceItem(
+                id,
+                name,
+                "convenience_store",
+                "편의점",
+                MOCK_CONVENIENCE_STORE_IMAGE_URL,
+                CampusPlaceLocationType.INDOOR.toString(),
+                floor,
+                locationDetail,
+                null,
+                MOCK_STORE_HOURS,
+                null,
+                building
+        );
+    }
+
+    private static CampusPlaceItem lounge(
+            Long id,
+            String name,
+            String floor,
+            String locationDetail,
+            BuildingSummary building
+    ) {
+        return new CampusPlaceItem(
+                id,
+                name,
+                "lounge",
+                "휴게실",
+                MOCK_LOUNGE_IMAGE_URL,
+                CampusPlaceLocationType.INDOOR.toString(),
+                floor,
+                locationDetail,
+                null,
+                MOCK_OPEN_24_HOURS,
+                null,
+                building
+        );
+    }
+
+    private static CampusPlaceItem kcube(
+            Long id,
+            String name,
+            String floor,
+            String locationDetail,
+            BuildingSummary building
+    ) {
+        return new CampusPlaceItem(
+                id,
+                name,
+                "kcube",
+                "KCUBE",
+                MOCK_KCUBE_IMAGE_URL,
+                CampusPlaceLocationType.INDOOR.toString(),
+                floor,
+                locationDetail,
+                null,
+                MOCK_BUILDING_HOURS,
+                KCUBE_EXTERNAL_URL,
+                building
+        );
     }
 
     private static BuildingDetailResponse buildingDetail(
             BuildingSummary building,
             String imageUrl,
-            CurrentOperatingHours currentOperatingHours,
+            List<OperatingHoursDto> operatingHours,
             CampusPlaceDetail... additionalCampusPlaces
     ) {
         var campusPlaces = Stream.concat(
@@ -331,7 +596,7 @@ public final class CampusMapMockFixture {
                 building.latitude(),
                 building.longitude(),
                 imageUrl,
-                currentOperatingHours,
+                operatingHours,
                 campusPlaces
         );
     }
@@ -347,25 +612,8 @@ public final class CampusMapMockFixture {
                 campusPlace.floor(),
                 campusPlace.locationDetail(),
                 campusPlace.quantity(),
-                campusPlace.currentOperatingHours(),
+                campusPlace.operatingHours(),
                 campusPlace.externalUrl()
         );
-    }
-
-    private static boolean matchesKeyword(
-            BuildingSummary building,
-            String normalizedKeyword
-    ) {
-        if (normalize(building.name()).contains(normalizedKeyword)) {
-            return true;
-        }
-
-        return BUILDING_SEARCH_KEYWORDS.getOrDefault(building.id(), List.of()).stream()
-                .map(CampusMapMockFixture::normalize)
-                .anyMatch(keyword -> keyword.contains(normalizedKeyword));
-    }
-
-    private static String normalize(String value) {
-        return value.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/mock/CampusMapMockFixture.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/mock/CampusMapMockFixture.java
@@ -534,7 +534,7 @@ public final class CampusMapMockFixture {
                 "흡연부스",
                 MOCK_SMOKING_BOOTH_IMAGE_URL,
                 CampusPlaceLocationType.OUTDOOR.toString(),
-                "OUTDOOR",
+                null,
                 locationDetail,
                 1,
                 MOCK_OPEN_24_HOURS,

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/mock/CampusMapMockFixture.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/mock/CampusMapMockFixture.java
@@ -37,6 +37,7 @@ public final class CampusMapMockFixture {
     private static final String MOCK_CAFE_IMAGE_URL = "https://placehold.co/600x400/png?text=Cafe";
     private static final String MOCK_RESTAURANT_IMAGE_URL = "https://placehold.co/600x400/png?text=Restaurant";
     private static final String MOCK_PRINTER_IMAGE_URL = "https://placehold.co/600x400/png?text=Printer";
+    private static final String MOCK_SMOKING_BOOTH_IMAGE_URL = "https://placehold.co/600x400/png?text=Smoking+Booth";
     private static final String MOCK_CONVENIENCE_STORE_IMAGE_URL = "https://placehold.co/600x400/png?text=Convenience+Store";
     private static final String MOCK_LOUNGE_IMAGE_URL = "https://placehold.co/600x400/png?text=Lounge";
     private static final String MOCK_KCUBE_IMAGE_URL = "https://placehold.co/600x400/png?text=K-Cube";
@@ -255,27 +256,37 @@ public final class CampusMapMockFixture {
             SCIENCE_BUILDING
     );
 
-    private static final Map<Long, List<String>> BUILDING_SEARCH_KEYWORDS = Map.of(
-            LAW_BUILDING.id(), List.of("종강", "종합강의동"),
-            STUDENT_CENTER_BUILDING.id(), List.of("학관", "제1학생회관")
+    private static final Map<Long, List<String>> BUILDING_SEARCH_KEYWORDS = Map.ofEntries(
+            Map.entry(BUSINESS_BUILDING.id(), List.of("경영대")),
+            Map.entry(LAW_BUILDING.id(), List.of("종강", "종합강의동", "법대")),
+            Map.entry(STUDENT_CENTER_BUILDING.id(), List.of("학관", "1학관", "제1학관", "제1학생회관")),
+            Map.entry(SANGHUH_RESEARCH_BUILDING.id(), List.of("상허관")),
+            Map.entry(EDUCATION_SCIENCE_BUILDING.id(), List.of("사범대", "사대")),
+            Map.entry(ARTS_AND_DESIGN_BUILDING.id(), List.of("예문관", "예디대")),
+            Map.entry(LANGUAGE_INSTITUTE_BUILDING.id(), List.of("언어원")),
+            Map.entry(SANGHUH_LIBRARY_BUILDING.id(), List.of("상허도서관", "중앙도서관", "중도")),
+            Map.entry(ANIMAL_SCIENCES_BUILDING.id(), List.of("동생대")),
+            Map.entry(ARCHITECTURE_BUILDING.id(), List.of("건축대")),
+            Map.entry(SCIENCE_BUILDING.id(), List.of("이과대"))
     );
 
     private static final List<CampusPlaceItem> CAMPUS_PLACES = List.of(
             cafe(201L, "카페 레스티오", "1F", "경영관 1층", BUSINESS_BUILDING),
             convenienceStore(202L, "CU 경영관점", "1F", "경영관 1층", BUSINESS_BUILDING),
             kcube(203L, "경영관 K-Hub", "1F", "경영관 1층", BUSINESS_BUILDING),
-            lounge(204L, "경영관 휴게실", null, "경영관 내부", BUSINESS_BUILDING),
+            lounge(204L, "경영관 휴게실", "1F", "경영관 1층", 1, BUSINESS_BUILDING),
+            smokingBooth(205L, "경영관 흡연부스", "경영관 CU 앞", BUSINESS_BUILDING),
 
-            printer(301L, "법학관 인쇄소", "B1", "법학관 지하 1층", LAW_BUILDING),
-            lounge(302L, "법학관 휴게실", null, "법학관 내부", LAW_BUILDING),
+            printer(301L, "법학관 인쇄소", "B1", "법학관 지하 1층", 1, LAW_BUILDING),
+            lounge(302L, "법학관 휴게실", "1F", "법학관 1층", 1, LAW_BUILDING),
 
             convenienceStore(401L, "CU 학생회관점", "1F", "학생회관 1층", STUDENT_CENTER_BUILDING),
-            printer(402L, "학생회관 복사실", "1F", "학생회관 1층", STUDENT_CENTER_BUILDING),
+            printer(402L, "학생회관 복사실", "1F", "학생회관 1층", 2, STUDENT_CENTER_BUILDING),
             restaurant(403L, "KU's Kitchen", "1F", "학생회관 1층", STUDENT_CENTER_BUILDING),
             restaurant(404L, "구시아 푸드마켓", "B1", "학생회관 지하 1층", STUDENT_CENTER_BUILDING),
             cafe(405L, "1847 샐러드카페", "1F", "학생회관 1층", STUDENT_CENTER_BUILDING),
 
-            printer(501L, "상허연구관 복사실", "1F", "상허연구관 1층", SANGHUH_RESEARCH_BUILDING),
+            printer(501L, "상허연구관 복사실", "1F", "상허연구관 1층", 1, SANGHUH_RESEARCH_BUILDING),
             cafe(502L, "카페 블루포트", "1F", "상허연구관 1층", SANGHUH_RESEARCH_BUILDING),
             kcube(503L, "상허연구관 K-Cube", "3F", "상허연구관 3층", SANGHUH_RESEARCH_BUILDING),
 
@@ -293,15 +304,17 @@ public final class CampusMapMockFixture {
             kcube(1302L, "동물생명과학관 K-Cube", "1F", "동물생명과학관 1층", ANIMAL_SCIENCES_BUILDING),
 
             convenienceStore(1501L, "이마트24 산학협동관점", "1F", "산학협동관 1층", INDUSTRY_COOPERATION_BUILDING),
-            printer(1502L, "산학협동관 복사실", "2F", "산학협동관 2층", INDUSTRY_COOPERATION_BUILDING),
+            printer(1502L, "산학협동관 복사실", "2F", "산학협동관 2층", 2, INDUSTRY_COOPERATION_BUILDING),
 
             restaurant(1601L, "KU's Dining", "B1", "새천년관 지하 1층", NEW_MILLENNIUM_BUILDING),
 
             kcube(1701L, "건축관 K-Hub", "1F", "건축관 1층", ARCHITECTURE_BUILDING),
+            smokingBooth(1702L, "건축관 흡연부스", "건축관 뒤", ARCHITECTURE_BUILDING),
 
             cafe(1801L, "카페 ING", "1F", "해봉부동산학관 1층", REAL_ESTATE_BUILDING),
 
-            kcube(2001L, "과학관 K-Hub", "1F", "과학관 1층", SCIENCE_BUILDING)
+            kcube(2001L, "과학관 K-Hub", "1F", "과학관 1층", SCIENCE_BUILDING),
+            smokingBooth(2002L, "과학관 흡연부스", "과학관 주차장", SCIENCE_BUILDING)
     );
 
     private static final CampusPlaceDetail STUDENT_CENTER_BANK = new CampusPlaceDetail(
@@ -489,6 +502,7 @@ public final class CampusMapMockFixture {
             String name,
             String floor,
             String locationDetail,
+            Integer quantity,
             BuildingSummary building
     ) {
         return new CampusPlaceItem(
@@ -500,8 +514,30 @@ public final class CampusMapMockFixture {
                 CampusPlaceLocationType.INDOOR.toString(),
                 floor,
                 locationDetail,
-                null,
+                quantity,
                 MOCK_STORE_HOURS,
+                null,
+                building
+        );
+    }
+
+    private static CampusPlaceItem smokingBooth(
+            Long id,
+            String name,
+            String locationDetail,
+            BuildingSummary building
+    ) {
+        return new CampusPlaceItem(
+                id,
+                name,
+                "smoking_booth",
+                "흡연부스",
+                MOCK_SMOKING_BOOTH_IMAGE_URL,
+                CampusPlaceLocationType.OUTDOOR.toString(),
+                "OUTDOOR",
+                locationDetail,
+                1,
+                MOCK_OPEN_24_HOURS,
                 null,
                 building
         );
@@ -535,6 +571,7 @@ public final class CampusMapMockFixture {
             String name,
             String floor,
             String locationDetail,
+            Integer quantity,
             BuildingSummary building
     ) {
         return new CampusPlaceItem(
@@ -546,7 +583,7 @@ public final class CampusMapMockFixture {
                 CampusPlaceLocationType.INDOOR.toString(),
                 floor,
                 locationDetail,
-                null,
+                quantity,
                 MOCK_OPEN_24_HOURS,
                 null,
                 building


### PR DESCRIPTION
## #️⃣ 이슈
#391 
## 📌 요약
- 클라이언트 측에서 캠퍼스맵 연동 테스트를 위한 추가 mock 데이터를 요청하여 관련 데이터를 보강했습니다.
- 운영시간 응답을 전체 운영시간 목록으로 변경하고 현재 적용되는 운영시간을 구분할 수 있도록 개선했습니다.
## 🛠️ 상세
- 운영시간 응답 구조를 변경했습니다.
  - `currentOperatingHours` 단일 객체를 `operatingHours` 목록으로 변경했습니다.
  - 현재 적용되는 운영시간을 구분하는 `isCurrent` 필드를 추가했습니다.
- mock 건물 및 시설 데이터를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 건물 및 캠퍼스 시설 정보에 여러 운영시간을 제공하며, 현재 운영 중인 시간 여부를 확인할 수 있습니다.
  * 건물 상세 정보와 시설 목록의 운영시간 응답 형식이 통합되었습니다.
  * 건물 검색 시 검색어의 앞뒤 공백과 대소문자를 자동으로 처리해 더 편리하게 검색할 수 있습니다.

* **버그 수정**
  * 시설 카테고리 조회 시 비어 있는 검색 조건을 검증하도록 개선했습니다.
  * 캠퍼스 지도와 건물 검색 결과의 데이터 정확성과 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->