### PR TITLE
Feat: 캠퍼스맵 전체 건물 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
@@ -1,5 +1,6 @@
 package com.kustacks.kuring.building.adapter.in.web;
 
+import com.kustacks.kuring.building.adapter.in.web.dto.BuildingListResponse;
 import com.kustacks.kuring.building.adapter.in.web.dto.CategoryListResponse;
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
 import com.kustacks.kuring.common.annotation.RestWebAdapter;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS;
 
 @Tag(name = "Campus Map-Query", description = "캠퍼스맵 정보 조회")
@@ -33,6 +35,15 @@ public class CampusMapQueryApiV2 {
         return ResponseEntity.ok(new BaseResponse<>(
                 CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS,
                 CategoryListResponse.from(campusMapQueryUseCase.getCategories())
+        ));
+    }
+
+    @Operation(summary = "캠퍼스맵 전체 건물 목록 조회")
+    @GetMapping("/buildings")
+    public ResponseEntity<BaseResponse<BuildingListResponse>> getBuildings() {
+        return ResponseEntity.ok(new BaseResponse<>(
+                CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS,
+                BuildingListResponse.from(campusMapQueryUseCase.getBuildings())
         ));
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/BuildingListResponse.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/BuildingListResponse.java
@@ -1,10 +1,17 @@
 package com.kustacks.kuring.building.adapter.in.web.dto;
 
 import com.kustacks.kuring.building.adapter.in.web.dto.model.BuildingSummary;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 
 import java.util.List;
 
 public record BuildingListResponse(
         List<BuildingSummary> buildings
 ) {
+
+    public static BuildingListResponse from(List<BuildingSummaryResult> results) {
+        return new BuildingListResponse(results.stream()
+                .map(BuildingSummary::from)
+                .toList());
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/BuildingSummary.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/BuildingSummary.java
@@ -1,5 +1,7 @@
 package com.kustacks.kuring.building.adapter.in.web.dto.model;
 
+import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
+
 public record BuildingSummary(
         Long id,
         String name,
@@ -7,4 +9,14 @@ public record BuildingSummary(
         Double latitude,
         Double longitude
 ) {
+
+    public static BuildingSummary from(BuildingSummaryResult result) {
+        return new BuildingSummary(
+                result.id(),
+                result.name(),
+                result.address(),
+                result.latitude(),
+                result.longitude()
+        );
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingRepository.java
@@ -3,5 +3,9 @@ package com.kustacks.kuring.building.adapter.out.persistence;
 import com.kustacks.kuring.building.domain.Building;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BuildingRepository extends JpaRepository<Building, Long> {
+
+    List<Building> findAllByOrderByIdAsc();
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.kustacks.kuring.building.adapter.out.persistence;
 
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
+import com.kustacks.kuring.building.domain.Building;
 import com.kustacks.kuring.common.annotation.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +12,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
 
+    private final BuildingRepository buildingRepository;
     private final CampusPlaceCategoryRepository categoryRepository;
 
     @Override
@@ -22,5 +24,10 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
                         category.getDisplayOrder()
                 ))
                 .toList();
+    }
+
+    @Override
+    public List<Building> findBuildings() {
+        return buildingRepository.findAllByOrderByIdAsc();
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.building.adapter.out.persistence;
 
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
+import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 import com.kustacks.kuring.building.domain.Building;
 import com.kustacks.kuring.common.annotation.PersistenceAdapter;
@@ -27,7 +28,19 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
     }
 
     @Override
-    public List<Building> findBuildings() {
-        return buildingRepository.findAllByOrderByIdAsc();
+    public List<BuildingSummaryReadModel> findBuildings() {
+        return buildingRepository.findAllByOrderByIdAsc().stream()
+                .map(this::toBuildingSummaryReadModel)
+                .toList();
+    }
+
+    private BuildingSummaryReadModel toBuildingSummaryReadModel(Building building) {
+        return new BuildingSummaryReadModel(
+                building.getId(),
+                building.getName(),
+                building.getAddress(),
+                building.getLat(),
+                building.getLon()
+        );
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
@@ -1,5 +1,6 @@
 package com.kustacks.kuring.building.application.port.in;
 
+import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 
 import java.util.List;
@@ -7,4 +8,6 @@ import java.util.List;
 public interface CampusMapQueryUseCase {
 
     List<CategoryResult> getCategories();
+
+    List<BuildingSummaryResult> getBuildings();
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/dto/BuildingSummaryResult.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/dto/BuildingSummaryResult.java
@@ -1,0 +1,10 @@
+package com.kustacks.kuring.building.application.port.in.dto;
+
+public record BuildingSummaryResult(
+        Long id,
+        String name,
+        String address,
+        Double latitude,
+        Double longitude
+) {
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
@@ -1,7 +1,7 @@
 package com.kustacks.kuring.building.application.port.out;
 
+import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
-import com.kustacks.kuring.building.domain.Building;
 
 import java.util.List;
 
@@ -9,5 +9,5 @@ public interface CampusMapQueryPort {
 
     List<CampusPlaceCategoryReadModel> findFilterCategories();
 
-    List<Building> findBuildings();
+    List<BuildingSummaryReadModel> findBuildings();
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
@@ -1,10 +1,13 @@
 package com.kustacks.kuring.building.application.port.out;
 
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
+import com.kustacks.kuring.building.domain.Building;
 
 import java.util.List;
 
 public interface CampusMapQueryPort {
 
     List<CampusPlaceCategoryReadModel> findFilterCategories();
+
+    List<Building> findBuildings();
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/dto/BuildingSummaryReadModel.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/dto/BuildingSummaryReadModel.java
@@ -1,0 +1,10 @@
+package com.kustacks.kuring.building.application.port.out.dto;
+
+public record BuildingSummaryReadModel(
+        Long id,
+        String name,
+        String address,
+        Double latitude,
+        Double longitude
+) {
+}

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -4,8 +4,8 @@ import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
+import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
-import com.kustacks.kuring.building.domain.Building;
 import com.kustacks.kuring.common.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,13 +41,13 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
         );
     }
 
-    private BuildingSummaryResult toBuildingSummaryResult(Building building) {
+    private BuildingSummaryResult toBuildingSummaryResult(BuildingSummaryReadModel building) {
         return new BuildingSummaryResult(
-                building.getId(),
-                building.getName(),
-                building.getAddress(),
-                building.getLat(),
-                building.getLon()
+                building.id(),
+                building.name(),
+                building.address(),
+                building.latitude(),
+                building.longitude()
         );
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -1,9 +1,11 @@
 package com.kustacks.kuring.building.application.service;
 
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
+import com.kustacks.kuring.building.domain.Building;
 import com.kustacks.kuring.common.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,11 +26,28 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
                 .toList();
     }
 
+    @Override
+    public List<BuildingSummaryResult> getBuildings() {
+        return campusMapQueryPort.findBuildings().stream()
+                .map(this::toBuildingSummaryResult)
+                .toList();
+    }
+
     private CategoryResult toCategoryResult(CampusPlaceCategoryReadModel category) {
         return new CategoryResult(
                 category.code(),
                 category.korName(),
                 category.displayOrder()
+        );
+    }
+
+    private BuildingSummaryResult toBuildingSummaryResult(Building building) {
+        return new BuildingSummaryResult(
+                building.getId(),
+                building.getName(),
+                building.getAddress(),
+                building.getLat(),
+                building.getLon()
         );
     }
 }

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -73,6 +73,7 @@ public enum ResponseCodeAndMessages {
 
     /* Campus Map */
     CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "장소 카테고리 목록 조회에 성공하였습니다"),
+    CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "캠퍼스 건물 목록 조회에 성공하였습니다"),
 
     /**
      * ErrorCodes about auth

--- a/src/main/resources/config/environments/common.yml
+++ b/src/main/resources/config/environments/common.yml
@@ -178,3 +178,6 @@ ip:
 
 staff:
   each-dept-url: https://{department}.konkuk.ac.kr/{department}/{siteId}/subview.do
+
+campus-map:
+  source: ${CAMPUS_MAP_SOURCE:mock}

--- a/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
@@ -1,7 +1,9 @@
 package com.kustacks.kuring.building.adapter.in.web;
 
+import com.kustacks.kuring.building.adapter.in.web.dto.model.BuildingSummary;
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CategoryDto;
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 import com.kustacks.kuring.common.dto.BaseResponse;
 import org.junit.jupiter.api.Assertions;
@@ -17,6 +19,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.when;
 
 @DisplayName("컨트롤러 : CampusMapQueryApiV2")
@@ -58,5 +61,53 @@ class CampusMapQueryApiV2Test {
                         tuple("cafe", "카페", 1),
                         tuple("restaurant", "식당", 2)
                 );
+    }
+
+    @Test
+    @DisplayName("캠퍼스맵 전체 건물 목록을 조회한다")
+    void get_buildings() {
+        // given
+        when(campusMapQueryUseCase.getBuildings()).thenReturn(List.of(
+                new BuildingSummaryResult(
+                        1L,
+                        "행정관",
+                        "서울특별시 광진구 능동로 120",
+                        37.54241,
+                        127.07382
+                ),
+                new BuildingSummaryResult(
+                        2L,
+                        "경영관",
+                        "서울특별시 광진구 능동로 120",
+                        37.54196,
+                        127.07531
+                )
+        ));
+
+        // when
+        var response = campusMapQueryApiV2.getBuildings();
+
+        // then
+        var body = response.getBody();
+        if (body == null) {
+            throw new AssertionError("Response body must not be null");
+        }
+
+        assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(body)
+                        .extracting(BaseResponse::getCode, BaseResponse::getMessage)
+                        .containsExactly(200, "캠퍼스 건물 목록 조회에 성공하였습니다"),
+                () -> assertThat(body.getData().buildings())
+                        .extracting(
+                                BuildingSummary::id,
+                                BuildingSummary::name,
+                                BuildingSummary::address
+                        )
+                        .containsExactly(
+                                tuple(1L, "행정관", "서울특별시 광진구 능동로 120"),
+                                tuple(2L, "경영관", "서울특별시 광진구 능동로 120")
+                        )
+        );
     }
 }

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
@@ -1,6 +1,8 @@
 package com.kustacks.kuring.building.adapter.out.persistence;
 
+import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
+import com.kustacks.kuring.building.domain.Building;
 import com.kustacks.kuring.building.domain.CampusPlaceCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -8,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
@@ -21,6 +24,9 @@ class CampusMapPersistenceAdapterTest {
 
     @Mock
     private CampusPlaceCategoryRepository categoryRepository;
+
+    @Mock
+    private BuildingRepository buildingRepository;
 
     @InjectMocks
     private CampusMapPersistenceAdapter campusMapPersistenceAdapter;
@@ -45,5 +51,49 @@ class CampusMapPersistenceAdapterTest {
                 new CampusPlaceCategoryReadModel("restaurant", "식당", 2)
         );
         verify(categoryRepository).findByFilterEnabledTrueOrderByDisplayOrderAscIdAsc();
+    }
+
+    @Test
+    @DisplayName("캠퍼스 건물을 ID 순서대로 조회한다")
+    void find_buildings() {
+        // given
+        Building administration = building(1L, "행정관", 37.54241, 127.07382);
+        Building business = building(2L, "경영관", 37.54196, 127.07531);
+        when(buildingRepository.findAllByOrderByIdAsc())
+                .thenReturn(List.of(administration, business));
+
+        // when
+        List<BuildingSummaryReadModel> result = campusMapPersistenceAdapter.findBuildings();
+
+        // then
+        assertThat(result).containsExactly(
+                new BuildingSummaryReadModel(
+                        1L,
+                        "행정관",
+                        "서울특별시 광진구 능동로 120",
+                        37.54241,
+                        127.07382
+                ),
+                new BuildingSummaryReadModel(
+                        2L,
+                        "경영관",
+                        "서울특별시 광진구 능동로 120",
+                        37.54196,
+                        127.07531
+                )
+        );
+        verify(buildingRepository).findAllByOrderByIdAsc();
+    }
+
+    private Building building(Long id, String name, Double latitude, Double longitude) {
+        Building building = new Building(
+                name,
+                "서울특별시 광진구 능동로 120",
+                latitude,
+                longitude,
+                null
+        );
+        ReflectionTestUtils.setField(building, "id", id);
+        return building;
     }
 }

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -1,7 +1,9 @@
 package com.kustacks.kuring.building.application.service;
 
+import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
+import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,5 +46,49 @@ class CampusMapQueryServiceTest {
                 new CategoryResult("restaurant", "식당", 2)
         );
         verify(campusMapQueryPort).findFilterCategories();
+    }
+
+    @Test
+    @DisplayName("캠퍼스맵 전체 건물 목록을 조회한다")
+    void get_buildings() {
+        // given
+        when(campusMapQueryPort.findBuildings()).thenReturn(List.of(
+                new BuildingSummaryReadModel(
+                        1L,
+                        "행정관",
+                        "서울특별시 광진구 능동로 120",
+                        37.54241,
+                        127.07382
+                ),
+                new BuildingSummaryReadModel(
+                        2L,
+                        "경영관",
+                        "서울특별시 광진구 능동로 120",
+                        37.54196,
+                        127.07531
+                )
+        ));
+
+        // when
+        List<BuildingSummaryResult> result = campusMapQueryService.getBuildings();
+
+        // then
+        assertThat(result).containsExactly(
+                new BuildingSummaryResult(
+                        1L,
+                        "행정관",
+                        "서울특별시 광진구 능동로 120",
+                        37.54241,
+                        127.07382
+                ),
+                new BuildingSummaryResult(
+                        2L,
+                        "경영관",
+                        "서울특별시 광진구 능동로 120",
+                        37.54196,
+                        127.07531
+                )
+        );
+        verify(campusMapQueryPort).findBuildings();
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈
#392 
## 📌 요약
- 캠퍼스맵 전체 건물 목록 조회 API를 실제 데이터 조회 로직과 연동했습니다.
## 🛠️ 상세
- GET /api/v2/maps/buildings 실제 조회 API를 구현했습니다.
- 건물 목록 조회 UseCase, Service, QueryPort 및 PersistenceAdapter를 구현했습니다.
- 조회 포트가 엔티티를 직접 반환하지 않도록 ReadModel을 적용했습니다.
- 실제 컨트롤러, 서비스 및 영속성 어댑터 테스트를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 캠퍼스맵에서 전체 건물 목록을 조회할 수 있는 API를 추가했습니다.
  * 건물 ID, 이름, 주소, 위도, 경도 정보를 오름차순으로 제공합니다.

* **테스트**
  * 건물 목록 조회와 응답 데이터 변환에 대한 검증을 추가했습니다.

* **설정**
  * 캠퍼스맵 데이터 소스를 환경 변수로 설정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->