### PR TITLE
Feat: 캠퍼스맵 건물 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
@@ -1,10 +1,12 @@
 package com.kustacks.kuring.building.adapter.in.web;
 
+import com.kustacks.kuring.building.adapter.in.web.dto.BuildingDetailResponse;
 import com.kustacks.kuring.building.adapter.in.web.dto.BuildingListResponse;
 import com.kustacks.kuring.building.adapter.in.web.dto.BuildingSearchResponse;
 import com.kustacks.kuring.building.adapter.in.web.dto.CampusPlaceListResponse;
 import com.kustacks.kuring.building.adapter.in.web.dto.CategoryListResponse;
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
 import com.kustacks.kuring.common.annotation.RestWebAdapter;
 import com.kustacks.kuring.common.dto.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,11 +18,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
+import java.util.Optional;
 
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_DETAIL_SEARCH_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS;
+import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_NOT_FOUND;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_SEARCH_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_PLACE_LIST_SEARCH_SUCCESS;
@@ -75,6 +81,24 @@ public class CampusMapQueryApiV2 {
         return ResponseEntity.ok(new BaseResponse<>(
                 CAMPUS_MAP_PLACE_LIST_SEARCH_SUCCESS,
                 CampusPlaceListResponse.from(campusMapQueryUseCase.getCampusPlaces(categories))
+        ));
+    }
+
+    @Operation(summary = "캠퍼스맵 건물 상세 조회")
+    @GetMapping("/buildings/{buildingId}")
+    public ResponseEntity<BaseResponse<BuildingDetailResponse>> getBuildingDetail(
+            @PathVariable Long buildingId
+    ) {
+        Optional<BuildingDetailResult> result = campusMapQueryUseCase.getBuildingDetail(buildingId);
+
+        if (result.isEmpty()) {
+            return ResponseEntity.status(CAMPUS_MAP_BUILDING_NOT_FOUND.getCode())
+                    .body(new BaseResponse<>(CAMPUS_MAP_BUILDING_NOT_FOUND, null));
+        }
+
+        return ResponseEntity.ok(new BaseResponse<>(
+                CAMPUS_MAP_BUILDING_DETAIL_SEARCH_SUCCESS,
+                BuildingDetailResponse.from(result.get())
         ));
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2.java
@@ -6,7 +6,6 @@ import com.kustacks.kuring.building.adapter.in.web.dto.BuildingSearchResponse;
 import com.kustacks.kuring.building.adapter.in.web.dto.CampusPlaceListResponse;
 import com.kustacks.kuring.building.adapter.in.web.dto.CategoryListResponse;
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
-import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
 import com.kustacks.kuring.common.annotation.RestWebAdapter;
 import com.kustacks.kuring.common.dto.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,11 +21,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_DETAIL_SEARCH_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS;
-import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_NOT_FOUND;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_BUILDING_SEARCH_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_CATEGORY_LIST_SEARCH_SUCCESS;
 import static com.kustacks.kuring.common.dto.ResponseCodeAndMessages.CAMPUS_MAP_PLACE_LIST_SEARCH_SUCCESS;
@@ -89,16 +86,9 @@ public class CampusMapQueryApiV2 {
     public ResponseEntity<BaseResponse<BuildingDetailResponse>> getBuildingDetail(
             @PathVariable Long buildingId
     ) {
-        Optional<BuildingDetailResult> result = campusMapQueryUseCase.getBuildingDetail(buildingId);
-
-        if (result.isEmpty()) {
-            return ResponseEntity.status(CAMPUS_MAP_BUILDING_NOT_FOUND.getCode())
-                    .body(new BaseResponse<>(CAMPUS_MAP_BUILDING_NOT_FOUND, null));
-        }
-
         return ResponseEntity.ok(new BaseResponse<>(
                 CAMPUS_MAP_BUILDING_DETAIL_SEARCH_SUCCESS,
-                BuildingDetailResponse.from(result.get())
+                BuildingDetailResponse.from(campusMapQueryUseCase.getBuildingDetail(buildingId))
         ));
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/BuildingDetailResponse.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/BuildingDetailResponse.java
@@ -2,6 +2,7 @@ package com.kustacks.kuring.building.adapter.in.web.dto;
 
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CampusPlaceDetail;
 import com.kustacks.kuring.building.adapter.in.web.dto.model.OperatingHoursDto;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
 
 import java.util.List;
 
@@ -15,4 +16,21 @@ public record BuildingDetailResponse(
         List<OperatingHoursDto> operatingHours,
         List<CampusPlaceDetail> campusPlaces
 ) {
+
+    public static BuildingDetailResponse from(BuildingDetailResult result) {
+        return new BuildingDetailResponse(
+                result.id(),
+                result.name(),
+                result.address(),
+                result.latitude(),
+                result.longitude(),
+                result.imageUrl(),
+                result.operatingHours().stream()
+                        .map(OperatingHoursDto::from)
+                        .toList(),
+                result.campusPlaces().stream()
+                        .map(CampusPlaceDetail::from)
+                        .toList()
+        );
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/CampusPlaceDetail.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/CampusPlaceDetail.java
@@ -1,5 +1,7 @@
 package com.kustacks.kuring.building.adapter.in.web.dto.model;
 
+import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
+
 import java.util.List;
 
 public record CampusPlaceDetail(
@@ -15,4 +17,22 @@ public record CampusPlaceDetail(
         List<OperatingHoursDto> operatingHours,
         String externalUrl
 ) {
+
+    public static CampusPlaceDetail from(CampusPlaceResult result) {
+        return new CampusPlaceDetail(
+                result.id(),
+                result.name(),
+                result.category(),
+                result.categoryKorName(),
+                result.imageUrl(),
+                result.locationType().name(),
+                result.floor(),
+                result.locationDetail(),
+                result.quantity(),
+                result.operatingHours().stream()
+                        .map(OperatingHoursDto::from)
+                        .toList(),
+                result.externalUrl()
+        );
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.building.adapter.out.persistence;
 
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
+import com.kustacks.kuring.building.application.port.out.dto.BuildingDetailReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceReadModel;
@@ -12,6 +13,7 @@ import com.kustacks.kuring.common.annotation.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.Optional;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
@@ -57,6 +59,19 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
                 .toList();
     }
 
+    @Override
+    public List<CampusPlaceReadModel> findCampusPlacesByBuildingId(Long buildingId) {
+        return campusPlaceRepository.findByBuildingId(buildingId).stream()
+                .map(this::toCampusPlaceReadModel)
+                .toList();
+    }
+
+    @Override
+    public Optional<BuildingDetailReadModel> findBuildingById(Long buildingId) {
+        return buildingRepository.findById(buildingId)
+                .map(this::toBuildingDetailReadModel);
+    }
+
     private CampusPlaceReadModel toCampusPlaceReadModel(CampusPlace place) {
         return new CampusPlaceReadModel(
                 place.getId(),
@@ -83,6 +98,20 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
                 operatingHours.getStatus(),
                 operatingHours.getOpensAt(),
                 operatingHours.getClosesAt()
+        );
+    }
+
+    private BuildingDetailReadModel toBuildingDetailReadModel(Building building) {
+        return new BuildingDetailReadModel(
+                building.getId(),
+                building.getName(),
+                building.getAddress(),
+                building.getLat(),
+                building.getLon(),
+                building.getImagePath(),
+                building.getOperatingHours().stream()
+                        .map(this::toOperatingHoursReadModel)
+                        .toList()
         );
     }
 

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface CampusPlaceQueryRepository {
 
     List<CampusPlace> findByFilterCategories(List<String> categoryCodes);
+
+    List<CampusPlace> findByBuildingId(Long buildingId);
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepositoryImpl.java
@@ -31,4 +31,17 @@ class CampusPlaceQueryRepositoryImpl implements CampusPlaceQueryRepository {
                 .orderBy(campusPlace.displayOrder.asc(), campusPlace.id.asc())
                 .fetch();
     }
+
+    @Override
+    public List<CampusPlace> findByBuildingId(Long buildingId) {
+        return queryFactory
+                .selectFrom(campusPlace)
+                .join(campusPlace.building, building).fetchJoin()
+                .join(campusPlace.category, campusPlaceCategory).fetchJoin()
+                .leftJoin(campusPlace.operatingHours, operatingHours).fetchJoin()
+                .where(campusPlace.building.id.eq(buildingId))
+                .distinct()
+                .orderBy(campusPlace.displayOrder.asc(), campusPlace.id.asc())
+                .fetch();
+    }
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
@@ -1,10 +1,12 @@
 package com.kustacks.kuring.building.application.port.in;
 
+import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CampusMapQueryUseCase {
 
@@ -15,4 +17,6 @@ public interface CampusMapQueryUseCase {
     List<BuildingSummaryResult> searchBuildings(String keyword);
 
     List<CampusPlaceResult> getCampusPlaces(List<String> categories);
+
+    Optional<BuildingDetailResult> getBuildingDetail(Long buildingId);
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
@@ -6,7 +6,6 @@ import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface CampusMapQueryUseCase {
 
@@ -18,5 +17,5 @@ public interface CampusMapQueryUseCase {
 
     List<CampusPlaceResult> getCampusPlaces(List<String> categories);
 
-    Optional<BuildingDetailResult> getBuildingDetail(Long buildingId);
+    BuildingDetailResult getBuildingDetail(Long buildingId);
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/dto/BuildingDetailResult.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/dto/BuildingDetailResult.java
@@ -1,0 +1,15 @@
+package com.kustacks.kuring.building.application.port.in.dto;
+
+import java.util.List;
+
+public record BuildingDetailResult(
+        Long id,
+        String name,
+        String address,
+        Double latitude,
+        Double longitude,
+        String imageUrl,
+        List<OperatingHoursResult> operatingHours,
+        List<CampusPlaceResult> campusPlaces
+) {
+}

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/CampusMapQueryPort.java
@@ -1,10 +1,12 @@
 package com.kustacks.kuring.building.application.port.out;
 
+import com.kustacks.kuring.building.application.port.out.dto.BuildingDetailReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceReadModel;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CampusMapQueryPort {
 
@@ -15,4 +17,8 @@ public interface CampusMapQueryPort {
     List<BuildingSummaryReadModel> searchBuildings(String keyword);
 
     List<CampusPlaceReadModel> findCampusPlacesByCategories(List<String> categoryCodes);
+
+    List<CampusPlaceReadModel> findCampusPlacesByBuildingId(Long buildingId);
+
+    Optional<BuildingDetailReadModel> findBuildingById(Long buildingId);
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/dto/BuildingDetailReadModel.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/dto/BuildingDetailReadModel.java
@@ -1,0 +1,14 @@
+package com.kustacks.kuring.building.application.port.out.dto;
+
+import java.util.List;
+
+public record BuildingDetailReadModel(
+        Long id,
+        String name,
+        String address,
+        Double latitude,
+        Double longitude,
+        String imagePath,
+        List<OperatingHoursReadModel> operatingHours
+) {
+}

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -17,6 +17,7 @@ import com.kustacks.kuring.building.application.service.model.OperatingContext;
 import com.kustacks.kuring.building.domain.OperatingDayGroup;
 import com.kustacks.kuring.building.domain.OperatingPeriod;
 import com.kustacks.kuring.common.annotation.UseCase;
+import com.kustacks.kuring.common.exception.NotFoundException;
 import com.kustacks.kuring.storage.application.port.out.StoragePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,8 +27,8 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 
+import static com.kustacks.kuring.common.exception.code.ErrorCode.BUILDING_NOT_FOUND;
 import static com.kustacks.kuring.common.utils.TimeUtils.isWeekend;
 
 @UseCase
@@ -74,13 +75,15 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
     }
 
     @Override
-    public Optional<BuildingDetailResult> getBuildingDetail(Long buildingId) {
-        return campusMapQueryPort.findBuildingById(buildingId)
-                .map(building -> toBuildingDetailResult(
-                        building,
-                        campusMapQueryPort.findCampusPlacesByBuildingId(buildingId),
-                        currentOperatingContext()
-                ));
+    public BuildingDetailResult getBuildingDetail(Long buildingId) {
+        BuildingDetailReadModel building = campusMapQueryPort.findBuildingById(buildingId)
+                .orElseThrow(() -> new NotFoundException(BUILDING_NOT_FOUND));
+
+        return toBuildingDetailResult(
+                building,
+                campusMapQueryPort.findCampusPlacesByBuildingId(buildingId),
+                currentOperatingContext()
+        );
     }
 
     private CategoryResult toCategoryResult(CampusPlaceCategoryReadModel category) {

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -1,12 +1,14 @@
 package com.kustacks.kuring.building.application.service;
 
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 import com.kustacks.kuring.building.application.port.in.dto.OperatingHoursResult;
 import com.kustacks.kuring.building.application.port.out.AcademicPeriodQueryPort;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
+import com.kustacks.kuring.building.application.port.out.dto.BuildingDetailReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceReadModel;
@@ -24,6 +26,7 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import static com.kustacks.kuring.common.utils.TimeUtils.isWeekend;
 
@@ -70,6 +73,16 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
                 .toList();
     }
 
+    @Override
+    public Optional<BuildingDetailResult> getBuildingDetail(Long buildingId) {
+        return campusMapQueryPort.findBuildingById(buildingId)
+                .map(building -> toBuildingDetailResult(
+                        building,
+                        campusMapQueryPort.findCampusPlacesByBuildingId(buildingId),
+                        currentOperatingContext()
+                ));
+    }
+
     private CategoryResult toCategoryResult(CampusPlaceCategoryReadModel category) {
         return new CategoryResult(
                 category.code(),
@@ -105,6 +118,25 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
                 resolveOperatingHours(place.operatingHours(), context),
                 place.externalUrl(),
                 toBuildingSummaryResult(place.building())
+        );
+    }
+
+    private BuildingDetailResult toBuildingDetailResult(
+            BuildingDetailReadModel building,
+            List<CampusPlaceReadModel> campusPlaces,
+            OperatingContext context
+    ) {
+        return new BuildingDetailResult(
+                building.id(),
+                building.name(),
+                building.address(),
+                building.latitude(),
+                building.longitude(),
+                resolveImageUrl(building.imagePath()),
+                resolveOperatingHours(building.operatingHours(), context),
+                campusPlaces.stream()
+                        .map(place -> toCampusPlaceResult(place, context))
+                        .toList()
         );
     }
 

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -76,6 +76,8 @@ public enum ResponseCodeAndMessages {
     CAMPUS_MAP_BUILDING_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "캠퍼스 건물 목록 조회에 성공하였습니다"),
     CAMPUS_MAP_BUILDING_SEARCH_SUCCESS(HttpStatus.OK.value(), "캠퍼스 건물 검색에 성공하였습니다"),
     CAMPUS_MAP_PLACE_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "카테고리 기반 시설 목록 조회에 성공하였습니다"),
+    CAMPUS_MAP_BUILDING_DETAIL_SEARCH_SUCCESS(HttpStatus.OK.value(), "캠퍼스 건물 상세 조회에 성공하였습니다"),
+    CAMPUS_MAP_BUILDING_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "캠퍼스 건물을 찾을 수 없습니다"),
 
     /**
      * ErrorCodes about auth

--- a/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/ResponseCodeAndMessages.java
@@ -77,7 +77,6 @@ public enum ResponseCodeAndMessages {
     CAMPUS_MAP_BUILDING_SEARCH_SUCCESS(HttpStatus.OK.value(), "캠퍼스 건물 검색에 성공하였습니다"),
     CAMPUS_MAP_PLACE_LIST_SEARCH_SUCCESS(HttpStatus.OK.value(), "카테고리 기반 시설 목록 조회에 성공하였습니다"),
     CAMPUS_MAP_BUILDING_DETAIL_SEARCH_SUCCESS(HttpStatus.OK.value(), "캠퍼스 건물 상세 조회에 성공하였습니다"),
-    CAMPUS_MAP_BUILDING_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "캠퍼스 건물을 찾을 수 없습니다"),
 
     /**
      * ErrorCodes about auth

--- a/src/main/resources/config/environments/dev.yml
+++ b/src/main/resources/config/environments/dev.yml
@@ -27,3 +27,6 @@ decorator:
   datasource:
     p6spy:
       enable-logging: true
+
+campus-map:
+  source: database

--- a/src/test/java/com/kustacks/kuring/acceptance/CampusMapQueryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CampusMapQueryAcceptanceTest.java
@@ -17,9 +17,9 @@ import java.util.List;
 
 import static com.kustacks.kuring.acceptance.CampusMapStep.assertBuildingListResponse;
 import static com.kustacks.kuring.acceptance.CampusMapStep.assertBuildingDetailResponse;
+import static com.kustacks.kuring.acceptance.CampusMapStep.assertBuildingNotFoundErrorResponse;
 import static com.kustacks.kuring.acceptance.CampusMapStep.assertCampusPlaceListResponse;
 import static com.kustacks.kuring.acceptance.CampusMapStep.assertCategoryListResponse;
-import static com.kustacks.kuring.acceptance.CampusMapStep.assertNotFoundResponse;
 import static com.kustacks.kuring.acceptance.CampusMapStep.requestBuildingSearch;
 import static com.kustacks.kuring.acceptance.CampusMapStep.requestBuildingDetail;
 import static com.kustacks.kuring.acceptance.CampusMapStep.requestBuildings;
@@ -156,7 +156,7 @@ class CampusMapQueryAcceptanceTest extends IntegrationTestSupport {
         var response = requestBuildingDetail(Long.MAX_VALUE);
 
         // then
-        assertNotFoundResponse(response);
+        assertBuildingNotFoundErrorResponse(response);
     }
 
     private Building building(String name, Double latitude, Double longitude) {

--- a/src/test/java/com/kustacks/kuring/acceptance/CampusMapQueryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CampusMapQueryAcceptanceTest.java
@@ -16,9 +16,12 @@ import org.springframework.test.context.TestPropertySource;
 import java.util.List;
 
 import static com.kustacks.kuring.acceptance.CampusMapStep.assertBuildingListResponse;
+import static com.kustacks.kuring.acceptance.CampusMapStep.assertBuildingDetailResponse;
 import static com.kustacks.kuring.acceptance.CampusMapStep.assertCampusPlaceListResponse;
 import static com.kustacks.kuring.acceptance.CampusMapStep.assertCategoryListResponse;
+import static com.kustacks.kuring.acceptance.CampusMapStep.assertNotFoundResponse;
 import static com.kustacks.kuring.acceptance.CampusMapStep.requestBuildingSearch;
+import static com.kustacks.kuring.acceptance.CampusMapStep.requestBuildingDetail;
 import static com.kustacks.kuring.acceptance.CampusMapStep.requestBuildings;
 import static com.kustacks.kuring.acceptance.CampusMapStep.requestCampusPlaces;
 import static com.kustacks.kuring.acceptance.CampusMapStep.requestCategories;
@@ -116,6 +119,44 @@ class CampusMapQueryAcceptanceTest extends IntegrationTestSupport {
                 "test_printer",
                 "학생회관"
         );
+    }
+
+    @Test
+    @DisplayName("건물 상세 정보와 등록된 시설을 조회한다")
+    void getBuildingDetail_success() {
+        // given
+        Building building = buildingRepository.saveAndFlush(building("학생회관", 37.5412, 127.0784));
+        CampusPlaceCategory category = categoryRepository.saveAndFlush(
+                new CampusPlaceCategory("test_main_facility", "주요시설", 100, false)
+        );
+        campusPlaceRepository.saveAndFlush(new CampusPlace(
+                building,
+                category,
+                "총학생회",
+                null,
+                CampusPlaceLocationType.INDOOR,
+                "2F",
+                null,
+                null,
+                null,
+                1
+        ));
+
+        // when
+        var response = requestBuildingDetail(building.getId());
+
+        // then
+        assertBuildingDetailResponse(response, "학생회관", "총학생회");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 건물 상세 조회 시 404 응답을 반환한다")
+    void getBuildingDetail_notFound() {
+        // when
+        var response = requestBuildingDetail(Long.MAX_VALUE);
+
+        // then
+        assertNotFoundResponse(response);
     }
 
     private Building building(String name, Double latitude, Double longitude) {

--- a/src/test/java/com/kustacks/kuring/acceptance/CampusMapStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CampusMapStep.java
@@ -80,6 +80,17 @@ public final class CampusMapStep {
         );
     }
 
+    public static void assertBuildingNotFoundErrorResponse(ExtractableResponse<Response> response) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value()),
+                () -> assertThat(response.jsonPath().getBoolean("isSuccess")).isFalse(),
+                () -> assertThat(response.jsonPath().getInt("resultCode"))
+                        .isEqualTo(HttpStatus.NOT_FOUND.value()),
+                () -> assertThat(response.jsonPath().getString("resultMsg"))
+                        .isEqualTo("해당 건물을 찾을 수 없습니다.")
+        );
+    }
+
     public static void assertCategoryListResponse(
             ExtractableResponse<Response> response,
             String... categoryNames

--- a/src/test/java/com/kustacks/kuring/acceptance/CampusMapStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CampusMapStep.java
@@ -119,6 +119,21 @@ public final class CampusMapStep {
         );
     }
 
+    public static void assertBuildingDetailResponse(
+            ExtractableResponse<Response> response,
+            String buildingName,
+            String campusPlaceName
+    ) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getString("data.name")).isEqualTo(buildingName),
+                () -> assertThat(response.jsonPath().getList("data.operatingHours")).isNotNull(),
+                () -> assertThat(response.jsonPath().getList("data.campusPlaces.name", String.class))
+                        .containsExactly(campusPlaceName)
+        );
+    }
+
     public static void assertBadRequest(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }

--- a/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
@@ -24,7 +24,6 @@ import org.springframework.http.HttpStatus;
 
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -219,7 +218,7 @@ class CampusMapQueryApiV2Test {
     @DisplayName("캠퍼스맵 건물 상세 정보를 조회한다")
     void get_building_detail() {
         // given
-        when(campusMapQueryUseCase.getBuildingDetail(4L)).thenReturn(Optional.of(
+        when(campusMapQueryUseCase.getBuildingDetail(4L)).thenReturn(
                 new BuildingDetailResult(
                         4L,
                         "학생회관",
@@ -230,7 +229,7 @@ class CampusMapQueryApiV2Test {
                         List.of(),
                         List.of()
                 )
-        ));
+        );
 
         // when
         var response = campusMapQueryApiV2.getBuildingDetail(4L);
@@ -248,25 +247,4 @@ class CampusMapQueryApiV2Test {
         );
     }
 
-    @Test
-    @DisplayName("존재하지 않는 건물 상세 조회 시 404 응답을 반환한다")
-    void get_building_detail_not_found() {
-        // given
-        when(campusMapQueryUseCase.getBuildingDetail(999L)).thenReturn(Optional.empty());
-
-        // when
-        var response = campusMapQueryApiV2.getBuildingDetail(999L);
-
-        // then
-        var body = response.getBody();
-        assertThat(body).isNotNull();
-
-        assertAll(
-                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND),
-                () -> assertThat(body)
-                        .extracting(BaseResponse::getCode, BaseResponse::getMessage)
-                        .containsExactly(404, "캠퍼스 건물을 찾을 수 없습니다"),
-                () -> assertThat(body.getData()).isNull()
-        );
-    }
 }

--- a/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
@@ -4,6 +4,7 @@ import com.kustacks.kuring.building.adapter.in.web.dto.model.BuildingSummary;
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CampusPlaceItem;
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CategoryDto;
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
@@ -23,6 +24,7 @@ import org.springframework.http.HttpStatus;
 
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -210,6 +212,61 @@ class CampusMapQueryApiV2Test {
                                 () -> assertThat(campusPlace.operatingHours().get(0).opensAt()).isEqualTo("08:00"),
                                 () -> assertThat(campusPlace.building().name()).isEqualTo("학생회관")
                         ))
+        );
+    }
+
+    @Test
+    @DisplayName("캠퍼스맵 건물 상세 정보를 조회한다")
+    void get_building_detail() {
+        // given
+        when(campusMapQueryUseCase.getBuildingDetail(4L)).thenReturn(Optional.of(
+                new BuildingDetailResult(
+                        4L,
+                        "학생회관",
+                        "서울특별시 광진구 능동로 120",
+                        37.5412,
+                        127.0784,
+                        "https://storage.example.com/student-center.png",
+                        List.of(),
+                        List.of()
+                )
+        ));
+
+        // when
+        var response = campusMapQueryApiV2.getBuildingDetail(4L);
+
+        // then
+        var body = response.getBody();
+        assertThat(body).isNotNull();
+
+        assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(body)
+                        .extracting(BaseResponse::getCode, BaseResponse::getMessage)
+                        .containsExactly(200, "캠퍼스 건물 상세 조회에 성공하였습니다"),
+                () -> assertThat(body.getData().name()).isEqualTo("학생회관")
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 건물 상세 조회 시 404 응답을 반환한다")
+    void get_building_detail_not_found() {
+        // given
+        when(campusMapQueryUseCase.getBuildingDetail(999L)).thenReturn(Optional.empty());
+
+        // when
+        var response = campusMapQueryApiV2.getBuildingDetail(999L);
+
+        // then
+        var body = response.getBody();
+        assertThat(body).isNotNull();
+
+        assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND),
+                () -> assertThat(body)
+                        .extracting(BaseResponse::getCode, BaseResponse::getMessage)
+                        .containsExactly(404, "캠퍼스 건물을 찾을 수 없습니다"),
+                () -> assertThat(body.getData()).isNull()
         );
     }
 }

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
@@ -177,6 +177,65 @@ class CampusMapPersistenceAdapterTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    @DisplayName("건물 상세 정보를 조회한다")
+    void find_building_by_id() {
+        // given
+        Building studentCenter = building(4L, "학생회관", 37.5412, 127.0784);
+        studentCenter.addOperatingHours(new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.SCHEDULED,
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0)
+        ));
+        when(buildingRepository.findById(4L)).thenReturn(java.util.Optional.of(studentCenter));
+
+        // when
+        var result = campusMapPersistenceAdapter.findBuildingById(4L);
+
+        // then
+        assertThat(result)
+                .hasValueSatisfying(building -> assertAll(
+                        () -> assertThat(building.name()).isEqualTo("학생회관"),
+                        () -> assertThat(building.operatingHours()).hasSize(1)
+                ));
+        verify(buildingRepository).findById(4L);
+    }
+
+    @Test
+    @DisplayName("건물에 등록된 캠퍼스 시설을 조회한다")
+    void find_campus_places_by_building_id() {
+        // given
+        Building studentCenter = building(4L, "학생회관", 37.5412, 127.0784);
+        CampusPlaceCategory category = new CampusPlaceCategory("printer", "프린터", 1, true);
+        CampusPlace printer = new CampusPlace(
+                studentCenter,
+                category,
+                "학생회관 프린터",
+                null,
+                CampusPlaceLocationType.INDOOR,
+                "1F",
+                null,
+                3,
+                null,
+                1
+        );
+        when(campusPlaceRepository.findByBuildingId(4L)).thenReturn(List.of(printer));
+
+        // when
+        List<CampusPlaceReadModel> result = campusMapPersistenceAdapter.findCampusPlacesByBuildingId(4L);
+
+        // then
+        assertThat(result)
+                .singleElement()
+                .satisfies(place -> assertAll(
+                        () -> assertThat(place.name()).isEqualTo("학생회관 프린터"),
+                        () -> assertThat(place.building().id()).isEqualTo(4L)
+                ));
+        verify(campusPlaceRepository).findByBuildingId(4L);
+    }
+
     private Building building(Long id, String name, Double latitude, Double longitude) {
         Building building = new Building(
                 name,

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepositoryTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusPlaceQueryRepositoryTest.java
@@ -79,6 +79,47 @@ class CampusPlaceQueryRepositoryTest extends IntegrationTestSupport {
         );
     }
 
+    @Test
+    @DisplayName("건물에 등록된 모든 캠퍼스 시설을 노출 순서대로 조회한다")
+    void find_campus_places_by_building_id() {
+        // given
+        Building building = buildingRepository.saveAndFlush(new Building(
+                "학생회관",
+                "서울특별시 광진구 능동로 120",
+                37.5412,
+                127.0784,
+                null
+        ));
+        CampusPlaceCategory mainFacility = categoryRepository.save(
+                new CampusPlaceCategory("test_main_facility", "주요시설", 100, false)
+        );
+        CampusPlaceCategory printer = categoryRepository.save(
+                new CampusPlaceCategory("test_printer", "프린터", 1, true)
+        );
+        CampusPlace studentCouncil = campusPlace(building, mainFacility, "총학생회", 2);
+        CampusPlace printerPlace = campusPlace(building, printer, "학생회관 프린터", 1);
+        printerPlace.addOperatingHours(new OperatingHours(
+                OperatingPeriod.SEMESTER,
+                OperatingDayGroup.WEEKDAY,
+                OperatingHoursStatus.SCHEDULED,
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0)
+        ));
+        campusPlaceRepository.saveAllAndFlush(List.of(studentCouncil, printerPlace));
+
+        // when
+        List<CampusPlace> result = campusPlaceRepository.findByBuildingId(building.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(result)
+                        .extracting(CampusPlace::getName)
+                        .containsExactly("학생회관 프린터", "총학생회"),
+                () -> assertThat(result.get(0).getOperatingHours()).hasSize(1),
+                () -> assertThat(result.get(1).getCategory().isFilterEnabled()).isFalse()
+        );
+    }
+
     private CampusPlace campusPlace(
             Building building,
             CampusPlaceCategory category,

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -15,6 +15,8 @@ import com.kustacks.kuring.building.domain.CampusPlaceLocationType;
 import com.kustacks.kuring.building.domain.OperatingDayGroup;
 import com.kustacks.kuring.building.domain.OperatingHoursStatus;
 import com.kustacks.kuring.building.domain.OperatingPeriod;
+import com.kustacks.kuring.common.exception.NotFoundException;
+import com.kustacks.kuring.common.exception.code.ErrorCode;
 import com.kustacks.kuring.storage.application.port.out.StoragePort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -261,32 +264,31 @@ class CampusMapQueryServiceTest {
                 .thenReturn("https://storage.example.com/printer.png");
 
         // when
-        Optional<BuildingDetailResult> result = campusMapQueryService.getBuildingDetail(4L);
+        BuildingDetailResult result = campusMapQueryService.getBuildingDetail(4L);
 
         // then
-        assertThat(result)
-                .hasValueSatisfying(detail -> assertAll(
-                        () -> assertThat(detail.name()).isEqualTo("학생회관"),
-                        () -> assertThat(detail.imageUrl())
-                                .isEqualTo("https://storage.example.com/student-center.png"),
-                        () -> assertThat(detail.campusPlaces())
-                                .singleElement()
-                                .satisfies(place -> assertThat(place.name()).isEqualTo("학생회관 프린터"))
-                ));
+        assertAll(
+                () -> assertThat(result.name()).isEqualTo("학생회관"),
+                () -> assertThat(result.imageUrl())
+                        .isEqualTo("https://storage.example.com/student-center.png"),
+                () -> assertThat(result.campusPlaces())
+                        .singleElement()
+                        .satisfies(place -> assertThat(place.name()).isEqualTo("학생회관 프린터"))
+        );
         verify(campusMapQueryPort).findCampusPlacesByBuildingId(4L);
     }
 
     @Test
-    @DisplayName("존재하지 않는 건물 상세 조회 시 빈 결과를 반환한다")
+    @DisplayName("존재하지 않는 건물 상세 조회 시 예외를 발생시킨다")
     void get_building_detail_not_found() {
         // given
         when(campusMapQueryPort.findBuildingById(999L)).thenReturn(Optional.empty());
 
-        // when
-        Optional<BuildingDetailResult> result = campusMapQueryService.getBuildingDetail(999L);
-
-        // then
-        assertThat(result).isEmpty();
+        // when, then
+        assertThatThrownBy(() -> campusMapQueryService.getBuildingDetail(999L))
+                .isInstanceOf(NotFoundException.class)
+                .extracting(exception -> ((NotFoundException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.BUILDING_NOT_FOUND);
         verify(campusMapQueryPort).findBuildingById(999L);
     }
 

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -1,10 +1,12 @@
 package com.kustacks.kuring.building.application.service;
 
+import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
 import com.kustacks.kuring.building.application.port.out.AcademicPeriodQueryPort;
 import com.kustacks.kuring.building.application.port.out.CampusMapQueryPort;
+import com.kustacks.kuring.building.application.port.out.dto.BuildingDetailReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.BuildingSummaryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceCategoryReadModel;
 import com.kustacks.kuring.building.application.port.out.dto.CampusPlaceReadModel;
@@ -26,6 +28,7 @@ import java.time.Instant;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -231,6 +234,60 @@ class CampusMapQueryServiceTest {
                         () -> assertThat(result.operatingHours().get(1).isCurrent()).isTrue()
                 ));
         verify(campusMapQueryPort).findCampusPlacesByCategories(List.of("printer"));
+    }
+
+    @Test
+    @DisplayName("건물 상세 정보와 등록된 시설을 조회한다")
+    void get_building_detail() {
+        // given
+        BuildingDetailReadModel building = new BuildingDetailReadModel(
+                4L,
+                "학생회관",
+                "서울특별시 광진구 능동로 120",
+                37.5412,
+                127.0784,
+                "campus-map/student-center.png",
+                List.of()
+        );
+        when(campusMapQueryPort.findBuildingById(4L)).thenReturn(Optional.of(building));
+        when(campusMapQueryPort.findCampusPlacesByBuildingId(4L))
+                .thenReturn(List.of(campusPlaceReadModel()));
+        when(academicPeriodQueryPort.determineOperatingPeriod(
+                MONDAY_CLOCK.instant().atZone(MONDAY_CLOCK.getZone()).toLocalDate()
+        )).thenReturn(OperatingPeriod.VACATION);
+        when(storagePort.getPresignedUrl("campus-map/student-center.png"))
+                .thenReturn("https://storage.example.com/student-center.png");
+        when(storagePort.getPresignedUrl("campus-map/printer.png"))
+                .thenReturn("https://storage.example.com/printer.png");
+
+        // when
+        Optional<BuildingDetailResult> result = campusMapQueryService.getBuildingDetail(4L);
+
+        // then
+        assertThat(result)
+                .hasValueSatisfying(detail -> assertAll(
+                        () -> assertThat(detail.name()).isEqualTo("학생회관"),
+                        () -> assertThat(detail.imageUrl())
+                                .isEqualTo("https://storage.example.com/student-center.png"),
+                        () -> assertThat(detail.campusPlaces())
+                                .singleElement()
+                                .satisfies(place -> assertThat(place.name()).isEqualTo("학생회관 프린터"))
+                ));
+        verify(campusMapQueryPort).findCampusPlacesByBuildingId(4L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 건물 상세 조회 시 빈 결과를 반환한다")
+    void get_building_detail_not_found() {
+        // given
+        when(campusMapQueryPort.findBuildingById(999L)).thenReturn(Optional.empty());
+
+        // when
+        Optional<BuildingDetailResult> result = campusMapQueryService.getBuildingDetail(999L);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(campusMapQueryPort).findBuildingById(999L);
     }
 
     private void givenCurrentOperatingPeriod() {


### PR DESCRIPTION
## #️⃣ 이슈
#392

## 📌 요약
- 캠퍼스맵 건물 상세 조회 API를 실제 데이터 조회 로직과 연동했습니다.

## 🛠️ 상세
- `GET /api/v2/maps/buildings/{buildingId}` 실제 조회 API를 구현했습니다.
- 건물 ID를 기준으로 건물 정보와 등록된 시설을 조회하도록 구현했습니다.
- 시설 조회 시 QueryDSL fetch join을 사용해 건물, 카테고리, 운영시간을 함께 조회하도록 구성했습니다.
- 건물과 시설의 기간·요일별 전체 운영시간을 반환하고 현재 적용되는 항목을 `isCurrent`로 표시하도록 구현했습니다.
- 저장된 이미지 경로를 클라이언트에서 사용할 수 있는 URL로 변환하도록 구현했습니다.
- 존재하지 않는 건물은 공통 응답 구조를 사용해 404 응답을 반환하도록 구현했습니다.
- 개발 환경에서 실제 DB 조회 API를 사용하도록 데이터 소스를 설정했습니다.
- 컨트롤러, 서비스, 영속성 계층 및 인수 테스트를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 캠퍼스맵에서 건물 ID로 상세 정보를 조회할 수 있습니다.
  * 건물명, 주소, 위치, 이미지, 운영시간과 소속 시설 정보를 제공합니다.
  * 시설 정보는 표시 순서에 따라 정렬됩니다.
  * 존재하지 않는 건물 조회 시 404 오류를 반환합니다.

* **테스트**
  * 건물 상세 조회 성공 및 미존재 시나리오를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->