### PR TITLE
Feat: 캠퍼스맵 카테고리 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapMockQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapMockQueryApiV2.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,11 +22,18 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@Slf4j
 @Tag(name = "Campus Map-Query", description = "캠퍼스맵 정보 조회")
 @Validated
+@ConditionalOnProperty(
+        prefix = "campus-map",
+        name = "source",
+        havingValue = "mock",
+        matchIfMissing = true
+)
 @RestWebAdapter(path = "/api/v2/maps")
-public class CampusMapQueryApiV2 {
+public class CampusMapMockQueryApiV2 {
+
+    // TODO: 실제 캠퍼스맵 데이터 등록 및 API 전환이 완료되면 제거한다.
 
     @Operation(summary = "캠퍼스맵 카테고리 목록 조회")
     @GetMapping("/categories")

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
@@ -1,0 +1,38 @@
+package com.kustacks.kuring.building.adapter.in.web;
+
+import com.kustacks.kuring.building.adapter.in.web.dto.CategoryListResponse;
+import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
+import com.kustacks.kuring.common.annotation.RestWebAdapter;
+import com.kustacks.kuring.common.dto.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS;
+
+@Tag(name = "Campus Map-Query", description = "캠퍼스맵 정보 조회")
+@Validated
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        prefix = "campus-map",
+        name = "source",
+        havingValue = "database"
+)
+@RestWebAdapter(path = "/api/v2/maps")
+public class CampusMapQueryApiV2 {
+
+    private final CampusMapQueryUseCase campusMapQueryUseCase;
+
+    @Operation(summary = "캠퍼스맵 카테고리 목록 조회")
+    @GetMapping("/categories")
+    public ResponseEntity<BaseResponse<CategoryListResponse>> getCategories() {
+        return ResponseEntity.ok(new BaseResponse<>(
+                CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS,
+                CategoryListResponse.from(campusMapQueryUseCase.getCategories())
+        ));
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/CategoryListResponse.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/CategoryListResponse.java
@@ -1,10 +1,17 @@
 package com.kustacks.kuring.building.adapter.in.web.dto;
 
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CategoryDto;
+import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 
 import java.util.List;
 
 public record CategoryListResponse(
         List<CategoryDto> categories
 ) {
+
+    public static CategoryListResponse from(List<CategoryResult> results) {
+        return new CategoryListResponse(results.stream()
+                .map(CategoryDto::from)
+                .toList());
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/CategoryDto.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/CategoryDto.java
@@ -1,8 +1,18 @@
 package com.kustacks.kuring.building.adapter.in.web.dto.model;
 
+import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
+
 public record CategoryDto(
         String name,
         String korName,
         Integer displayOrder
 ) {
+
+    public static CategoryDto from(CategoryResult result) {
+        return new CategoryDto(
+                result.name(),
+                result.korName(),
+                result.displayOrder()
+        );
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.kustacks.kuring.building.adapter.out.persistence;
 
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
-import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 import com.kustacks.kuring.common.annotation.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +14,13 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
     private final CampusPlaceCategoryRepository categoryRepository;
 
     @Override
-    public List<CampusPlaceCategory> findFilterCategories() {
-        return categoryRepository.findByFilterEnabledTrueOrderByDisplayOrderAscIdAsc();
+    public List<CampusPlaceCategoryReadModel> findFilterCategories() {
+        return categoryRepository.findByFilterEnabledTrueOrderByDisplayOrderAscIdAsc().stream()
+                .map(category -> new CampusPlaceCategoryReadModel(
+                        category.getCode(),
+                        category.getKorName(),
+                        category.getDisplayOrder()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
@@ -1,0 +1,20 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
+import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import com.kustacks.kuring.common.annotation.PersistenceAdapter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
+
+    private final CampusPlaceCategoryRepository categoryRepository;
+
+    @Override
+    public List<CampusPlaceCategory> findFilterCategories() {
+        return categoryRepository.findByFilterEnabledTrueOrderByDisplayOrderAscIdAsc();
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceCategoryRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceCategoryRepository.java
@@ -1,0 +1,11 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CampusPlaceCategoryRepository extends JpaRepository<CampusPlaceCategory, Long> {
+
+    List<CampusPlaceCategory> findByFilterEnabledTrueOrderByDisplayOrderAscIdAsc();
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
@@ -1,0 +1,10 @@
+package com.kustacks.kuring.building.application.port.in;
+
+import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
+
+import java.util.List;
+
+public interface CampusMapQueryUseCase {
+
+    List<CategoryResult> getCategories();
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/dto/CategoryResult.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/dto/CategoryResult.java
@@ -1,0 +1,8 @@
+package com.kustacks.kuring.building.application.port.in.dto;
+
+public record CategoryResult(
+        String name,
+        String korName,
+        int displayOrder
+) {
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
@@ -1,10 +1,10 @@
 package com.kustacks.kuring.building.application.port.out;
 
-import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 
 import java.util.List;
 
 public interface CampusMapQueryPort {
 
-    List<CampusPlaceCategory> findFilterCategories();
+    List<CampusPlaceCategoryReadModel> findFilterCategories();
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
@@ -1,0 +1,10 @@
+package com.kustacks.kuring.building.application.port.out;
+
+import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+
+import java.util.List;
+
+public interface CampusMapQueryPort {
+
+    List<CampusPlaceCategory> findFilterCategories();
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/dto/CampusPlaceCategoryReadModel.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/dto/CampusPlaceCategoryReadModel.java
@@ -1,0 +1,8 @@
+package com.kustacks.kuring.building.application.port.out.dto;
+
+public record CampusPlaceCategoryReadModel(
+        String code,
+        String korName,
+        int displayOrder
+) {
+}

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -3,7 +3,7 @@ package com.kustacks.kuring.building.application.service;
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
-import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 import com.kustacks.kuring.common.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,11 +24,11 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
                 .toList();
     }
 
-    private CategoryResult toCategoryResult(CampusPlaceCategory category) {
+    private CategoryResult toCategoryResult(CampusPlaceCategoryReadModel category) {
         return new CategoryResult(
-                category.getCode(),
-                category.getKorName(),
-                category.getDisplayOrder()
+                category.code(),
+                category.korName(),
+                category.displayOrder()
         );
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -1,0 +1,34 @@
+package com.kustacks.kuring.building.application.service;
+
+import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
+import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
+import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
+import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import com.kustacks.kuring.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CampusMapQueryService implements CampusMapQueryUseCase {
+
+    private final CampusMapQueryPort campusMapQueryPort;
+
+    @Override
+    public List<CategoryResult> getCategories() {
+        return campusMapQueryPort.findFilterCategories().stream()
+                .map(this::toCategoryResult)
+                .toList();
+    }
+
+    private CategoryResult toCategoryResult(CampusPlaceCategory category) {
+        return new CategoryResult(
+                category.getCode(),
+                category.getKorName(),
+                category.getDisplayOrder()
+        );
+    }
+}

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -71,6 +71,9 @@ public enum ResponseCodeAndMessages {
     CLUB_SUBSCRIPTION_DELETE_SUCCESS(HttpStatus.OK.value(), "구독이 취소되었습니다."),
     CLUB_SUBSCRIPTION_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "구독한 동아리 목록 조회에 성공하였습니다"),
 
+    /* Campus Map */
+    CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "장소 카테고리 목록 조회에 성공하였습니다"),
+
     /**
      * ErrorCodes about auth
      */

--- a/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
@@ -1,0 +1,62 @@
+package com.kustacks.kuring.building.adapter.in.web;
+
+import com.kustacks.kuring.building.adapter.in.web.dto.model.CategoryDto;
+import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
+import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
+import com.kustacks.kuring.common.dto.BaseResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.Mockito.when;
+
+@DisplayName("컨트롤러 : CampusMapQueryApiV2")
+@ExtendWith(MockitoExtension.class)
+class CampusMapQueryApiV2Test {
+
+    @Mock
+    private CampusMapQueryUseCase campusMapQueryUseCase;
+
+    @InjectMocks
+    private CampusMapQueryApiV2 campusMapQueryApiV2;
+
+    @Test
+    @DisplayName("캠퍼스맵 카테고리 목록을 조회한다")
+    void get_categories() {
+        // given
+        when(campusMapQueryUseCase.getCategories()).thenReturn(List.of(
+                new CategoryResult("cafe", "카페", 1),
+                new CategoryResult("restaurant", "식당", 2)
+        ));
+
+        // when
+        var response = campusMapQueryApiV2.getCategories();
+
+        // then
+        BaseResponse<?> body = response.getBody();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(body)
+                .extracting(BaseResponse::getCode, BaseResponse::getMessage)
+                .containsExactly(200, "장소 카테고리 목록 조회에 성공하였습니다");
+        Assertions.assertNotNull(response.getBody());
+        assertThat(response.getBody().getData().categories())
+                .extracting(
+                        CategoryDto::name,
+                        CategoryDto::korName,
+                        CategoryDto::displayOrder
+                )
+                .containsExactly(
+                        tuple("cafe", "카페", 1),
+                        tuple("restaurant", "식당", 2)
+                );
+    }
+}

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
@@ -1,5 +1,6 @@
 package com.kustacks.kuring.building.adapter.out.persistence;
 
+import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 import com.kustacks.kuring.building.domain.CampusPlaceCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,10 +37,13 @@ class CampusMapPersistenceAdapterTest {
                 .thenReturn(categories);
 
         // when
-        List<CampusPlaceCategory> result = campusMapPersistenceAdapter.findFilterCategories();
+        List<CampusPlaceCategoryReadModel> result = campusMapPersistenceAdapter.findFilterCategories();
 
         // then
-        assertThat(result).containsExactlyElementsOf(categories);
+        assertThat(result).containsExactly(
+                new CampusPlaceCategoryReadModel("cafe", "카페", 1),
+                new CampusPlaceCategoryReadModel("restaurant", "식당", 2)
+        );
         verify(categoryRepository).findByFilterEnabledTrueOrderByDisplayOrderAscIdAsc();
     }
 }

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
@@ -1,0 +1,45 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("영속성 어댑터 : CampusMapPersistenceAdapter")
+@ExtendWith(MockitoExtension.class)
+class CampusMapPersistenceAdapterTest {
+
+    @Mock
+    private CampusPlaceCategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CampusMapPersistenceAdapter campusMapPersistenceAdapter;
+
+    @Test
+    @DisplayName("필터에 노출되는 카테고리를 노출 순서대로 조회한다")
+    void find_filter_categories() {
+        // given
+        List<CampusPlaceCategory> categories = List.of(
+                new CampusPlaceCategory("cafe", "카페", 1, true),
+                new CampusPlaceCategory("restaurant", "식당", 2, true)
+        );
+        when(categoryRepository.findByFilterEnabledTrueOrderByDisplayOrderAscIdAsc())
+                .thenReturn(categories);
+
+        // when
+        List<CampusPlaceCategory> result = campusMapPersistenceAdapter.findFilterCategories();
+
+        // then
+        assertThat(result).containsExactlyElementsOf(categories);
+        verify(categoryRepository).findByFilterEnabledTrueOrderByDisplayOrderAscIdAsc();
+    }
+}

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -2,7 +2,7 @@ package com.kustacks.kuring.building.application.service;
 
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
-import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,8 +31,8 @@ class CampusMapQueryServiceTest {
     void get_categories() {
         // given
         when(campusMapQueryPort.findFilterCategories()).thenReturn(List.of(
-                new CampusPlaceCategory("cafe", "카페", 1, true),
-                new CampusPlaceCategory("restaurant", "식당", 2, true)
+                new CampusPlaceCategoryReadModel("cafe", "카페", 1),
+                new CampusPlaceCategoryReadModel("restaurant", "식당", 2)
         ));
 
         // when

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -1,0 +1,48 @@
+package com.kustacks.kuring.building.application.service;
+
+import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
+import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
+import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("서비스 : CampusMapQueryService")
+@ExtendWith(MockitoExtension.class)
+class CampusMapQueryServiceTest {
+
+    @Mock
+    private CampusMapQueryPort campusMapQueryPort;
+
+    @InjectMocks
+    private CampusMapQueryService campusMapQueryService;
+
+    @Test
+    @DisplayName("필터에 노출되는 캠퍼스맵 카테고리 목록을 조회한다")
+    void get_categories() {
+        // given
+        when(campusMapQueryPort.findFilterCategories()).thenReturn(List.of(
+                new CampusPlaceCategory("cafe", "카페", 1, true),
+                new CampusPlaceCategory("restaurant", "식당", 2, true)
+        ));
+
+        // when
+        List<CategoryResult> result = campusMapQueryService.getCategories();
+
+        // then
+        assertThat(result).containsExactly(
+                new CategoryResult("cafe", "카페", 1),
+                new CategoryResult("restaurant", "식당", 2)
+        );
+        verify(campusMapQueryPort).findFilterCategories();
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈
#392 
## 📌 요약
- 캠퍼스맵 카테고리 목록 조회 API를 실제 데이터 조회 로직과 연동했습니다.
## 🛠️ 상세
- GET /api/v2/maps/categories 실제 조회 API를 구현했습니다.
- 카테고리 조회 UseCase, Service, QueryPort 및 PersistenceAdapter를 구현했습니다.
- campus-map.source 설정에 따라 컨트롤러가 활성화되도록 분리했습니다.
  - 미설정 또는 mock: mock API 활성화
  - database: 실제 API 활성화
- 실제 컨트롤러, 서비스 및 영속성 어댑터 테스트를 추가했습니다.
## 💬 기타
- 실제 데이터 등록 전까지 기존 mock API를 유지할 수 있도록 mock/실제 컨트롤러를 분리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캠퍼스맵에서 필터용 장소 카테고리 목록을 조회할 수 있습니다.
  * 카테고리는 노출 설정과 표시 순서에 따라 제공됩니다.
  * Mock 환경에서 카테고리, 건물 목록, 검색, 시설 및 건물 상세 조회를 지원합니다.

* **개선 사항**
  * 카테고리 조회 응답 형식과 성공 메시지를 정비했습니다.
  * 조회 결과가 없는 건물 상세 요청에 오류 응답을 제공합니다.

* **테스트**
  * 카테고리 조회, 데이터 변환 및 정렬 결과를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->