### PR TITLE
Feat: 캠퍼스맵 카테고리 기반 시설 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
@@ -70,7 +70,7 @@ public class CampusMapQueryApiV2 {
     @Operation(summary = "캠퍼스맵 카테고리 기반 시설 목록 조회")
     @GetMapping("/campus-places")
     public ResponseEntity<BaseResponse<CampusPlaceListResponse>> getCampusPlaces(
-            @RequestParam(name = "categories") @NotEmpty List<String> categories
+            @RequestParam(name = "categories") @NotEmpty List<@NotBlank String> categories
     ) {
         return ResponseEntity.ok(new BaseResponse<>(
                 CAMPUS_MAP_PLACE_LIST_SEARCH_SUCCESS,

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
@@ -2,6 +2,7 @@ package com.kustacks.kuring.building.adapter.in.web;
 
 import com.kustacks.kuring.building.adapter.in.web.dto.BuildingListResponse;
 import com.kustacks.kuring.building.adapter.in.web.dto.BuildingSearchResponse;
+import com.kustacks.kuring.building.adapter.in.web.dto.CampusPlaceListResponse;
 import com.kustacks.kuring.building.adapter.in.web.dto.CategoryListResponse;
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
 import com.kustacks.kuring.common.annotation.RestWebAdapter;
@@ -9,6 +10,7 @@ import com.kustacks.kuring.common.dto.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +18,12 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_SEARCH_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_PLACE_LIST_SEARCH_SUCCESS;
 
 @Tag(name = "Campus Map-Query", description = "캠퍼스맵 정보 조회")
 @Validated
@@ -59,6 +64,17 @@ public class CampusMapQueryApiV2 {
         return ResponseEntity.ok(new BaseResponse<>(
                 CAMPUS_MAP_BUILDING_SEARCH_SUCCESS,
                 BuildingSearchResponse.from(campusMapQueryUseCase.searchBuildings(keyword))
+        ));
+    }
+
+    @Operation(summary = "캠퍼스맵 카테고리 기반 시설 목록 조회")
+    @GetMapping("/campus-places")
+    public ResponseEntity<BaseResponse<CampusPlaceListResponse>> getCampusPlaces(
+            @RequestParam(name = "categories") @NotEmpty List<String> categories
+    ) {
+        return ResponseEntity.ok(new BaseResponse<>(
+                CAMPUS_MAP_PLACE_LIST_SEARCH_SUCCESS,
+                CampusPlaceListResponse.from(campusMapQueryUseCase.getCampusPlaces(categories))
         ));
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/CampusPlaceListResponse.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/CampusPlaceListResponse.java
@@ -1,10 +1,19 @@
 package com.kustacks.kuring.building.adapter.in.web.dto;
 
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CampusPlaceItem;
+import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 
 import java.util.List;
 
 public record CampusPlaceListResponse(
         List<CampusPlaceItem> campusPlaces
 ) {
+
+    public static CampusPlaceListResponse from(List<CampusPlaceResult> results) {
+        return new CampusPlaceListResponse(
+                results.stream()
+                        .map(CampusPlaceItem::from)
+                        .toList()
+        );
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/CampusPlaceItem.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/CampusPlaceItem.java
@@ -1,5 +1,7 @@
 package com.kustacks.kuring.building.adapter.in.web.dto.model;
 
+import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
+
 import java.util.List;
 
 public record CampusPlaceItem(
@@ -16,4 +18,23 @@ public record CampusPlaceItem(
         String externalUrl,
         BuildingSummary building
 ) {
+
+    public static CampusPlaceItem from(CampusPlaceResult result) {
+        return new CampusPlaceItem(
+                result.id(),
+                result.name(),
+                result.category(),
+                result.categoryKorName(),
+                result.imageUrl(),
+                result.locationType().name(),
+                result.floor(),
+                result.locationDetail(),
+                result.quantity(),
+                result.operatingHours().stream()
+                        .map(OperatingHoursDto::from)
+                        .toList(),
+                result.externalUrl(),
+                BuildingSummary.from(result.building())
+        );
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/OperatingHoursDto.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/OperatingHoursDto.java
@@ -1,5 +1,10 @@
 package com.kustacks.kuring.building.adapter.in.web.dto.model;
 
+import com.kustacks.kuring.building.application.port.in.dto.OperatingHoursResult;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
 public record OperatingHoursDto(
         String period,
         String dayGroup,
@@ -8,4 +13,21 @@ public record OperatingHoursDto(
         String closesAt,
         boolean isCurrent
 ) {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    public static OperatingHoursDto from(OperatingHoursResult result) {
+        return new OperatingHoursDto(
+                result.period().name(),
+                result.dayGroup().name(),
+                result.status().name(),
+                format(result.opensAt()),
+                format(result.closesAt()),
+                result.isCurrent()
+        );
+    }
+
+    private static String format(LocalTime time) {
+        return time == null ? null : time.format(TIME_FORMATTER);
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapter.java
@@ -1,0 +1,50 @@
+package com.kustacks.kuring.building.adapter.out.calendar;
+
+import com.kustacks.kuring.building.application.port.out.AcademicPeriodPort;
+import com.kustacks.kuring.building.domain.OperatingPeriod;
+import com.kustacks.kuring.calendar.application.port.out.AcademicEventQueryPort;
+import com.kustacks.kuring.calendar.application.port.out.dto.AcademicEventReadModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class AcademicEventPeriodAdapter implements AcademicPeriodPort {
+
+    private final AcademicEventQueryPort academicEventQueryPort;
+
+    @Override
+    public OperatingPeriod resolve(LocalDate date) {
+        return academicEventQueryPort.findEventsBefore(date).stream()
+                .map(this::toBoundary)
+                .flatMap(Optional::stream)
+                .max(Comparator.comparing(PeriodBoundary::startsAt))
+                .map(PeriodBoundary::period)
+                .orElse(OperatingPeriod.SEMESTER);
+    }
+
+    private Optional<PeriodBoundary> toBoundary(AcademicEventReadModel event) {
+        String summary = event.summary()
+                .replaceAll("\\s", "")
+                .toLowerCase(Locale.ROOT);
+
+        if (summary.contains("개강")) {
+            return Optional.of(new PeriodBoundary(event.startTime(), OperatingPeriod.SEMESTER));
+        }
+
+        if (summary.contains("방학")) {
+            return Optional.of(new PeriodBoundary(event.startTime(), OperatingPeriod.VACATION));
+        }
+
+        return Optional.empty();
+    }
+
+    private record PeriodBoundary(LocalDateTime startsAt, OperatingPeriod period) {
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapter.java
@@ -17,16 +17,21 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class AcademicEventPeriodAdapter implements AcademicPeriodPort {
 
+    private static final int RECENT_BOUNDARY_MONTHS = 5;
+
     private final AcademicEventQueryPort academicEventQueryPort;
 
     @Override
     public OperatingPeriod resolve(LocalDate date) {
+        LocalDateTime recentBoundaryThreshold = date.minusMonths(RECENT_BOUNDARY_MONTHS).atStartOfDay();
+
         return academicEventQueryPort.findEventsBefore(date).stream()
                 .map(this::toBoundary)
                 .flatMap(Optional::stream)
+                .filter(boundary -> !boundary.startsAt().isBefore(recentBoundaryThreshold))
                 .max(Comparator.comparing(PeriodBoundary::startsAt))
                 .map(PeriodBoundary::period)
-                .orElse(OperatingPeriod.SEMESTER);
+                .orElseGet(() -> resolveFallback(date));
     }
 
     private Optional<PeriodBoundary> toBoundary(AcademicEventReadModel event) {
@@ -43,6 +48,13 @@ public class AcademicEventPeriodAdapter implements AcademicPeriodPort {
         }
 
         return Optional.empty();
+    }
+
+    private OperatingPeriod resolveFallback(LocalDate date) {
+        return switch (date.getMonth()) {
+            case JANUARY, FEBRUARY, JULY, AUGUST -> OperatingPeriod.VACATION;
+            default -> OperatingPeriod.SEMESTER;
+        };
     }
 
     private record PeriodBoundary(LocalDateTime startsAt, OperatingPeriod period) {

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapter.java
@@ -1,9 +1,10 @@
 package com.kustacks.kuring.building.adapter.out.calendar;
 
-import com.kustacks.kuring.building.application.port.out.AcademicPeriodPort;
+import com.kustacks.kuring.building.application.port.out.AcademicPeriodQueryPort;
 import com.kustacks.kuring.building.domain.OperatingPeriod;
-import com.kustacks.kuring.calendar.application.port.out.AcademicEventQueryPort;
-import com.kustacks.kuring.calendar.application.port.out.dto.AcademicEventReadModel;
+import com.kustacks.kuring.calendar.application.port.in.AcademicEventQueryUseCase;
+import com.kustacks.kuring.calendar.application.port.in.dto.AcademicEventLookupCommand;
+import com.kustacks.kuring.calendar.application.port.in.dto.AcademicEventResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,17 +16,19 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class AcademicEventPeriodAdapter implements AcademicPeriodPort {
+public class AcademicEventPeriodAdapter implements AcademicPeriodQueryPort {
 
     private static final int RECENT_BOUNDARY_MONTHS = 5;
 
-    private final AcademicEventQueryPort academicEventQueryPort;
+    private final AcademicEventQueryUseCase academicEventQueryUseCase;
 
     @Override
-    public OperatingPeriod resolve(LocalDate date) {
+    public OperatingPeriod determineOperatingPeriod(LocalDate date) {
         LocalDateTime recentBoundaryThreshold = date.minusMonths(RECENT_BOUNDARY_MONTHS).atStartOfDay();
 
-        return academicEventQueryPort.findEventsBefore(date).stream()
+        return academicEventQueryUseCase.getAcademicEventsByDateRange(
+                        new AcademicEventLookupCommand(null, date)
+                ).stream()
                 .map(this::toBoundary)
                 .flatMap(Optional::stream)
                 .filter(boundary -> !boundary.startsAt().isBefore(recentBoundaryThreshold))
@@ -34,7 +37,7 @@ public class AcademicEventPeriodAdapter implements AcademicPeriodPort {
                 .orElseGet(() -> resolveFallback(date));
     }
 
-    private Optional<PeriodBoundary> toBoundary(AcademicEventReadModel event) {
+    private Optional<PeriodBoundary> toBoundary(AcademicEventResult event) {
         String summary = event.summary()
                 .replaceAll("\\s", "")
                 .toLowerCase(Locale.ROOT);

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
@@ -3,7 +3,11 @@ package com.kustacks.kuring.building.adapter.out.persistence;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
+import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceReadModel;
+import com.kustacks.kuring.building.application.port.out.dto.OperatingHoursReadModel;
 import com.kustacks.kuring.building.domain.Building;
+import com.kustacks.kuring.building.domain.CampusPlace;
+import com.kustacks.kuring.building.domain.OperatingHours;
 import com.kustacks.kuring.common.annotation.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +18,7 @@ import java.util.List;
 public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
 
     private final BuildingRepository buildingRepository;
+    private final CampusPlaceRepository campusPlaceRepository;
     private final CampusPlaceCategoryRepository categoryRepository;
 
     @Override
@@ -39,6 +44,46 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
         return buildingRepository.searchByKeyword(keyword).stream()
                 .map(this::toBuildingSummaryReadModel)
                 .toList();
+    }
+
+    @Override
+    public List<CampusPlaceReadModel> findCampusPlacesByCategories(List<String> categoryCodes) {
+        if (categoryCodes.isEmpty()) {
+            return List.of();
+        }
+
+        return campusPlaceRepository.findByFilterCategories(categoryCodes).stream()
+                .map(this::toCampusPlaceReadModel)
+                .toList();
+    }
+
+    private CampusPlaceReadModel toCampusPlaceReadModel(CampusPlace place) {
+        return new CampusPlaceReadModel(
+                place.getId(),
+                place.getName(),
+                place.getCategory().getCode(),
+                place.getCategory().getKorName(),
+                place.getImagePath(),
+                place.getLocationType(),
+                place.getFloor(),
+                place.getLocationDetail(),
+                place.getQuantity(),
+                place.getOperatingHours().stream()
+                        .map(this::toOperatingHoursReadModel)
+                        .toList(),
+                place.getExternalUrl(),
+                toBuildingSummaryReadModel(place.getBuilding())
+        );
+    }
+
+    private OperatingHoursReadModel toOperatingHoursReadModel(OperatingHours operatingHours) {
+        return new OperatingHoursReadModel(
+                operatingHours.getPeriod(),
+                operatingHours.getDayGroup(),
+                operatingHours.getStatus(),
+                operatingHours.getOpensAt(),
+                operatingHours.getClosesAt()
+        );
     }
 
     private BuildingSummaryReadModel toBuildingSummaryReadModel(Building building) {

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepository.java
@@ -1,0 +1,10 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.domain.CampusPlace;
+
+import java.util.List;
+
+public interface CampusPlaceQueryRepository {
+
+    List<CampusPlace> findByFilterCategories(List<String> categoryCodes);
+}

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.domain.CampusPlace;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.kustacks.kuring.building.domain.QBuilding.building;
+import static com.kustacks.kuring.building.domain.QCampusPlace.campusPlace;
+import static com.kustacks.kuring.building.domain.QCampusPlaceCategory.campusPlaceCategory;
+import static com.kustacks.kuring.building.domain.QOperatingHours.operatingHours;
+
+@RequiredArgsConstructor
+class CampusPlaceQueryRepositoryImpl implements CampusPlaceQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CampusPlace> findByFilterCategories(List<String> categoryCodes) {
+        return queryFactory
+                .selectFrom(campusPlace)
+                .join(campusPlace.building, building).fetchJoin()
+                .join(campusPlace.category, campusPlaceCategory).fetchJoin()
+                .leftJoin(campusPlace.operatingHours, operatingHours).fetchJoin()
+                .where(
+                        campusPlaceCategory.code.in(categoryCodes),
+                        campusPlaceCategory.filterEnabled.isTrue()
+                )
+                .distinct()
+                .orderBy(campusPlace.displayOrder.asc(), campusPlace.id.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceRepository.java
@@ -1,0 +1,7 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.domain.CampusPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CampusPlaceRepository extends JpaRepository<CampusPlace, Long>, CampusPlaceQueryRepository {
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.building.application.port.in;
 
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
+import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 
 import java.util.List;
@@ -12,4 +13,6 @@ public interface CampusMapQueryUseCase {
     List<BuildingSummaryResult> getBuildings();
 
     List<BuildingSummaryResult> searchBuildings(String keyword);
+
+    List<CampusPlaceResult> getCampusPlaces(List<String> categories);
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/dto/CampusPlaceResult.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/dto/CampusPlaceResult.java
@@ -1,0 +1,21 @@
+package com.kustacks.kuring.building.application.port.in.dto;
+
+import com.kustacks.kuring.building.domain.CampusPlaceLocationType;
+
+import java.util.List;
+
+public record CampusPlaceResult(
+        Long id,
+        String name,
+        String category,
+        String categoryKorName,
+        String imageUrl,
+        CampusPlaceLocationType locationType,
+        String floor,
+        String locationDetail,
+        Integer quantity,
+        List<OperatingHoursResult> operatingHours,
+        String externalUrl,
+        BuildingSummaryResult building
+) {
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/dto/OperatingHoursResult.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/dto/OperatingHoursResult.java
@@ -1,0 +1,17 @@
+package com.kustacks.kuring.building.application.port.in.dto;
+
+import com.kustacks.kuring.building.domain.OperatingDayGroup;
+import com.kustacks.kuring.building.domain.OperatingHoursStatus;
+import com.kustacks.kuring.building.domain.OperatingPeriod;
+
+import java.time.LocalTime;
+
+public record OperatingHoursResult(
+        OperatingPeriod period,
+        OperatingDayGroup dayGroup,
+        OperatingHoursStatus status,
+        LocalTime opensAt,
+        LocalTime closesAt,
+        boolean isCurrent
+) {
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/AcademicPeriodPort.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/AcademicPeriodPort.java
@@ -1,0 +1,10 @@
+package com.kustacks.kuring.building.application.port.out;
+
+import com.kustacks.kuring.building.domain.OperatingPeriod;
+
+import java.time.LocalDate;
+
+public interface AcademicPeriodPort {
+
+    OperatingPeriod resolve(LocalDate date);
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/AcademicPeriodQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/AcademicPeriodQueryPort.java
@@ -4,7 +4,7 @@ import com.kustacks.kuring.building.domain.OperatingPeriod;
 
 import java.time.LocalDate;
 
-public interface AcademicPeriodPort {
+public interface AcademicPeriodQueryPort {
 
-    OperatingPeriod resolve(LocalDate date);
+    OperatingPeriod determineOperatingPeriod(LocalDate date);
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
@@ -2,6 +2,7 @@ package com.kustacks.kuring.building.application.port.out;
 
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
+import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceReadModel;
 
 import java.util.List;
 
@@ -12,4 +13,6 @@ public interface CampusMapQueryPort {
     List<BuildingSummaryReadModel> findBuildings();
 
     List<BuildingSummaryReadModel> searchBuildings(String keyword);
+
+    List<CampusPlaceReadModel> findCampusPlacesByCategories(List<String> categoryCodes);
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/dto/CampusPlaceReadModel.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/dto/CampusPlaceReadModel.java
@@ -1,0 +1,21 @@
+package com.kustacks.kuring.building.application.port.out.dto;
+
+import com.kustacks.kuring.building.domain.CampusPlaceLocationType;
+
+import java.util.List;
+
+public record CampusPlaceReadModel(
+        Long id,
+        String name,
+        String categoryCode,
+        String categoryKorName,
+        String imagePath,
+        CampusPlaceLocationType locationType,
+        String floor,
+        String locationDetail,
+        Integer quantity,
+        List<OperatingHoursReadModel> operatingHours,
+        String externalUrl,
+        BuildingSummaryReadModel building
+) {
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/dto/OperatingHoursReadModel.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/dto/OperatingHoursReadModel.java
@@ -1,0 +1,20 @@
+package com.kustacks.kuring.building.application.port.out.dto;
+
+import com.kustacks.kuring.building.domain.OperatingDayGroup;
+import com.kustacks.kuring.building.domain.OperatingHoursStatus;
+import com.kustacks.kuring.building.domain.OperatingPeriod;
+
+import java.time.LocalTime;
+
+public record OperatingHoursReadModel(
+        OperatingPeriod period,
+        OperatingDayGroup dayGroup,
+        OperatingHoursStatus status,
+        LocalTime opensAt,
+        LocalTime closesAt
+) {
+
+    public boolean matches(OperatingPeriod period, OperatingDayGroup dayGroup) {
+        return this.period == period && this.dayGroup == dayGroup;
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -2,15 +2,29 @@ package com.kustacks.kuring.building.application.service;
 
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
+import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
+import com.kustacks.kuring.building.application.port.in.dto.OperatingHoursResult;
+import com.kustacks.kuring.building.application.port.out.AcademicPeriodPort;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
+import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceReadModel;
+import com.kustacks.kuring.building.application.port.out.dto.OperatingHoursReadModel;
+import com.kustacks.kuring.building.application.service.model.OperatingContext;
+import com.kustacks.kuring.building.domain.OperatingDayGroup;
+import com.kustacks.kuring.building.domain.OperatingPeriod;
 import com.kustacks.kuring.common.annotation.UseCase;
+import com.kustacks.kuring.storage.application.port.out.StoragePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 @UseCase
 @Transactional(readOnly = true)
@@ -18,6 +32,9 @@ import java.util.List;
 public class CampusMapQueryService implements CampusMapQueryUseCase {
 
     private final CampusMapQueryPort campusMapQueryPort;
+    private final AcademicPeriodPort academicPeriodPort;
+    private final StoragePort storagePort;
+    private final Clock clock;
 
     @Override
     public List<CategoryResult> getCategories() {
@@ -42,6 +59,16 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
                 .toList();
     }
 
+    @Override
+    public List<CampusPlaceResult> getCampusPlaces(List<String> categories) {
+        List<String> normalizedCategories = normalizeCategories(categories);
+        OperatingContext context = currentOperatingContext();
+
+        return campusMapQueryPort.findCampusPlacesByCategories(normalizedCategories).stream()
+                .map(place -> toCampusPlaceResult(place, context))
+                .toList();
+    }
+
     private CategoryResult toCategoryResult(CampusPlaceCategoryReadModel category) {
         return new CategoryResult(
                 category.code(),
@@ -59,4 +86,75 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
                 building.longitude()
         );
     }
+
+    private CampusPlaceResult toCampusPlaceResult(
+            CampusPlaceReadModel place,
+            OperatingContext context
+    ) {
+        return new CampusPlaceResult(
+                place.id(),
+                place.name(),
+                place.categoryCode(),
+                place.categoryKorName(),
+                resolveImageUrl(place.imagePath()),
+                place.locationType(),
+                place.floor(),
+                place.locationDetail(),
+                place.quantity(),
+                resolveOperatingHours(place.operatingHours(), context),
+                place.externalUrl(),
+                toBuildingSummaryResult(place.building())
+        );
+    }
+
+    private List<OperatingHoursResult> resolveOperatingHours(
+            List<OperatingHoursReadModel> operatingHours,
+            OperatingContext context
+    ) {
+        return operatingHours.stream()
+                .sorted(Comparator.comparing(OperatingHoursReadModel::period)
+                        .thenComparing(OperatingHoursReadModel::dayGroup))
+                .map(hours -> new OperatingHoursResult(
+                        hours.period(),
+                        hours.dayGroup(),
+                        hours.status(),
+                        hours.opensAt(),
+                        hours.closesAt(),
+                        hours.matches(context.period(), context.dayGroup())
+                ))
+                .toList();
+    }
+
+    private OperatingContext currentOperatingContext() {
+        LocalDate today = LocalDate.now(clock);
+        OperatingPeriod period = academicPeriodPort.resolve(today);
+        OperatingDayGroup dayGroup = isWeekend(today)? OperatingDayGroup.WEEKEND : OperatingDayGroup.WEEKDAY;
+
+        return new OperatingContext(period, dayGroup);
+    }
+
+    private List<String> normalizeCategories(List<String> categories) {
+        return categories.stream()
+                .flatMap(category -> Arrays.stream(category.split(",")))
+                .map(String::trim)
+                .map(category -> category.toLowerCase(Locale.ROOT))
+                .filter(category -> !category.isBlank())
+                .distinct()
+                .toList();
+    }
+
+    private boolean isWeekend(LocalDate date) {
+        return switch (date.getDayOfWeek()) {
+            case SATURDAY, SUNDAY -> true;
+            default -> false;
+        };
+    }
+
+    private String resolveImageUrl(String imagePath) {
+        if (imagePath == null || imagePath.isBlank()) {
+            return null;
+        }
+        return storagePort.getPresignedUrl(imagePath);
+    }
+
 }

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -25,6 +25,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
+import static com.kustacks.kuring.common.utils.TimeUtils.isWeekend;
+
 @UseCase
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -139,13 +141,6 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
                 .filter(category -> !category.isBlank())
                 .distinct()
                 .toList();
-    }
-
-    private boolean isWeekend(LocalDate date) {
-        return switch (date.getDayOfWeek()) {
-            case SATURDAY, SUNDAY -> true;
-            default -> false;
-        };
     }
 
     private String resolveImageUrl(String imagePath) {

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -5,7 +5,7 @@ import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResul
 import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 import com.kustacks.kuring.building.application.port.in.dto.OperatingHoursResult;
-import com.kustacks.kuring.building.application.port.out.AcademicPeriodPort;
+import com.kustacks.kuring.building.application.port.out.AcademicPeriodQueryPort;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
@@ -33,7 +33,7 @@ import static com.kustacks.kuring.common.utils.TimeUtils.isWeekend;
 public class CampusMapQueryService implements CampusMapQueryUseCase {
 
     private final CampusMapQueryPort campusMapQueryPort;
-    private final AcademicPeriodPort academicPeriodPort;
+    private final AcademicPeriodQueryPort academicPeriodQueryPort;
     private final StoragePort storagePort;
     private final Clock clock;
 
@@ -128,8 +128,8 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
 
     private OperatingContext currentOperatingContext() {
         LocalDate today = LocalDate.now(clock);
-        OperatingPeriod period = academicPeriodPort.resolve(today);
-        OperatingDayGroup dayGroup = isWeekend(today)? OperatingDayGroup.WEEKEND : OperatingDayGroup.WEEKDAY;
+        OperatingPeriod period = academicPeriodQueryPort.determineOperatingPeriod(today);
+        OperatingDayGroup dayGroup = isWeekend(today) ? OperatingDayGroup.WEEKEND : OperatingDayGroup.WEEKDAY;
 
         return new OperatingContext(period, dayGroup);
     }

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -135,7 +134,6 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
 
     private List<String> normalizeCategories(List<String> categories) {
         return categories.stream()
-                .flatMap(category -> Arrays.stream(category.split(",")))
                 .map(String::trim)
                 .map(category -> category.toLowerCase(Locale.ROOT))
                 .filter(category -> !category.isBlank())

--- a/src/main/java/com/kustacks/kuring/building/application/service/model/OperatingContext.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/model/OperatingContext.java
@@ -1,0 +1,10 @@
+package com.kustacks.kuring.building.application.service.model;
+
+import com.kustacks.kuring.building.domain.OperatingDayGroup;
+import com.kustacks.kuring.building.domain.OperatingPeriod;
+
+public record OperatingContext(
+        OperatingPeriod period,
+        OperatingDayGroup dayGroup
+) {
+}

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -75,6 +75,7 @@ public enum ResponseCodeAndMessages {
     CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "장소 카테고리 목록 조회에 성공하였습니다"),
     CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "캠퍼스 건물 목록 조회에 성공하였습니다"),
     CAMPUS_MAP_BUILDING_SEARCH_SUCCESS(HttpStatus.OK.value(), "캠퍼스 건물 검색에 성공하였습니다"),
+    CAMPUS_MAP_PLACE_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "카테고리 기반 시설 목록 조회에 성공하였습니다"),
 
     /**
      * ErrorCodes about auth

--- a/src/main/java/com/kustacks/kuring/common/utils/TimeUtils.java
+++ b/src/main/java/com/kustacks/kuring/common/utils/TimeUtils.java
@@ -1,0 +1,16 @@
+package com.kustacks.kuring.common.utils;
+
+import java.time.LocalDate;
+
+public final class TimeUtils {
+
+    private TimeUtils() {
+    }
+
+    public static boolean isWeekend(LocalDate date) {
+        return switch (date.getDayOfWeek()) {
+            case SATURDAY, SUNDAY -> true;
+            default -> false;
+        };
+    }
+}

--- a/src/test/java/com/kustacks/kuring/acceptance/CampusMapQueryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CampusMapQueryAcceptanceTest.java
@@ -1,0 +1,130 @@
+package com.kustacks.kuring.acceptance;
+
+import com.kustacks.kuring.building.adapter.out.persistence.BuildingRepository;
+import com.kustacks.kuring.building.adapter.out.persistence.CampusPlaceCategoryRepository;
+import com.kustacks.kuring.building.adapter.out.persistence.CampusPlaceRepository;
+import com.kustacks.kuring.building.domain.Building;
+import com.kustacks.kuring.building.domain.CampusPlace;
+import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import com.kustacks.kuring.building.domain.CampusPlaceLocationType;
+import com.kustacks.kuring.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+
+import static com.kustacks.kuring.acceptance.CampusMapStep.assertBuildingListResponse;
+import static com.kustacks.kuring.acceptance.CampusMapStep.assertCampusPlaceListResponse;
+import static com.kustacks.kuring.acceptance.CampusMapStep.assertCategoryListResponse;
+import static com.kustacks.kuring.acceptance.CampusMapStep.requestBuildingSearch;
+import static com.kustacks.kuring.acceptance.CampusMapStep.requestBuildings;
+import static com.kustacks.kuring.acceptance.CampusMapStep.requestCampusPlaces;
+import static com.kustacks.kuring.acceptance.CampusMapStep.requestCategories;
+
+@DisplayName("인수 : 캠퍼스맵 조회 API")
+@TestPropertySource(properties = "campus-map.source=database")
+class CampusMapQueryAcceptanceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private BuildingRepository buildingRepository;
+
+    @Autowired
+    private CampusPlaceCategoryRepository categoryRepository;
+
+    @Autowired
+    private CampusPlaceRepository campusPlaceRepository;
+
+    @Test
+    @DisplayName("필터에 노출되는 카테고리 목록을 조회한다")
+    void getCategories_success() {
+        // given
+        categoryRepository.saveAllAndFlush(List.of(
+                new CampusPlaceCategory("printer", "프린터", 1, true),
+                new CampusPlaceCategory("cafe", "카페", 2, true),
+                new CampusPlaceCategory("main_facility", "주요시설", 3, false)
+        ));
+
+        // when
+        var response = requestCategories();
+
+        // then
+        assertCategoryListResponse(response, "printer", "cafe");
+    }
+
+    @Test
+    @DisplayName("등록된 전체 건물 목록을 조회한다")
+    void getBuildings_success() {
+        // given
+        buildingRepository.saveAllAndFlush(List.of(
+                building("행정관", 37.54241, 127.07382),
+                building("경영관", 37.54196, 127.07531)
+        ));
+
+        // when
+        var response = requestBuildings();
+
+        // then
+        assertBuildingListResponse(response, "행정관", "경영관");
+    }
+
+    @Test
+    @DisplayName("건물에 등록된 키워드로 건물을 검색한다")
+    void searchBuildings_success() {
+        // given
+        Building lawBuilding = building("법학관", 37.54174, 127.07649);
+        lawBuilding.addSearchKeyword("종강");
+        buildingRepository.saveAndFlush(lawBuilding);
+        buildingRepository.saveAndFlush(building("학생회관", 37.5412, 127.0784));
+
+        // when
+        var response = requestBuildingSearch("종강");
+
+        // then
+        assertBuildingListResponse(response, "법학관");
+    }
+
+    @Test
+    @DisplayName("카테고리에 해당하는 캠퍼스 시설을 조회한다")
+    void getCampusPlaces_success() {
+        // given
+        Building building = buildingRepository.saveAndFlush(building("학생회관", 37.5412, 127.0784));
+        CampusPlaceCategory category = categoryRepository.saveAndFlush(
+                new CampusPlaceCategory("test_printer", "프린터", 1, true)
+        );
+        campusPlaceRepository.saveAndFlush(new CampusPlace(
+                building,
+                category,
+                "학생회관 프린터",
+                null,
+                CampusPlaceLocationType.INDOOR,
+                "1F",
+                "라운지 안쪽",
+                3,
+                null,
+                1
+        ));
+
+        // when
+        var response = requestCampusPlaces("test_printer");
+
+        // then
+        assertCampusPlaceListResponse(
+                response,
+                "학생회관 프린터",
+                "test_printer",
+                "학생회관"
+        );
+    }
+
+    private Building building(String name, Double latitude, Double longitude) {
+        return new Building(
+                name,
+                "서울특별시 광진구 능동로 120",
+                latitude,
+                longitude,
+                null
+        );
+    }
+}

--- a/src/test/java/com/kustacks/kuring/acceptance/CampusMapStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CampusMapStep.java
@@ -80,6 +80,45 @@ public final class CampusMapStep {
         );
     }
 
+    public static void assertCategoryListResponse(
+            ExtractableResponse<Response> response,
+            String... categoryNames
+    ) {
+        assertSuccessfulListResponse(response, "data.categories");
+
+        assertThat(response.jsonPath().getList("data.categories.name", String.class))
+                .containsExactly(categoryNames);
+    }
+
+    public static void assertBuildingListResponse(
+            ExtractableResponse<Response> response,
+            String... buildingNames
+    ) {
+        assertSuccessfulListResponse(response, "data.buildings");
+
+        assertThat(response.jsonPath().getList("data.buildings.name", String.class))
+                .containsExactly(buildingNames);
+    }
+
+    public static void assertCampusPlaceListResponse(
+            ExtractableResponse<Response> response,
+            String placeName,
+            String category,
+            String buildingName
+    ) {
+        assertSuccessfulListResponse(response, "data.campusPlaces");
+
+        assertAll(
+                () -> assertThat(response.jsonPath().getList("data.campusPlaces")).hasSize(1),
+                () -> assertThat(response.jsonPath().getString("data.campusPlaces[0].name"))
+                        .isEqualTo(placeName),
+                () -> assertThat(response.jsonPath().getString("data.campusPlaces[0].category"))
+                        .isEqualTo(category),
+                () -> assertThat(response.jsonPath().getString("data.campusPlaces[0].building.name"))
+                        .isEqualTo(buildingName)
+        );
+    }
+
     public static void assertBadRequest(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }

--- a/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
@@ -1,10 +1,17 @@
 package com.kustacks.kuring.building.adapter.in.web;
 
 import com.kustacks.kuring.building.adapter.in.web.dto.model.BuildingSummary;
+import com.kustacks.kuring.building.adapter.in.web.dto.model.CampusPlaceItem;
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CategoryDto;
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
+import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
+import com.kustacks.kuring.building.application.port.in.dto.OperatingHoursResult;
+import com.kustacks.kuring.building.domain.CampusPlaceLocationType;
+import com.kustacks.kuring.building.domain.OperatingDayGroup;
+import com.kustacks.kuring.building.domain.OperatingHoursStatus;
+import com.kustacks.kuring.building.domain.OperatingPeriod;
 import com.kustacks.kuring.common.dto.BaseResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
+import java.time.LocalTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -144,6 +152,60 @@ class CampusMapQueryApiV2Test {
                         .containsExactly(
                                 tuple(4L, "학생회관", "서울특별시 광진구 능동로 120")
                         )
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리 기반 캠퍼스 시설 목록을 조회한다")
+    void get_campus_places() {
+        // given
+        when(campusMapQueryUseCase.getCampusPlaces(List.of("printer"))).thenReturn(List.of(
+                new CampusPlaceResult(
+                        10L,
+                        "학생회관 프린터",
+                        "printer",
+                        "프린터",
+                        "https://storage.example.com/printer.png",
+                        CampusPlaceLocationType.INDOOR,
+                        "1F",
+                        "라운지 안쪽",
+                        3,
+                        List.of(new OperatingHoursResult(
+                                OperatingPeriod.SEMESTER,
+                                OperatingDayGroup.WEEKDAY,
+                                OperatingHoursStatus.SCHEDULED,
+                                LocalTime.of(8, 0),
+                                LocalTime.of(22, 0),
+                                true
+                        )),
+                        null,
+                        new BuildingSummaryResult(
+                                4L,
+                                "학생회관",
+                                "서울특별시 광진구 능동로 120",
+                                37.5412,
+                                127.0784
+                        )
+                )
+        ));
+
+        // when
+        var response = campusMapQueryApiV2.getCampusPlaces(List.of("printer"));
+
+        // then
+        var body = response.getBody();
+        assertThat(body).isNotNull();
+        CampusPlaceItem campusPlace = body.getData().campusPlaces().get(0);
+
+        assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(body)
+                        .extracting(BaseResponse::getCode, BaseResponse::getMessage)
+                        .containsExactly(200, "카테고리 기반 시설 목록 조회에 성공하였습니다"),
+                () -> assertThat(campusPlace.name()).isEqualTo("학생회관 프린터"),
+                () -> assertThat(campusPlace.operatingHours().get(0).isCurrent()).isTrue(),
+                () -> assertThat(campusPlace.operatingHours().get(0).opensAt()).isEqualTo("08:00"),
+                () -> assertThat(campusPlace.building().name()).isEqualTo("학생회관")
         );
     }
 }

--- a/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
@@ -13,7 +13,6 @@ import com.kustacks.kuring.building.domain.OperatingDayGroup;
 import com.kustacks.kuring.building.domain.OperatingHoursStatus;
 import com.kustacks.kuring.building.domain.OperatingPeriod;
 import com.kustacks.kuring.common.dto.BaseResponse;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,22 +52,25 @@ class CampusMapQueryApiV2Test {
         var response = campusMapQueryApiV2.getCategories();
 
         // then
-        BaseResponse<?> body = response.getBody();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(body)
-                .extracting(BaseResponse::getCode, BaseResponse::getMessage)
-                .containsExactly(200, "장소 카테고리 목록 조회에 성공하였습니다");
-        Assertions.assertNotNull(response.getBody());
-        assertThat(response.getBody().getData().categories())
-                .extracting(
-                        CategoryDto::name,
-                        CategoryDto::korName,
-                        CategoryDto::displayOrder
-                )
-                .containsExactly(
-                        tuple("cafe", "카페", 1),
-                        tuple("restaurant", "식당", 2)
-                );
+        var body = response.getBody();
+        assertThat(body).isNotNull();
+
+        assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(body)
+                        .extracting(BaseResponse::getCode, BaseResponse::getMessage)
+                        .containsExactly(200, "장소 카테고리 목록 조회에 성공하였습니다"),
+                () -> assertThat(body.getData().categories())
+                        .extracting(
+                                CategoryDto::name,
+                                CategoryDto::korName,
+                                CategoryDto::displayOrder
+                        )
+                        .containsExactly(
+                                tuple("cafe", "카페", 1),
+                                tuple("restaurant", "식당", 2)
+                        )
+        );
     }
 
     @Test
@@ -195,17 +197,19 @@ class CampusMapQueryApiV2Test {
         // then
         var body = response.getBody();
         assertThat(body).isNotNull();
-        CampusPlaceItem campusPlace = body.getData().campusPlaces().get(0);
-
         assertAll(
                 () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
                 () -> assertThat(body)
                         .extracting(BaseResponse::getCode, BaseResponse::getMessage)
                         .containsExactly(200, "카테고리 기반 시설 목록 조회에 성공하였습니다"),
-                () -> assertThat(campusPlace.name()).isEqualTo("학생회관 프린터"),
-                () -> assertThat(campusPlace.operatingHours().get(0).isCurrent()).isTrue(),
-                () -> assertThat(campusPlace.operatingHours().get(0).opensAt()).isEqualTo("08:00"),
-                () -> assertThat(campusPlace.building().name()).isEqualTo("학생회관")
+                () -> assertThat(body.getData().campusPlaces())
+                        .singleElement()
+                        .satisfies(campusPlace -> assertAll(
+                                () -> assertThat(campusPlace.name()).isEqualTo("학생회관 프린터"),
+                                () -> assertThat(campusPlace.operatingHours().get(0).isCurrent()).isTrue(),
+                                () -> assertThat(campusPlace.operatingHours().get(0).opensAt()).isEqualTo("08:00"),
+                                () -> assertThat(campusPlace.building().name()).isEqualTo("학생회관")
+                        ))
         );
     }
 }

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapterTest.java
@@ -47,7 +47,7 @@ class AcademicEventPeriodAdapterTest {
     }
 
     @Test
-    @DisplayName("판단할 학사일정이 없으면 학기중으로 판단한다")
+    @DisplayName("판단할 학사일정이 없으면 날짜를 기준으로 운영기간을 판단한다")
     void resolve_semester_when_boundary_does_not_exist() {
         // given
         LocalDate today = LocalDate.of(2026, 3, 2);
@@ -58,6 +58,22 @@ class AcademicEventPeriodAdapterTest {
 
         // then
         assertThat(period).isEqualTo(OperatingPeriod.SEMESTER);
+    }
+
+    @Test
+    @DisplayName("가장 최근 학사일정이 5개월보다 오래되면 날짜를 기준으로 운영기간을 판단한다")
+    void resolve_period_from_date_when_boundary_is_stale() {
+        // given
+        LocalDate today = LocalDate.of(2026, 8, 20);
+        when(academicEventQueryPort.findEventsBefore(today)).thenReturn(List.of(
+                event(1L, "2025학년도 2학기 개강", LocalDateTime.of(2025, 9, 1, 0, 0))
+        ));
+
+        // when
+        OperatingPeriod period = academicEventPeriodAdapter.resolve(today);
+
+        // then
+        assertThat(period).isEqualTo(OperatingPeriod.VACATION);
     }
 
     private AcademicEventReadModel event(Long id, String summary, LocalDateTime startsAt) {

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapterTest.java
@@ -1,0 +1,77 @@
+package com.kustacks.kuring.building.adapter.out.calendar;
+
+import com.kustacks.kuring.building.domain.OperatingPeriod;
+import com.kustacks.kuring.calendar.application.port.out.AcademicEventQueryPort;
+import com.kustacks.kuring.calendar.application.port.out.dto.AcademicEventReadModel;
+import com.kustacks.kuring.calendar.domain.Transparent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@DisplayName("어댑터 : AcademicEventPeriodAdapter")
+@ExtendWith(MockitoExtension.class)
+class AcademicEventPeriodAdapterTest {
+
+    @Mock
+    private AcademicEventQueryPort academicEventQueryPort;
+
+    @InjectMocks
+    private AcademicEventPeriodAdapter academicEventPeriodAdapter;
+
+    @Test
+    @DisplayName("가장 최근 개강 또는 방학 일정을 기준으로 운영기간을 판단한다")
+    void resolve_period_from_latest_academic_boundary() {
+        // given
+        LocalDate today = LocalDate.of(2026, 7, 20);
+        when(academicEventQueryPort.findEventsBefore(today)).thenReturn(List.of(
+                event(1L, "2026학년도 1학기 개강", LocalDateTime.of(2026, 3, 2, 0, 0)),
+                event(2L, "하계 방학", LocalDateTime.of(2026, 6, 22, 0, 0)),
+                event(3L, "하계 계절학기 수강정정", LocalDateTime.of(2026, 7, 1, 0, 0))
+        ));
+
+        // when
+        OperatingPeriod period = academicEventPeriodAdapter.resolve(today);
+
+        // then
+        assertThat(period).isEqualTo(OperatingPeriod.VACATION);
+    }
+
+    @Test
+    @DisplayName("판단할 학사일정이 없으면 학기중으로 판단한다")
+    void resolve_semester_when_boundary_does_not_exist() {
+        // given
+        LocalDate today = LocalDate.of(2026, 3, 2);
+        when(academicEventQueryPort.findEventsBefore(today)).thenReturn(List.of());
+
+        // when
+        OperatingPeriod period = academicEventPeriodAdapter.resolve(today);
+
+        // then
+        assertThat(period).isEqualTo(OperatingPeriod.SEMESTER);
+    }
+
+    private AcademicEventReadModel event(Long id, String summary, LocalDateTime startsAt) {
+        return new AcademicEventReadModel(
+                id,
+                "event-" + id,
+                summary,
+                null,
+                "ACADEMIC_OPERATION_EVENT",
+                Transparent.TRANSPARENT,
+                0,
+                false,
+                startsAt,
+                startsAt.plusDays(1)
+        );
+    }
+}

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/calendar/AcademicEventPeriodAdapterTest.java
@@ -1,9 +1,9 @@
 package com.kustacks.kuring.building.adapter.out.calendar;
 
 import com.kustacks.kuring.building.domain.OperatingPeriod;
-import com.kustacks.kuring.calendar.application.port.out.AcademicEventQueryPort;
-import com.kustacks.kuring.calendar.application.port.out.dto.AcademicEventReadModel;
-import com.kustacks.kuring.calendar.domain.Transparent;
+import com.kustacks.kuring.calendar.application.port.in.AcademicEventQueryUseCase;
+import com.kustacks.kuring.calendar.application.port.in.dto.AcademicEventLookupCommand;
+import com.kustacks.kuring.calendar.application.port.in.dto.AcademicEventResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,24 +23,26 @@ import static org.mockito.Mockito.when;
 class AcademicEventPeriodAdapterTest {
 
     @Mock
-    private AcademicEventQueryPort academicEventQueryPort;
+    private AcademicEventQueryUseCase academicEventQueryUseCase;
 
     @InjectMocks
     private AcademicEventPeriodAdapter academicEventPeriodAdapter;
 
     @Test
     @DisplayName("가장 최근 개강 또는 방학 일정을 기준으로 운영기간을 판단한다")
-    void resolve_period_from_latest_academic_boundary() {
+    void determine_period_from_latest_academic_boundary() {
         // given
         LocalDate today = LocalDate.of(2026, 7, 20);
-        when(academicEventQueryPort.findEventsBefore(today)).thenReturn(List.of(
+        when(academicEventQueryUseCase.getAcademicEventsByDateRange(
+                new AcademicEventLookupCommand(null, today)
+        )).thenReturn(List.of(
                 event(1L, "2026학년도 1학기 개강", LocalDateTime.of(2026, 3, 2, 0, 0)),
                 event(2L, "하계 방학", LocalDateTime.of(2026, 6, 22, 0, 0)),
                 event(3L, "하계 계절학기 수강정정", LocalDateTime.of(2026, 7, 1, 0, 0))
         ));
 
         // when
-        OperatingPeriod period = academicEventPeriodAdapter.resolve(today);
+        OperatingPeriod period = academicEventPeriodAdapter.determineOperatingPeriod(today);
 
         // then
         assertThat(period).isEqualTo(OperatingPeriod.VACATION);
@@ -48,13 +50,15 @@ class AcademicEventPeriodAdapterTest {
 
     @Test
     @DisplayName("판단할 학사일정이 없으면 날짜를 기준으로 운영기간을 판단한다")
-    void resolve_semester_when_boundary_does_not_exist() {
+    void determine_semester_when_boundary_does_not_exist() {
         // given
         LocalDate today = LocalDate.of(2026, 3, 2);
-        when(academicEventQueryPort.findEventsBefore(today)).thenReturn(List.of());
+        when(academicEventQueryUseCase.getAcademicEventsByDateRange(
+                new AcademicEventLookupCommand(null, today)
+        )).thenReturn(List.of());
 
         // when
-        OperatingPeriod period = academicEventPeriodAdapter.resolve(today);
+        OperatingPeriod period = academicEventPeriodAdapter.determineOperatingPeriod(today);
 
         // then
         assertThat(period).isEqualTo(OperatingPeriod.SEMESTER);
@@ -62,28 +66,30 @@ class AcademicEventPeriodAdapterTest {
 
     @Test
     @DisplayName("가장 최근 학사일정이 5개월보다 오래되면 날짜를 기준으로 운영기간을 판단한다")
-    void resolve_period_from_date_when_boundary_is_stale() {
+    void determine_period_from_date_when_boundary_is_stale() {
         // given
         LocalDate today = LocalDate.of(2026, 8, 20);
-        when(academicEventQueryPort.findEventsBefore(today)).thenReturn(List.of(
+        when(academicEventQueryUseCase.getAcademicEventsByDateRange(
+                new AcademicEventLookupCommand(null, today)
+        )).thenReturn(List.of(
                 event(1L, "2025학년도 2학기 개강", LocalDateTime.of(2025, 9, 1, 0, 0))
         ));
 
         // when
-        OperatingPeriod period = academicEventPeriodAdapter.resolve(today);
+        OperatingPeriod period = academicEventPeriodAdapter.determineOperatingPeriod(today);
 
         // then
         assertThat(period).isEqualTo(OperatingPeriod.VACATION);
     }
 
-    private AcademicEventReadModel event(Long id, String summary, LocalDateTime startsAt) {
-        return new AcademicEventReadModel(
+    private AcademicEventResult event(Long id, String summary, LocalDateTime startsAt) {
+        return new AcademicEventResult(
                 id,
                 "event-" + id,
                 summary,
                 null,
                 "ACADEMIC_OPERATION_EVENT",
-                Transparent.TRANSPARENT,
+                "TRANSPARENT",
                 0,
                 false,
                 startsAt,

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
@@ -170,7 +170,11 @@ class CampusMapPersistenceAdapterTest {
     @Test
     @DisplayName("카테고리가 비어 있으면 캠퍼스 시설을 조회하지 않는다")
     void return_empty_campus_places_when_categories_are_empty() {
-        assertThat(campusMapPersistenceAdapter.findCampusPlacesByCategories(List.of())).isEmpty();
+        // when
+        List<CampusPlaceReadModel> result = campusMapPersistenceAdapter.findCampusPlacesByCategories(List.of());
+
+        // then
+        assertThat(result).isEmpty();
     }
 
     private Building building(Long id, String name, Double latitude, Double longitude) {

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
@@ -2,8 +2,15 @@ package com.kustacks.kuring.building.adapter.out.persistence;
 
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
+import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceReadModel;
 import com.kustacks.kuring.building.domain.Building;
+import com.kustacks.kuring.building.domain.CampusPlace;
 import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import com.kustacks.kuring.building.domain.CampusPlaceLocationType;
+import com.kustacks.kuring.building.domain.OperatingDayGroup;
+import com.kustacks.kuring.building.domain.OperatingHours;
+import com.kustacks.kuring.building.domain.OperatingHoursStatus;
+import com.kustacks.kuring.building.domain.OperatingPeriod;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,9 +19,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +36,9 @@ class CampusMapPersistenceAdapterTest {
 
     @Mock
     private BuildingRepository buildingRepository;
+
+    @Mock
+    private CampusPlaceRepository campusPlaceRepository;
 
     @InjectMocks
     private CampusMapPersistenceAdapter campusMapPersistenceAdapter;
@@ -107,6 +119,58 @@ class CampusMapPersistenceAdapterTest {
                 )
         );
         verify(buildingRepository).searchByKeyword("학관");
+    }
+
+    @Test
+    @DisplayName("선택한 카테고리에 해당하는 캠퍼스 시설을 조회한다")
+    void find_campus_places_by_categories() {
+        // given
+        Building studentCenter = building(4L, "학생회관", 37.5412, 127.0784);
+        CampusPlaceCategory category = new CampusPlaceCategory("printer", "프린터", 1, true);
+        CampusPlace printer = new CampusPlace(
+                studentCenter,
+                category,
+                "학생회관 프린터",
+                "campus-map/printer.png",
+                CampusPlaceLocationType.INDOOR,
+                "1F",
+                "라운지 안쪽",
+                3,
+                null,
+                1
+        );
+        ReflectionTestUtils.setField(printer, "id", 10L);
+        printer.addOperatingHours(new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.SCHEDULED,
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0)
+        ));
+        when(campusPlaceRepository.findByFilterCategories(List.of("printer")))
+                .thenReturn(List.of(printer));
+
+        // when
+        List<CampusPlaceReadModel> result = campusMapPersistenceAdapter.findCampusPlacesByCategories(
+                List.of("printer")
+        );
+
+        // then
+        assertThat(result).singleElement().satisfies(place -> {
+            assertAll(
+                    () -> assertThat(place.name()).isEqualTo("학생회관 프린터"),
+                    () -> assertThat(place.categoryCode()).isEqualTo("printer"),
+                    () -> assertThat(place.operatingHours()).hasSize(1),
+                    () -> assertThat(place.building().name()).isEqualTo("학생회관")
+            );
+        });
+        verify(campusPlaceRepository).findByFilterCategories(List.of("printer"));
+    }
+
+    @Test
+    @DisplayName("카테고리가 비어 있으면 캠퍼스 시설을 조회하지 않는다")
+    void return_empty_campus_places_when_categories_are_empty() {
+        assertThat(campusMapPersistenceAdapter.findCampusPlacesByCategories(List.of())).isEmpty();
     }
 
     private Building building(Long id, String name, Double latitude, Double longitude) {

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepositoryTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.kustacks.kuring.building.adapter.out.persistence;
+
+import com.kustacks.kuring.building.domain.Building;
+import com.kustacks.kuring.building.domain.CampusPlace;
+import com.kustacks.kuring.building.domain.CampusPlaceCategory;
+import com.kustacks.kuring.building.domain.CampusPlaceLocationType;
+import com.kustacks.kuring.building.domain.OperatingDayGroup;
+import com.kustacks.kuring.building.domain.OperatingHours;
+import com.kustacks.kuring.building.domain.OperatingHoursStatus;
+import com.kustacks.kuring.building.domain.OperatingPeriod;
+import com.kustacks.kuring.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("리포지토리 : CampusPlaceQueryRepository")
+class CampusPlaceQueryRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private BuildingRepository buildingRepository;
+
+    @Autowired
+    private CampusPlaceCategoryRepository categoryRepository;
+
+    @Autowired
+    private CampusPlaceRepository campusPlaceRepository;
+
+    @Test
+    @DisplayName("필터에 노출되는 카테고리의 캠퍼스 시설을 노출 순서대로 조회한다")
+    void find_campus_places_by_filter_categories() {
+        // given
+        Building building = buildingRepository.saveAndFlush(new Building(
+                "학생회관",
+                "서울특별시 광진구 능동로 120",
+                37.5412,
+                127.0784,
+                null
+        ));
+        CampusPlaceCategory cafe = categoryRepository.save(
+                new CampusPlaceCategory("test_cafe", "카페", 2, true)
+        );
+        CampusPlaceCategory printer = categoryRepository.save(
+                new CampusPlaceCategory("test_printer", "프린터", 1, true)
+        );
+        CampusPlaceCategory mainFacility = categoryRepository.save(
+                new CampusPlaceCategory("test_main_facility", "주요시설", 100, false)
+        );
+
+        CampusPlace cafePlace = campusPlace(building, cafe, "학생회관 카페", 1);
+        CampusPlace printerPlace = campusPlace(building, printer, "학생회관 프린터", 2);
+        printerPlace.addOperatingHours(new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.SCHEDULED,
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0)
+        ));
+        CampusPlace studentCouncil = campusPlace(building, mainFacility, "총학생회", 3);
+        campusPlaceRepository.saveAllAndFlush(List.of(cafePlace, printerPlace, studentCouncil));
+
+        // when
+        List<CampusPlace> result = campusPlaceRepository.findByFilterCategories(
+                List.of("test_printer", "test_cafe", "test_main_facility")
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(result)
+                        .extracting(CampusPlace::getName)
+                        .containsExactly("학생회관 카페", "학생회관 프린터"),
+                () -> assertThat(result.get(1).getOperatingHours()).hasSize(1),
+                () -> assertThat(result.get(1).getBuilding().getName()).isEqualTo("학생회관")
+        );
+    }
+
+    private CampusPlace campusPlace(
+            Building building,
+            CampusPlaceCategory category,
+            String name,
+            int displayOrder
+    ) {
+        return new CampusPlace(
+                building,
+                category,
+                name,
+                null,
+                CampusPlaceLocationType.INDOOR,
+                "1F",
+                null,
+                null,
+                null,
+                displayOrder
+        );
+    }
+}

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -1,20 +1,34 @@
 package com.kustacks.kuring.building.application.service;
 
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
+import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
+import com.kustacks.kuring.building.application.port.out.AcademicPeriodPort;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
+import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceReadModel;
+import com.kustacks.kuring.building.application.port.out.dto.OperatingHoursReadModel;
+import com.kustacks.kuring.building.domain.CampusPlaceLocationType;
+import com.kustacks.kuring.building.domain.OperatingDayGroup;
+import com.kustacks.kuring.building.domain.OperatingHoursStatus;
+import com.kustacks.kuring.building.domain.OperatingPeriod;
+import com.kustacks.kuring.storage.application.port.out.StoragePort;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,11 +36,31 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class CampusMapQueryServiceTest {
 
+    private static final Clock MONDAY_CLOCK = Clock.fixed(
+            Instant.parse("2026-07-20T00:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
     @Mock
     private CampusMapQueryPort campusMapQueryPort;
 
-    @InjectMocks
+    @Mock
+    private AcademicPeriodPort academicPeriodPort;
+
+    @Mock
+    private StoragePort storagePort;
+
     private CampusMapQueryService campusMapQueryService;
+
+    @BeforeEach
+    void setUp() {
+        campusMapQueryService = new CampusMapQueryService(
+                campusMapQueryPort,
+                academicPeriodPort,
+                storagePort,
+                MONDAY_CLOCK
+        );
+    }
 
     @Test
     @DisplayName("필터에 노출되는 캠퍼스맵 카테고리 목록을 조회한다")
@@ -120,5 +154,74 @@ class CampusMapQueryServiceTest {
                 )
         );
         verify(campusMapQueryPort).searchBuildings("학관");
+    }
+
+    @Test
+    @DisplayName("카테고리를 정규화하고 전체 운영시간과 현재 적용 여부를 반환한다")
+    void get_campus_places_with_operating_hours() {
+        // given
+        CampusPlaceReadModel place = new CampusPlaceReadModel(
+                10L,
+                "학생회관 프린터",
+                "printer",
+                "프린터",
+                "campus-map/printer.png",
+                CampusPlaceLocationType.INDOOR,
+                "1F",
+                "라운지 안쪽",
+                3,
+                List.of(
+                        new OperatingHoursReadModel(
+                                OperatingPeriod.SEMESTER,
+                                OperatingDayGroup.WEEKDAY,
+                                OperatingHoursStatus.SCHEDULED,
+                                LocalTime.of(8, 0),
+                                LocalTime.of(22, 0)
+                        ),
+                        new OperatingHoursReadModel(
+                                OperatingPeriod.VACATION,
+                                OperatingDayGroup.WEEKDAY,
+                                OperatingHoursStatus.OPEN_24_HOURS,
+                                null,
+                                null
+                        )
+                ),
+                null,
+                new BuildingSummaryReadModel(
+                        4L,
+                        "학생회관",
+                        "서울특별시 광진구 능동로 120",
+                        37.5412,
+                        127.0784
+                )
+        );
+        when(academicPeriodPort.resolve(
+                MONDAY_CLOCK.instant().atZone(MONDAY_CLOCK.getZone()).toLocalDate()
+        )).thenReturn(OperatingPeriod.VACATION);
+        when(campusMapQueryPort.findCampusPlacesByCategories(List.of("printer", "cafe")))
+                .thenReturn(List.of(place));
+        when(storagePort.getPresignedUrl("campus-map/printer.png"))
+                .thenReturn("https://storage.example.com/printer.png");
+
+        // when
+        List<CampusPlaceResult> results = campusMapQueryService.getCampusPlaces(
+                List.of(" Printer, cafe ", "printer")
+        );
+
+        // then
+        CampusPlaceResult result = results.get(0);
+        assertAll(
+                () -> assertThat(results).hasSize(1),
+                () -> assertThat(result.imageUrl()).isEqualTo("https://storage.example.com/printer.png"),
+                () -> assertThat(result.operatingHours()).hasSize(2),
+                () -> assertThat(result.operatingHours().get(0).period()).isEqualTo(OperatingPeriod.SEMESTER),
+                () -> assertThat(result.operatingHours().get(0).isCurrent()).isFalse(),
+                () -> assertThat(result.operatingHours().get(1).period()).isEqualTo(OperatingPeriod.VACATION),
+                () -> assertThat(result.operatingHours().get(1).dayGroup()).isEqualTo(OperatingDayGroup.WEEKDAY),
+                () -> assertThat(result.operatingHours().get(1).status())
+                        .isEqualTo(OperatingHoursStatus.OPEN_24_HOURS),
+                () -> assertThat(result.operatingHours().get(1).isCurrent()).isTrue()
+        );
+        verify(campusMapQueryPort).findCampusPlacesByCategories(List.of("printer", "cafe"));
     }
 }

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -3,7 +3,7 @@ package com.kustacks.kuring.building.application.service;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
-import com.kustacks.kuring.building.application.port.out.AcademicPeriodPort;
+import com.kustacks.kuring.building.application.port.out.AcademicPeriodQueryPort;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
@@ -45,7 +45,7 @@ class CampusMapQueryServiceTest {
     private CampusMapQueryPort campusMapQueryPort;
 
     @Mock
-    private AcademicPeriodPort academicPeriodPort;
+    private AcademicPeriodQueryPort academicPeriodQueryPort;
 
     @Mock
     private StoragePort storagePort;
@@ -56,7 +56,7 @@ class CampusMapQueryServiceTest {
     void setUp() {
         campusMapQueryService = new CampusMapQueryService(
                 campusMapQueryPort,
-                academicPeriodPort,
+                academicPeriodQueryPort,
                 storagePort,
                 MONDAY_CLOCK
         );
@@ -157,10 +157,90 @@ class CampusMapQueryServiceTest {
     }
 
     @Test
-    @DisplayName("카테고리를 정규화하고 전체 운영시간과 현재 적용 여부를 반환한다")
+    @DisplayName("시설 카테고리의 앞뒤 공백을 제거하여 조회한다")
+    void get_campus_places_with_trimmed_category() {
+        // given
+        givenCurrentOperatingPeriod();
+
+        // when
+        campusMapQueryService.getCampusPlaces(List.of(" printer "));
+
+        // then
+        verify(campusMapQueryPort).findCampusPlacesByCategories(List.of("printer"));
+    }
+
+    @Test
+    @DisplayName("시설 카테고리를 소문자로 변환하여 조회한다")
+    void get_campus_places_with_lowercase_category() {
+        // given
+        givenCurrentOperatingPeriod();
+
+        // when
+        campusMapQueryService.getCampusPlaces(List.of("PRINTER"));
+
+        // then
+        verify(campusMapQueryPort).findCampusPlacesByCategories(List.of("printer"));
+    }
+
+    @Test
+    @DisplayName("중복된 시설 카테고리를 제거하여 조회한다")
+    void get_campus_places_with_distinct_categories() {
+        // given
+        givenCurrentOperatingPeriod();
+
+        // when
+        campusMapQueryService.getCampusPlaces(List.of("printer", "printer"));
+
+        // then
+        verify(campusMapQueryPort).findCampusPlacesByCategories(List.of("printer"));
+    }
+
+    @Test
+    @DisplayName("시설의 전체 운영시간과 현재 적용 여부를 반환한다")
     void get_campus_places_with_operating_hours() {
         // given
-        CampusPlaceReadModel place = new CampusPlaceReadModel(
+        CampusPlaceReadModel place = campusPlaceReadModel();
+        when(academicPeriodQueryPort.determineOperatingPeriod(
+                MONDAY_CLOCK.instant().atZone(MONDAY_CLOCK.getZone()).toLocalDate()
+        )).thenReturn(OperatingPeriod.VACATION);
+        when(campusMapQueryPort.findCampusPlacesByCategories(List.of("printer")))
+                .thenReturn(List.of(place));
+        when(storagePort.getPresignedUrl("campus-map/printer.png"))
+                .thenReturn("https://storage.example.com/printer.png");
+
+        // when
+        List<CampusPlaceResult> results = campusMapQueryService.getCampusPlaces(
+                List.of("printer")
+        );
+
+        // then
+        assertThat(results)
+                .singleElement()
+                .satisfies(result -> assertAll(
+                        () -> assertThat(result.imageUrl()).isEqualTo("https://storage.example.com/printer.png"),
+                        () -> assertThat(result.operatingHours()).hasSize(2),
+                        () -> assertThat(result.operatingHours().get(0).period())
+                                .isEqualTo(OperatingPeriod.SEMESTER),
+                        () -> assertThat(result.operatingHours().get(0).isCurrent()).isFalse(),
+                        () -> assertThat(result.operatingHours().get(1).period())
+                                .isEqualTo(OperatingPeriod.VACATION),
+                        () -> assertThat(result.operatingHours().get(1).dayGroup())
+                                .isEqualTo(OperatingDayGroup.WEEKDAY),
+                        () -> assertThat(result.operatingHours().get(1).status())
+                                .isEqualTo(OperatingHoursStatus.OPEN_24_HOURS),
+                        () -> assertThat(result.operatingHours().get(1).isCurrent()).isTrue()
+                ));
+        verify(campusMapQueryPort).findCampusPlacesByCategories(List.of("printer"));
+    }
+
+    private void givenCurrentOperatingPeriod() {
+        when(academicPeriodQueryPort.determineOperatingPeriod(
+                MONDAY_CLOCK.instant().atZone(MONDAY_CLOCK.getZone()).toLocalDate()
+        )).thenReturn(OperatingPeriod.VACATION);
+    }
+
+    private CampusPlaceReadModel campusPlaceReadModel() {
+        return new CampusPlaceReadModel(
                 10L,
                 "학생회관 프린터",
                 "printer",
@@ -195,33 +275,5 @@ class CampusMapQueryServiceTest {
                         127.0784
                 )
         );
-        when(academicPeriodPort.resolve(
-                MONDAY_CLOCK.instant().atZone(MONDAY_CLOCK.getZone()).toLocalDate()
-        )).thenReturn(OperatingPeriod.VACATION);
-        when(campusMapQueryPort.findCampusPlacesByCategories(List.of("printer", "cafe")))
-                .thenReturn(List.of(place));
-        when(storagePort.getPresignedUrl("campus-map/printer.png"))
-                .thenReturn("https://storage.example.com/printer.png");
-
-        // when
-        List<CampusPlaceResult> results = campusMapQueryService.getCampusPlaces(
-                List.of(" Printer ", "cafe", "printer")
-        );
-
-        // then
-        CampusPlaceResult result = results.get(0);
-        assertAll(
-                () -> assertThat(results).hasSize(1),
-                () -> assertThat(result.imageUrl()).isEqualTo("https://storage.example.com/printer.png"),
-                () -> assertThat(result.operatingHours()).hasSize(2),
-                () -> assertThat(result.operatingHours().get(0).period()).isEqualTo(OperatingPeriod.SEMESTER),
-                () -> assertThat(result.operatingHours().get(0).isCurrent()).isFalse(),
-                () -> assertThat(result.operatingHours().get(1).period()).isEqualTo(OperatingPeriod.VACATION),
-                () -> assertThat(result.operatingHours().get(1).dayGroup()).isEqualTo(OperatingDayGroup.WEEKDAY),
-                () -> assertThat(result.operatingHours().get(1).status())
-                        .isEqualTo(OperatingHoursStatus.OPEN_24_HOURS),
-                () -> assertThat(result.operatingHours().get(1).isCurrent()).isTrue()
-        );
-        verify(campusMapQueryPort).findCampusPlacesByCategories(List.of("printer", "cafe"));
     }
 }

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -205,7 +205,7 @@ class CampusMapQueryServiceTest {
 
         // when
         List<CampusPlaceResult> results = campusMapQueryService.getCampusPlaces(
-                List.of(" Printer, cafe ", "printer")
+                List.of(" Printer ", "cafe", "printer")
         );
 
         // then

--- a/src/test/java/com/kustacks/kuring/common/utils/TimeUtilsTest.java
+++ b/src/test/java/com/kustacks/kuring/common/utils/TimeUtilsTest.java
@@ -1,0 +1,44 @@
+package com.kustacks.kuring.common.utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("유틸 : TimeUtils")
+class TimeUtilsTest {
+
+    @Test
+    @DisplayName("토요일과 일요일을 주말로 판단한다")
+    void determine_weekend() {
+        // given
+        LocalDate saturday = LocalDate.of(2026, 7, 25);
+        LocalDate sunday = LocalDate.of(2026, 7, 26);
+
+        // when
+        boolean saturdayResult = TimeUtils.isWeekend(saturday);
+        boolean sundayResult = TimeUtils.isWeekend(sunday);
+
+        // then
+        assertAll(
+                () -> assertThat(saturdayResult).isTrue(),
+                () -> assertThat(sundayResult).isTrue()
+        );
+    }
+
+    @Test
+    @DisplayName("평일을 주말이 아닌 것으로 판단한다")
+    void determine_weekday() {
+        // given
+        LocalDate weekday = LocalDate.of(2026, 7, 20);
+
+        // when
+        boolean result = TimeUtils.isWeekend(weekday);
+
+        // then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈
#392 
## 📌 요약
- 카테고리 기반 캠퍼스 시설 목록 조회 API를 구현했습니다.
## 🛠️ 상세
- `GET /api/v2/maps/campus-places` API를 실제 조회 로직과 연동했습니다.
- QueryDSL을 사용해 선택한 카테고리의 시설과 소속 건물, 운영시간을 조회하도록 구현했습니다.
- 학사일정을 기준으로 학기·방학을 판단하고 현재 적용되는 운영시간을 표시하도록 구현했습니다.
- 기간·요일별 전체 운영시간과 시설 이미지 URL을 반환하도록 구현했습니다.
- 컨트롤러, 서비스 및 영속성 계층 테스트를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카테고리별 캠퍼스 시설 목록을 조회할 수 있는 API를 추가했습니다.
  * 시설의 위치, 수량, 운영시간, 건물 정보, 외부 링크 및 이미지를 제공합니다.
  * 현재 학사 기간과 평일·주말에 맞는 운영시간 및 운영 여부를 표시합니다.
  * 카테고리 입력값을 자동 정리하고 중복을 제거합니다.
* **테스트**
  * 시설 조회, 운영시간, 학사 기간 및 카테고리 필터링 시나리오를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->