### PR TITLE
Feat: 캠퍼스맵 건물 키워드 검색 API 구현

### DIFF
--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
@@ -1,19 +1,23 @@
 package com.kustacks.kuring.building.adapter.in.web;
 
 import com.kustacks.kuring.building.adapter.in.web.dto.BuildingListResponse;
+import com.kustacks.kuring.building.adapter.in.web.dto.BuildingSearchResponse;
 import com.kustacks.kuring.building.adapter.in.web.dto.CategoryListResponse;
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
 import com.kustacks.kuring.common.annotation.RestWebAdapter;
 import com.kustacks.kuring.common.dto.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_SEARCH_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS;
 
 @Tag(name = "Campus Map-Query", description = "캠퍼스맵 정보 조회")
@@ -44,6 +48,17 @@ public class CampusMapQueryApiV2 {
         return ResponseEntity.ok(new BaseResponse<>(
                 CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS,
                 BuildingListResponse.from(campusMapQueryUseCase.getBuildings())
+        ));
+    }
+
+    @Operation(summary = "캠퍼스맵 건물 키워드 검색")
+    @GetMapping("/buildings/search")
+    public ResponseEntity<BaseResponse<BuildingSearchResponse>> searchBuildings(
+            @RequestParam(name = "keyword") @NotBlank String keyword
+    ) {
+        return ResponseEntity.ok(new BaseResponse<>(
+                CAMPUS_MAP_BUILDING_SEARCH_SUCCESS,
+                BuildingSearchResponse.from(campusMapQueryUseCase.searchBuildings(keyword))
         ));
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/BuildingSearchResponse.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/BuildingSearchResponse.java
@@ -1,10 +1,17 @@
 package com.kustacks.kuring.building.adapter.in.web.dto;
 
 import com.kustacks.kuring.building.adapter.in.web.dto.model.BuildingSummary;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 
 import java.util.List;
 
 public record BuildingSearchResponse(
         List<BuildingSummary> buildings
 ) {
+
+    public static BuildingSearchResponse from(List<BuildingSummaryResult> results) {
+        return new BuildingSearchResponse(results.stream()
+                .map(BuildingSummary::from)
+                .toList());
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepository.java
@@ -1,0 +1,10 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.domain.Building;
+
+import java.util.List;
+
+public interface BuildingQueryRepository {
+
+    List<Building> searchByKeyword(String keyword);
+}

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryImpl.java
@@ -1,19 +1,15 @@
 package com.kustacks.kuring.building.adapter.out.persistence;
 
 import com.kustacks.kuring.building.domain.Building;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 import static com.kustacks.kuring.building.domain.QBuilding.building;
-import static com.kustacks.kuring.building.domain.QBuildingSearchKeyword.buildingSearchKeyword;
 
 @RequiredArgsConstructor
 class BuildingQueryRepositoryImpl implements BuildingQueryRepository {
-
-    private static final char LIKE_ESCAPE = '\\';
 
     private final JPAQueryFactory queryFactory;
 
@@ -21,25 +17,12 @@ class BuildingQueryRepositoryImpl implements BuildingQueryRepository {
     public List<Building> searchByKeyword(String keyword) {
         return queryFactory
                 .selectFrom(building)
-                .leftJoin(building.keywords, buildingSearchKeyword)
-                .where(keywordContains(keyword))
-                .distinct()
+                .where(
+                        building.name.containsIgnoreCase(keyword)
+                                .or(building.address.containsIgnoreCase(keyword))
+                                .or(building.keywords.any().keyword.containsIgnoreCase(keyword))
+                )
                 .orderBy(building.id.asc())
                 .fetch();
-    }
-
-    private BooleanExpression keywordContains(String keyword) {
-        String pattern = "%" + escapeLikePattern(keyword) + "%";
-
-        return building.name.likeIgnoreCase(pattern, LIKE_ESCAPE)
-                .or(building.address.likeIgnoreCase(pattern, LIKE_ESCAPE))
-                .or(buildingSearchKeyword.keyword.likeIgnoreCase(pattern, LIKE_ESCAPE));
-    }
-
-    private String escapeLikePattern(String keyword) {
-        return keyword
-                .replace("\\", "\\\\")
-                .replace("%", "\\%")
-                .replace("_", "\\_");
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.domain.Building;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.kustacks.kuring.building.domain.QBuilding.building;
+import static com.kustacks.kuring.building.domain.QBuildingSearchKeyword.buildingSearchKeyword;
+
+@RequiredArgsConstructor
+class BuildingQueryRepositoryImpl implements BuildingQueryRepository {
+
+    private static final char LIKE_ESCAPE = '\\';
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Building> searchByKeyword(String keyword) {
+        return queryFactory
+                .selectFrom(building)
+                .leftJoin(building.keywords, buildingSearchKeyword)
+                .where(keywordContains(keyword))
+                .distinct()
+                .orderBy(building.id.asc())
+                .fetch();
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        String pattern = "%" + escapeLikePattern(keyword) + "%";
+
+        return building.name.likeIgnoreCase(pattern, LIKE_ESCAPE)
+                .or(building.address.likeIgnoreCase(pattern, LIKE_ESCAPE))
+                .or(buildingSearchKeyword.keyword.likeIgnoreCase(pattern, LIKE_ESCAPE));
+    }
+
+    private String escapeLikePattern(String keyword) {
+        return keyword
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface BuildingRepository extends JpaRepository<Building, Long> {
+public interface BuildingRepository extends JpaRepository<Building, Long>, BuildingQueryRepository {
 
     List<Building> findAllByOrderByIdAsc();
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
@@ -34,6 +34,13 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
                 .toList();
     }
 
+    @Override
+    public List<BuildingSummaryReadModel> searchBuildings(String keyword) {
+        return buildingRepository.searchByKeyword(keyword).stream()
+                .map(this::toBuildingSummaryReadModel)
+                .toList();
+    }
+
     private BuildingSummaryReadModel toBuildingSummaryReadModel(Building building) {
         return new BuildingSummaryReadModel(
                 building.getId(),

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
@@ -10,4 +10,6 @@ public interface CampusMapQueryUseCase {
     List<CategoryResult> getCategories();
 
     List<BuildingSummaryResult> getBuildings();
+
+    List<BuildingSummaryResult> searchBuildings(String keyword);
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
@@ -10,4 +10,6 @@ public interface CampusMapQueryPort {
     List<CampusPlaceCategoryReadModel> findFilterCategories();
 
     List<BuildingSummaryReadModel> findBuildings();
+
+    List<BuildingSummaryReadModel> searchBuildings(String keyword);
 }

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -33,6 +33,15 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
                 .toList();
     }
 
+    @Override
+    public List<BuildingSummaryResult> searchBuildings(String keyword) {
+        String normalizedKeyword = keyword.trim();
+
+        return campusMapQueryPort.searchBuildings(normalizedKeyword).stream()
+                .map(this::toBuildingSummaryResult)
+                .toList();
+    }
+
     private CategoryResult toCategoryResult(CampusPlaceCategoryReadModel category) {
         return new CategoryResult(
                 category.code(),

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -74,6 +74,7 @@ public enum ResponseCodeAndMessages {
     /* Campus Map */
     CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "장소 카테고리 목록 조회에 성공하였습니다"),
     CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "캠퍼스 건물 목록 조회에 성공하였습니다"),
+    CAMPUS_MAP_BUILDING_SEARCH_SUCCESS(HttpStatus.OK.value(), "캠퍼스 건물 검색에 성공하였습니다"),
 
     /**
      * ErrorCodes about auth

--- a/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
@@ -110,4 +110,44 @@ class CampusMapQueryApiV2Test {
                         )
         );
     }
+
+    @Test
+    @DisplayName("캠퍼스맵 건물을 키워드로 검색한다")
+    void search_buildings() {
+        // given
+        when(campusMapQueryUseCase.searchBuildings("학관")).thenReturn(List.of(
+                new BuildingSummaryResult(
+                        4L,
+                        "학생회관",
+                        "서울특별시 광진구 능동로 120",
+                        37.5412,
+                        127.0784
+                )
+        ));
+
+        // when
+        var response = campusMapQueryApiV2.searchBuildings("학관");
+
+        // then
+        var body = response.getBody();
+        if (body == null) {
+            throw new AssertionError("Response body must not be null");
+        }
+
+        assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(body)
+                        .extracting(BaseResponse::getCode, BaseResponse::getMessage)
+                        .containsExactly(200, "캠퍼스 건물 검색에 성공하였습니다"),
+                () -> assertThat(body.getData().buildings())
+                        .extracting(
+                                BuildingSummary::id,
+                                BuildingSummary::name,
+                                BuildingSummary::address
+                        )
+                        .containsExactly(
+                                tuple(4L, "학생회관", "서울특별시 광진구 능동로 120")
+                        )
+        );
+    }
 }

--- a/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
@@ -89,9 +89,7 @@ class CampusMapQueryApiV2Test {
 
         // then
         var body = response.getBody();
-        if (body == null) {
-            throw new AssertionError("Response body must not be null");
-        }
+        assertThat(body).isNotNull();
 
         assertAll(
                 () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
@@ -130,9 +128,7 @@ class CampusMapQueryApiV2Test {
 
         // then
         var body = response.getBody();
-        if (body == null) {
-            throw new AssertionError("Response body must not be null");
-        }
+        assertThat(body).isNotNull();
 
         assertAll(
                 () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("리포지토리 : BuildingQueryRepository")
 class BuildingQueryRepositoryTest extends IntegrationTestSupport {
@@ -31,15 +32,17 @@ class BuildingQueryRepositoryTest extends IntegrationTestSupport {
         buildingRepository.saveAndFlush(lawBuilding);
 
         // when & then
-        assertThat(buildingRepository.searchByKeyword("법학"))
-                .extracting(Building::getName)
-                .containsExactly("법학관");
-        assertThat(buildingRepository.searchByKeyword("능동로"))
-                .extracting(Building::getName)
-                .containsExactly("법학관");
-        assertThat(buildingRepository.searchByKeyword("종강"))
-                .extracting(Building::getName)
-                .containsExactly("법학관");
+        assertAll(
+                () -> assertThat(buildingRepository.searchByKeyword("법학"))
+                        .extracting(Building::getName)
+                        .containsExactly("법학관"),
+                () -> assertThat(buildingRepository.searchByKeyword("능동로"))
+                        .extracting(Building::getName)
+                        .containsExactly("법학관"),
+                () -> assertThat(buildingRepository.searchByKeyword("종강"))
+                        .extracting(Building::getName)
+                        .containsExactly("법학관")
+        );
     }
 
     @Test
@@ -58,15 +61,17 @@ class BuildingQueryRepositoryTest extends IntegrationTestSupport {
         ));
 
         // when & then
-        assertThat(buildingRepository.searchByKeyword("%"))
-                .extracting(Building::getName)
-                .containsExactly("100%관");
-        assertThat(buildingRepository.searchByKeyword("_"))
-                .extracting(Building::getName)
-                .containsExactly("A_B관");
-        assertThat(buildingRepository.searchByKeyword("\\"))
-                .extracting(Building::getName)
-                .containsExactly("A\\B관");
+        assertAll(
+                () -> assertThat(buildingRepository.searchByKeyword("%"))
+                        .extracting(Building::getName)
+                        .containsExactly("100%관"),
+                () -> assertThat(buildingRepository.searchByKeyword("_"))
+                        .extracting(Building::getName)
+                        .containsExactly("A_B관"),
+                () -> assertThat(buildingRepository.searchByKeyword("\\"))
+                        .extracting(Building::getName)
+                        .containsExactly("A\\B관")
+        );
     }
 
     private Building building(String name) {

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.domain.Building;
+import com.kustacks.kuring.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("리포지토리 : BuildingQueryRepository")
+class BuildingQueryRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private BuildingRepository buildingRepository;
+
+    @Test
+    @DisplayName("건물명, 주소, 등록된 검색어로 건물을 검색한다")
+    void search_buildings_by_name_address_and_keyword() {
+        // given
+        Building lawBuilding = new Building(
+                "법학관",
+                "서울특별시 광진구 능동로 120",
+                37.54174,
+                127.07649,
+                null
+        );
+        lawBuilding.addSearchKeyword("종강");
+        buildingRepository.saveAndFlush(lawBuilding);
+
+        // when & then
+        assertThat(buildingRepository.searchByKeyword("법학"))
+                .extracting(Building::getName)
+                .containsExactly("법학관");
+        assertThat(buildingRepository.searchByKeyword("능동로"))
+                .extracting(Building::getName)
+                .containsExactly("법학관");
+        assertThat(buildingRepository.searchByKeyword("종강"))
+                .extracting(Building::getName)
+                .containsExactly("법학관");
+    }
+
+    @Test
+    @DisplayName("LIKE 와일드카드를 일반 문자로 검색한다")
+    void search_like_wildcards_as_literal_characters() {
+        // given
+        Building percentBuilding = building("100%관");
+        Building underscoreBuilding = building("A_B관");
+        Building backslashBuilding = building("A\\B관");
+        Building normalBuilding = building("일반관");
+        buildingRepository.saveAllAndFlush(List.of(
+                percentBuilding,
+                underscoreBuilding,
+                backslashBuilding,
+                normalBuilding
+        ));
+
+        // when & then
+        assertThat(buildingRepository.searchByKeyword("%"))
+                .extracting(Building::getName)
+                .containsExactly("100%관");
+        assertThat(buildingRepository.searchByKeyword("_"))
+                .extracting(Building::getName)
+                .containsExactly("A_B관");
+        assertThat(buildingRepository.searchByKeyword("\\"))
+                .extracting(Building::getName)
+                .containsExactly("A\\B관");
+    }
+
+    private Building building(String name) {
+        return new Building(
+                name,
+                "서울특별시 광진구 능동로 120",
+                37.5412,
+                127.0784,
+                null
+        );
+    }
+}

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
@@ -85,6 +85,30 @@ class CampusMapPersistenceAdapterTest {
         verify(buildingRepository).findAllByOrderByIdAsc();
     }
 
+    @Test
+    @DisplayName("건물 검색 결과를 조회한다")
+    void search_buildings() {
+        // given
+        Building studentCenter = building(4L, "학생회관", 37.5412, 127.0784);
+        when(buildingRepository.searchByKeyword("학관"))
+                .thenReturn(List.of(studentCenter));
+
+        // when
+        List<BuildingSummaryReadModel> result = campusMapPersistenceAdapter.searchBuildings("학관");
+
+        // then
+        assertThat(result).containsExactly(
+                new BuildingSummaryReadModel(
+                        4L,
+                        "학생회관",
+                        "서울특별시 광진구 능동로 120",
+                        37.5412,
+                        127.0784
+                )
+        );
+        verify(buildingRepository).searchByKeyword("학관");
+    }
+
     private Building building(Long id, String name, Double latitude, Double longitude) {
         Building building = new Building(
                 name,

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -91,4 +91,34 @@ class CampusMapQueryServiceTest {
         );
         verify(campusMapQueryPort).findBuildings();
     }
+
+    @Test
+    @DisplayName("건물 검색어의 앞뒤 공백을 제거하여 조회한다")
+    void search_buildings_with_trimmed_keyword() {
+        // given
+        when(campusMapQueryPort.searchBuildings("학관")).thenReturn(List.of(
+                new BuildingSummaryReadModel(
+                        4L,
+                        "학생회관",
+                        "서울특별시 광진구 능동로 120",
+                        37.5412,
+                        127.0784
+                )
+        ));
+
+        // when
+        List<BuildingSummaryResult> result = campusMapQueryService.searchBuildings("  학관  ");
+
+        // then
+        assertThat(result).containsExactly(
+                new BuildingSummaryResult(
+                        4L,
+                        "학생회관",
+                        "서울특별시 광진구 능동로 120",
+                        37.5412,
+                        127.0784
+                )
+        );
+        verify(campusMapQueryPort).searchBuildings("학관");
+    }
 }


### PR DESCRIPTION
## #️⃣ 이슈
#392 
## 📌 요약
- 캠퍼스맵 건물 키워드 검색 API를 실제 데이터 조회 로직과 연동했습니다.
## 🛠️ 상세
- GET /api/v2/maps/buildings/search API를 구현했습니다.
- 건물명, 주소 및 건물에 등록된 검색 키워드를 기준으로 조회하도록 구현했습니다.
- QueryDSL을 사용해 건물 검색 쿼리를 구현했습니다.
- 검색어의 %, _, \ 문자를 와일드카드가 아닌 일반 문자로 처리했습니다.
- 컨트롤러, 서비스, 영속성 어댑터 및 QueryDSL 조회 테스트를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 캠퍼스 지도에서 건물명, 주소 및 연관 검색어로 건물을 검색할 수 있습니다.
  * 검색 결과에 건물 식별자, 이름, 주소가 표시됩니다.
  * 대소문자를 구분하지 않으며, 검색어 앞뒤 공백을 자동으로 정리합니다.
  * 검색어가 비어 있거나 공백만 포함된 경우 안내된 형식으로 요청해야 합니다.

* **테스트**
  * 다양한 검색 조건과 결과 표시를 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->