### PR TITLE
Feat: 캠퍼스맵 건물 노출 우선순위 조회 구현

### DIFF
--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/BuildingListResponse.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/BuildingListResponse.java
@@ -1,17 +1,17 @@
 package com.kustacks.kuring.building.adapter.in.web.dto;
 
-import com.kustacks.kuring.building.adapter.in.web.dto.model.BuildingSummary;
-import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
+import com.kustacks.kuring.building.adapter.in.web.dto.model.BuildingOverview;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingOverviewResult;
 
 import java.util.List;
 
 public record BuildingListResponse(
-        List<BuildingSummary> buildings
+        List<BuildingOverview> buildings
 ) {
 
-    public static BuildingListResponse from(List<BuildingSummaryResult> results) {
+    public static BuildingListResponse from(List<BuildingOverviewResult> results) {
         return new BuildingListResponse(results.stream()
-                .map(BuildingSummary::from)
+                .map(BuildingOverview::from)
                 .toList());
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/BuildingOverview.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/BuildingOverview.java
@@ -1,0 +1,24 @@
+package com.kustacks.kuring.building.adapter.in.web.dto.model;
+
+import com.kustacks.kuring.building.application.port.in.dto.BuildingOverviewResult;
+
+public record BuildingOverview(
+        Long id,
+        String name,
+        String address,
+        Double latitude,
+        Double longitude,
+        Integer displayOrder
+) {
+
+    public static BuildingOverview from(BuildingOverviewResult result) {
+        return new BuildingOverview(
+                result.id(),
+                result.name(),
+                result.address(),
+                result.latitude(),
+                result.longitude(),
+                result.displayOrder()
+        );
+    }
+}

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepository.java
@@ -6,5 +6,7 @@ import java.util.List;
 
 public interface BuildingQueryRepository {
 
+    List<Building> findAllSortedByDisplayOrder();
+
     List<Building> searchByKeyword(String keyword);
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryImpl.java
@@ -22,7 +22,7 @@ class BuildingQueryRepositoryImpl implements BuildingQueryRepository {
                                 .or(building.address.containsIgnoreCase(keyword))
                                 .or(building.keywords.any().keyword.containsIgnoreCase(keyword))
                 )
-                .orderBy(building.id.asc())
+                .orderBy(building.displayOrder.asc(), building.id.asc())
                 .fetch();
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.building.adapter.out.persistence;
 
 import com.kustacks.kuring.building.domain.Building;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +15,22 @@ class BuildingQueryRepositoryImpl implements BuildingQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
+    public List<Building> findAllSortedByDisplayOrder() {
+        return queryFactory
+                .selectFrom(building)
+                .orderBy(
+                        new CaseBuilder()
+                                .when(building.displayOrder.isNull())
+                                .then(1)
+                                .otherwise(0)
+                                .asc(),
+                        building.displayOrder.asc(),
+                        building.id.asc()
+                )
+                .fetch();
+    }
+
+    @Override
     public List<Building> searchByKeyword(String keyword) {
         return queryFactory
                 .selectFrom(building)
@@ -22,7 +39,15 @@ class BuildingQueryRepositoryImpl implements BuildingQueryRepository {
                                 .or(building.address.containsIgnoreCase(keyword))
                                 .or(building.keywords.any().keyword.containsIgnoreCase(keyword))
                 )
-                .orderBy(building.displayOrder.asc(), building.id.asc())
+                .orderBy(
+                        new CaseBuilder()
+                                .when(building.displayOrder.isNull())
+                                .then(1)
+                                .otherwise(0)
+                                .asc(),
+                        building.displayOrder.asc(),
+                        building.id.asc()
+                )
                 .fetch();
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface BuildingRepository extends JpaRepository<Building, Long>, BuildingQueryRepository {
 
-    List<Building> findAllByOrderByIdAsc();
+    List<Building> findAllByOrderByDisplayOrderAscIdAsc();
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingRepository.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingRepository.java
@@ -3,9 +3,5 @@ package com.kustacks.kuring.building.adapter.out.persistence;
 import com.kustacks.kuring.building.domain.Building;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface BuildingRepository extends JpaRepository<Building, Long>, BuildingQueryRepository {
-
-    List<Building> findAllByOrderByDisplayOrderAscIdAsc();
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
@@ -36,7 +36,7 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
 
     @Override
     public List<BuildingSummaryReadModel> findBuildings() {
-        return buildingRepository.findAllByOrderByDisplayOrderAscIdAsc().stream()
+        return buildingRepository.findAllSortedByDisplayOrder().stream()
                 .map(this::toBuildingSummaryReadModel)
                 .toList();
     }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
@@ -36,7 +36,7 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
 
     @Override
     public List<BuildingSummaryReadModel> findBuildings() {
-        return buildingRepository.findAllByOrderByIdAsc().stream()
+        return buildingRepository.findAllByOrderByDisplayOrderAscIdAsc().stream()
                 .map(this::toBuildingSummaryReadModel)
                 .toList();
     }
@@ -121,7 +121,8 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
                 building.getName(),
                 building.getAddress(),
                 building.getLat(),
-                building.getLon()
+                building.getLon(),
+                building.getDisplayOrder()
         );
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/CampusMapQueryUseCase.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.building.application.port.in;
 
 import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingOverviewResult;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
@@ -11,7 +12,7 @@ public interface CampusMapQueryUseCase {
 
     List<CategoryResult> getCategories();
 
-    List<BuildingSummaryResult> getBuildings();
+    List<BuildingOverviewResult> getBuildings();
 
     List<BuildingSummaryResult> searchBuildings(String keyword);
 

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/dto/BuildingOverviewResult.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/dto/BuildingOverviewResult.java
@@ -1,6 +1,6 @@
-package com.kustacks.kuring.building.application.port.out.dto;
+package com.kustacks.kuring.building.application.port.in.dto;
 
-public record BuildingSummaryReadModel(
+public record BuildingOverviewResult(
         Long id,
         String name,
         String address,

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -2,6 +2,7 @@ package com.kustacks.kuring.building.application.service;
 
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingOverviewResult;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
@@ -49,9 +50,9 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
     }
 
     @Override
-    public List<BuildingSummaryResult> getBuildings() {
+    public List<BuildingOverviewResult> getBuildings() {
         return campusMapQueryPort.findBuildings().stream()
-                .map(this::toBuildingSummaryResult)
+                .map(this::toBuildingOverviewResult)
                 .toList();
     }
 
@@ -101,6 +102,17 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
                 building.address(),
                 building.latitude(),
                 building.longitude()
+        );
+    }
+
+    private BuildingOverviewResult toBuildingOverviewResult(BuildingSummaryReadModel building) {
+        return new BuildingOverviewResult(
+                building.id(),
+                building.name(),
+                building.address(),
+                building.latitude(),
+                building.longitude(),
+                building.displayOrder()
         );
     }
 

--- a/src/main/java/com/kustacks/kuring/building/domain/Building.java
+++ b/src/main/java/com/kustacks/kuring/building/domain/Building.java
@@ -48,6 +48,9 @@ public class Building {
     @Column(name = "image_path")
     private String imagePath;
 
+    @Column(name = "display_order")
+    private Integer displayOrder;
+
     @OneToMany(
             mappedBy = "building",
             cascade = CascadeType.ALL,

--- a/src/main/resources/db/migration/V260808__Add_building_display_order.sql
+++ b/src/main/resources/db/migration/V260808__Add_building_display_order.sql
@@ -1,0 +1,2 @@
+ALTER TABLE building
+    ADD COLUMN display_order INT NULL AFTER image_path;

--- a/src/test/java/com/kustacks/kuring/acceptance/CampusMapQueryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CampusMapQueryAcceptanceTest.java
@@ -11,6 +11,7 @@ import com.kustacks.kuring.support.IntegrationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
@@ -59,15 +60,19 @@ class CampusMapQueryAcceptanceTest extends IntegrationTestSupport {
     void getBuildings_success() {
         // given
         buildingRepository.saveAllAndFlush(List.of(
-                building("행정관", 37.54241, 127.07382),
-                building("경영관", 37.54196, 127.07531)
+                building("행정관", 37.54241, 127.07382, 2),
+                building("경영관", 37.54196, 127.07531, 1)
         ));
 
         // when
         var response = requestBuildings();
 
         // then
-        assertBuildingListResponse(response, "행정관", "경영관");
+        assertBuildingListResponse(
+                response,
+                List.of("경영관", "행정관"),
+                List.of(1, 2)
+        );
     }
 
     @Test
@@ -165,5 +170,11 @@ class CampusMapQueryAcceptanceTest extends IntegrationTestSupport {
                 longitude,
                 null
         );
+    }
+
+    private Building building(String name, Double latitude, Double longitude, Integer displayOrder) {
+        Building building = building(name, latitude, longitude);
+        ReflectionTestUtils.setField(building, "displayOrder", displayOrder);
+        return building;
     }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/CampusMapStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CampusMapStep.java
@@ -111,6 +111,21 @@ public final class CampusMapStep {
                 .containsExactly(buildingNames);
     }
 
+    public static void assertBuildingListResponse(
+            ExtractableResponse<Response> response,
+            List<String> buildingNames,
+            List<Integer> displayOrders
+    ) {
+        assertSuccessfulListResponse(response, "data.buildings");
+
+        assertAll(
+                () -> assertThat(response.jsonPath().getList("data.buildings.name", String.class))
+                        .isEqualTo(buildingNames),
+                () -> assertThat(response.jsonPath().getList("data.buildings.displayOrder", Integer.class))
+                        .isEqualTo(displayOrders)
+        );
+    }
+
     public static void assertCampusPlaceListResponse(
             ExtractableResponse<Response> response,
             String placeName,

--- a/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
@@ -1,10 +1,11 @@
 package com.kustacks.kuring.building.adapter.in.web;
 
+import com.kustacks.kuring.building.adapter.in.web.dto.model.BuildingOverview;
 import com.kustacks.kuring.building.adapter.in.web.dto.model.BuildingSummary;
-import com.kustacks.kuring.building.adapter.in.web.dto.model.CampusPlaceItem;
 import com.kustacks.kuring.building.adapter.in.web.dto.model.CategoryDto;
 import com.kustacks.kuring.building.application.port.in.CampusMapQueryUseCase;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingOverviewResult;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
@@ -79,19 +80,21 @@ class CampusMapQueryApiV2Test {
     void get_buildings() {
         // given
         when(campusMapQueryUseCase.getBuildings()).thenReturn(List.of(
-                new BuildingSummaryResult(
+                new BuildingOverviewResult(
                         1L,
                         "행정관",
                         "서울특별시 광진구 능동로 120",
                         37.54241,
-                        127.07382
+                        127.07382,
+                        1
                 ),
-                new BuildingSummaryResult(
+                new BuildingOverviewResult(
                         2L,
                         "경영관",
                         "서울특별시 광진구 능동로 120",
                         37.54196,
-                        127.07531
+                        127.07531,
+                        2
                 )
         ));
 
@@ -101,22 +104,21 @@ class CampusMapQueryApiV2Test {
         // then
         var body = response.getBody();
         assertThat(body).isNotNull();
+        List<BuildingOverview> buildings = body.getData().buildings();
 
         assertAll(
                 () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
-                () -> assertThat(body)
-                        .extracting(BaseResponse::getCode, BaseResponse::getMessage)
-                        .containsExactly(200, "캠퍼스 건물 목록 조회에 성공하였습니다"),
-                () -> assertThat(body.getData().buildings())
-                        .extracting(
-                                BuildingSummary::id,
-                                BuildingSummary::name,
-                                BuildingSummary::address
-                        )
-                        .containsExactly(
-                                tuple(1L, "행정관", "서울특별시 광진구 능동로 120"),
-                                tuple(2L, "경영관", "서울특별시 광진구 능동로 120")
-                        )
+                () -> assertThat(body.getCode()).isEqualTo(200),
+                () -> assertThat(body.getMessage()).isEqualTo("캠퍼스 건물 목록 조회에 성공하였습니다"),
+                () -> assertThat(buildings).hasSize(2),
+                () -> assertThat(buildings.get(0).id()).isEqualTo(1L),
+                () -> assertThat(buildings.get(0).name()).isEqualTo("행정관"),
+                () -> assertThat(buildings.get(0).address()).isEqualTo("서울특별시 광진구 능동로 120"),
+                () -> assertThat(buildings.get(0).displayOrder()).isEqualTo(1),
+                () -> assertThat(buildings.get(1).id()).isEqualTo(2L),
+                () -> assertThat(buildings.get(1).name()).isEqualTo("경영관"),
+                () -> assertThat(buildings.get(1).address()).isEqualTo("서울특별시 광진구 능동로 120"),
+                () -> assertThat(buildings.get(1).displayOrder()).isEqualTo(2)
         );
     }
 

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/BuildingQueryRepositoryTest.java
@@ -5,6 +5,7 @@ import com.kustacks.kuring.support.IntegrationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
@@ -71,6 +72,28 @@ class BuildingQueryRepositoryTest extends IntegrationTestSupport {
                 () -> assertThat(buildingRepository.searchByKeyword("\\"))
                         .extracting(Building::getName)
                         .containsExactly("A\\B관")
+        );
+    }
+
+    @Test
+    @DisplayName("노출 우선순위가 없는 건물을 우선순위가 있는 건물 뒤에 정렬한다")
+    void sort_null_display_order_last() {
+        // given
+        Building first = building("우선순위 1관");
+        Building second = building("우선순위 2관");
+        Building unordered = building("우선순위 미지정관");
+        ReflectionTestUtils.setField(first, "displayOrder", 1);
+        ReflectionTestUtils.setField(second, "displayOrder", 2);
+        buildingRepository.saveAllAndFlush(List.of(unordered, second, first));
+
+        // when & then
+        assertAll(
+                () -> assertThat(buildingRepository.findAllSortedByDisplayOrder())
+                        .extracting(Building::getName)
+                        .containsExactly("우선순위 1관", "우선순위 2관", "우선순위 미지정관"),
+                () -> assertThat(buildingRepository.searchByKeyword("우선순위"))
+                        .extracting(Building::getName)
+                        .containsExactly("우선순위 1관", "우선순위 2관", "우선순위 미지정관")
         );
     }
 

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
@@ -71,7 +71,7 @@ class CampusMapPersistenceAdapterTest {
         // given
         Building administration = building(1L, "행정관", 37.54241, 127.07382);
         Building business = building(2L, "경영관", 37.54196, 127.07531);
-        when(buildingRepository.findAllByOrderByDisplayOrderAscIdAsc())
+        when(buildingRepository.findAllSortedByDisplayOrder())
                 .thenReturn(List.of(administration, business));
 
         // when
@@ -84,7 +84,7 @@ class CampusMapPersistenceAdapterTest {
                 () -> assertThat(result.get(0).displayOrder()).isEqualTo(1),
                 () -> assertThat(result.get(1).name()).isEqualTo("경영관"),
                 () -> assertThat(result.get(1).displayOrder()).isEqualTo(2),
-                () -> verify(buildingRepository).findAllByOrderByDisplayOrderAscIdAsc()
+                () -> verify(buildingRepository).findAllSortedByDisplayOrder()
         );
     }
 

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
@@ -66,35 +66,26 @@ class CampusMapPersistenceAdapterTest {
     }
 
     @Test
-    @DisplayName("캠퍼스 건물을 ID 순서대로 조회한다")
+    @DisplayName("캠퍼스 건물을 노출 우선순위대로 조회한다")
     void find_buildings() {
         // given
         Building administration = building(1L, "행정관", 37.54241, 127.07382);
         Building business = building(2L, "경영관", 37.54196, 127.07531);
-        when(buildingRepository.findAllByOrderByIdAsc())
+        when(buildingRepository.findAllByOrderByDisplayOrderAscIdAsc())
                 .thenReturn(List.of(administration, business));
 
         // when
         List<BuildingSummaryReadModel> result = campusMapPersistenceAdapter.findBuildings();
 
         // then
-        assertThat(result).containsExactly(
-                new BuildingSummaryReadModel(
-                        1L,
-                        "행정관",
-                        "서울특별시 광진구 능동로 120",
-                        37.54241,
-                        127.07382
-                ),
-                new BuildingSummaryReadModel(
-                        2L,
-                        "경영관",
-                        "서울특별시 광진구 능동로 120",
-                        37.54196,
-                        127.07531
-                )
+        assertAll(
+                () -> assertThat(result).hasSize(2),
+                () -> assertThat(result.get(0).name()).isEqualTo("행정관"),
+                () -> assertThat(result.get(0).displayOrder()).isEqualTo(1),
+                () -> assertThat(result.get(1).name()).isEqualTo("경영관"),
+                () -> assertThat(result.get(1).displayOrder()).isEqualTo(2),
+                () -> verify(buildingRepository).findAllByOrderByDisplayOrderAscIdAsc()
         );
-        verify(buildingRepository).findAllByOrderByIdAsc();
     }
 
     @Test
@@ -115,7 +106,8 @@ class CampusMapPersistenceAdapterTest {
                         "학생회관",
                         "서울특별시 광진구 능동로 120",
                         37.5412,
-                        127.0784
+                        127.0784,
+                        4
                 )
         );
         verify(buildingRepository).searchByKeyword("학관");
@@ -245,6 +237,7 @@ class CampusMapPersistenceAdapterTest {
                 null
         );
         ReflectionTestUtils.setField(building, "id", id);
+        ReflectionTestUtils.setField(building, "displayOrder", id.intValue());
         return building;
     }
 }

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -1,6 +1,7 @@
 package com.kustacks.kuring.building.application.service;
 
 import com.kustacks.kuring.building.application.port.in.dto.BuildingDetailResult;
+import com.kustacks.kuring.building.application.port.in.dto.BuildingOverviewResult;
 import com.kustacks.kuring.building.application.port.in.dto.BuildingSummaryResult;
 import com.kustacks.kuring.building.application.port.in.dto.CampusPlaceResult;
 import com.kustacks.kuring.building.application.port.in.dto.CategoryResult;
@@ -98,38 +99,31 @@ class CampusMapQueryServiceTest {
                         "행정관",
                         "서울특별시 광진구 능동로 120",
                         37.54241,
-                        127.07382
+                        127.07382,
+                        1
                 ),
                 new BuildingSummaryReadModel(
                         2L,
                         "경영관",
                         "서울특별시 광진구 능동로 120",
                         37.54196,
-                        127.07531
+                        127.07531,
+                        2
                 )
         ));
 
         // when
-        List<BuildingSummaryResult> result = campusMapQueryService.getBuildings();
+        List<BuildingOverviewResult> result = campusMapQueryService.getBuildings();
 
         // then
-        assertThat(result).containsExactly(
-                new BuildingSummaryResult(
-                        1L,
-                        "행정관",
-                        "서울특별시 광진구 능동로 120",
-                        37.54241,
-                        127.07382
-                ),
-                new BuildingSummaryResult(
-                        2L,
-                        "경영관",
-                        "서울특별시 광진구 능동로 120",
-                        37.54196,
-                        127.07531
-                )
+        assertAll(
+                () -> assertThat(result).hasSize(2),
+                () -> assertThat(result.get(0).name()).isEqualTo("행정관"),
+                () -> assertThat(result.get(0).displayOrder()).isEqualTo(1),
+                () -> assertThat(result.get(1).name()).isEqualTo("경영관"),
+                () -> assertThat(result.get(1).displayOrder()).isEqualTo(2),
+                () -> verify(campusMapQueryPort).findBuildings()
         );
-        verify(campusMapQueryPort).findBuildings();
     }
 
     @Test
@@ -142,7 +136,8 @@ class CampusMapQueryServiceTest {
                         "학생회관",
                         "서울특별시 광진구 능동로 120",
                         37.5412,
-                        127.0784
+                        127.0784,
+                        4
                 )
         ));
 
@@ -331,7 +326,8 @@ class CampusMapQueryServiceTest {
                         "학생회관",
                         "서울특별시 광진구 능동로 120",
                         37.5412,
-                        127.0784
+                        127.0784,
+                        4
                 )
         );
     }


### PR DESCRIPTION
## #️⃣ 이슈
#392
## 📌 요약
- 캠퍼스맵 건물 목록에 건물 노출 우선순위를 추가했습니다.
## 🛠️ 상세
- `Building`에 건물 노출 우선순위를 저장하는 `displayOrder` 필드를 추가했습니다.
- `GET /api/v2/maps/buildings` 응답에 `displayOrder`를 추가했습니다.
- 건물 목록과 키워드 검색 결과를 노출 우선순위와 건물 ID 순서로 정렬하도록 변경했습니다.
- 전체 건물 목록 전용 응답 모델을 분리해 검색 및 시설 응답 구조와 구분했습니다.
- 컨트롤러, 서비스, 영속성 계층 및 인수 테스트를 추가했습니다.
## 💬 기타
- 건물 우선순위가 등록되지 않은 경우 `displayOrder`는 `null`로 반환됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캠퍼스 건물 목록에 표시 순서 정보가 포함됩니다.
  * 건물 목록이 표시 순서와 건물 ID 기준으로 정렬됩니다.
  * 건물 목록 응답에 건물 ID, 이름, 주소, 위치 정보가 제공됩니다.

* **버그 수정**
  * 전체 건물 조회와 키워드 검색 결과의 정렬 기준이 일관되게 적용됩니다.
  * 표시 순서가 없는 건물은 목록의 마지막에 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->