### PR TITLE
Feat: 캠퍼스맵 검색 건물 이미지 응답 추가

### DIFF
--- a/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/BuildingSummary.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/in/web/dto/model/BuildingSummary.java
@@ -7,7 +7,8 @@ public record BuildingSummary(
         String name,
         String address,
         Double latitude,
-        Double longitude
+        Double longitude,
+        String imageUrl
 ) {
 
     public static BuildingSummary from(BuildingSummaryResult result) {
@@ -16,7 +17,8 @@ public record BuildingSummary(
                 result.name(),
                 result.address(),
                 result.latitude(),
-                result.longitude()
+                result.longitude(),
+                result.imageUrl()
         );
     }
 }

--- a/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
+++ b/src/main/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapter.java
@@ -129,6 +129,7 @@ public class CampusMapPersistenceAdapter implements CampusMapQueryPort {
                 building.getAddress(),
                 building.getLat(),
                 building.getLon(),
+                building.getImagePath(),
                 building.getDisplayOrder()
         );
     }

--- a/src/main/java/com/kustacks/kuring/building/application/port/in/dto/BuildingSummaryResult.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/in/dto/BuildingSummaryResult.java
@@ -5,6 +5,7 @@ public record BuildingSummaryResult(
         String name,
         String address,
         Double latitude,
-        Double longitude
+        Double longitude,
+        String imageUrl
 ) {
 }

--- a/src/main/java/com/kustacks/kuring/building/application/port/out/dto/BuildingSummaryReadModel.java
+++ b/src/main/java/com/kustacks/kuring/building/application/port/out/dto/BuildingSummaryReadModel.java
@@ -6,6 +6,7 @@ public record BuildingSummaryReadModel(
         String address,
         Double latitude,
         Double longitude,
+        String imagePath,
         Integer displayOrder
 ) {
 }

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -27,8 +27,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static com.kustacks.kuring.common.exception.code.ErrorCode.BUILDING_NOT_FOUND;
 import static com.kustacks.kuring.common.utils.TimeUtils.isWeekend;
@@ -63,13 +65,21 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
         List<BuildingSummaryReadModel> buildings = campusMapQueryPort.searchBuildings(normalizedKeyword);
         List<CampusPlaceReadModel> campusPlaces = campusMapQueryPort.searchCampusPlaces(normalizedKeyword);
         OperatingContext context = currentOperatingContext();
+        Map<String, String> imageUrlsByPath = new HashMap<>();
 
         return new CampusMapSearchResult(
                 buildings.stream()
-                        .map(this::toBuildingSummaryResult)
+                        .map(building -> toBuildingSummaryResult(
+                                building,
+                                resolveImageUrl(building.imagePath(), imageUrlsByPath)
+                        ))
                         .toList(),
                 campusPlaces.stream()
-                        .map(place -> toCampusPlaceResult(place, context))
+                        .map(place -> toCampusPlaceResult(
+                                place,
+                                context,
+                                resolveImageUrl(place.buildingImagePath(), imageUrlsByPath)
+                        ))
                         .toList()
         );
     }
@@ -144,8 +154,14 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
             CampusPlaceReadModel place,
             OperatingContext context
     ) {
-        String imageUrl = resolveImageUrl(place.buildingImagePath());
+        return toCampusPlaceResult(place, context, resolveImageUrl(place.buildingImagePath()));
+    }
 
+    private CampusPlaceResult toCampusPlaceResult(
+            CampusPlaceReadModel place,
+            OperatingContext context,
+            String imageUrl
+    ) {
         return new CampusPlaceResult(
                 place.id(),
                 place.name(),
@@ -221,6 +237,16 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
             return null;
         }
         return storagePort.getPresignedUrl(imagePath);
+    }
+
+    private String resolveImageUrl(String imagePath, Map<String, String> imageUrlsByPath) {
+        if (imagePath == null || imagePath.isBlank()) {
+            return null;
+        }
+        if (!imageUrlsByPath.containsKey(imagePath)) {
+            imageUrlsByPath.put(imagePath, resolveImageUrl(imagePath));
+        }
+        return imageUrlsByPath.get(imagePath);
     }
 
 }

--- a/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
+++ b/src/main/java/com/kustacks/kuring/building/application/service/CampusMapQueryService.java
@@ -110,7 +110,22 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
                 building.name(),
                 building.address(),
                 building.latitude(),
-                building.longitude()
+                building.longitude(),
+                resolveImageUrl(building.imagePath())
+        );
+    }
+
+    private BuildingSummaryResult toBuildingSummaryResult(
+            BuildingSummaryReadModel building,
+            String imageUrl
+    ) {
+        return new BuildingSummaryResult(
+                building.id(),
+                building.name(),
+                building.address(),
+                building.latitude(),
+                building.longitude(),
+                imageUrl
         );
     }
 
@@ -129,19 +144,21 @@ public class CampusMapQueryService implements CampusMapQueryUseCase {
             CampusPlaceReadModel place,
             OperatingContext context
     ) {
+        String imageUrl = resolveImageUrl(place.buildingImagePath());
+
         return new CampusPlaceResult(
                 place.id(),
                 place.name(),
                 place.categoryCode(),
                 place.categoryKorName(),
-                resolveImageUrl(place.buildingImagePath()),
+                imageUrl,
                 place.locationType(),
                 place.floor(),
                 place.locationDetail(),
                 place.quantity(),
                 resolveOperatingHours(place.operatingHours(), context),
                 place.externalUrl(),
-                toBuildingSummaryResult(place.building())
+                toBuildingSummaryResult(place.building(), imageUrl)
         );
     }
 

--- a/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/in/web/CampusMapQueryApiV2Test.java
@@ -135,7 +135,8 @@ class CampusMapQueryApiV2Test {
                                 "학생회관",
                                 "서울특별시 광진구 능동로 120",
                                 37.5412,
-                                127.0784
+                                127.0784,
+                                "https://storage.example.com/student-center.png"
                         )),
                         List.of(campusPlaceResult())
                 )
@@ -156,10 +157,16 @@ class CampusMapQueryApiV2Test {
                         .extracting(
                                 BuildingSummary::id,
                                 BuildingSummary::name,
-                                BuildingSummary::address
+                                BuildingSummary::address,
+                                BuildingSummary::imageUrl
                         )
                         .containsExactly(
-                                tuple(4L, "학생회관", "서울특별시 광진구 능동로 120")
+                                tuple(
+                                        4L,
+                                        "학생회관",
+                                        "서울특별시 광진구 능동로 120",
+                                        "https://storage.example.com/student-center.png"
+                                )
                         ),
                 () -> assertThat(body.getData().campusPlaces()).hasSize(1),
                 () -> assertThat(body.getData().campusPlaces().get(0).name())
@@ -255,7 +262,8 @@ class CampusMapQueryApiV2Test {
                         "학생회관",
                         "서울특별시 광진구 능동로 120",
                         37.5412,
-                        127.0784
+                        127.0784,
+                        "https://storage.example.com/student-center.png"
                 )
         );
     }

--- a/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
+++ b/src/test/java/com/kustacks/kuring/building/adapter/out/persistence/CampusMapPersistenceAdapterTest.java
@@ -107,6 +107,7 @@ class CampusMapPersistenceAdapterTest {
                         "서울특별시 광진구 능동로 120",
                         37.5412,
                         127.0784,
+                        "campus-map/student-center.png",
                         4
                 )
         );

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -175,7 +174,7 @@ class CampusMapQueryServiceTest {
         );
         verify(campusMapQueryPort).searchBuildings("학생회관");
         verify(campusMapQueryPort).searchCampusPlaces("학생회관");
-        verify(storagePort, times(2)).getPresignedUrl("campus-map/student-center.png");
+        verify(storagePort).getPresignedUrl("campus-map/student-center.png");
     }
 
     @Test

--- a/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
+++ b/src/test/java/com/kustacks/kuring/building/application/service/CampusMapQueryServiceTest.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -101,6 +102,7 @@ class CampusMapQueryServiceTest {
                         "서울특별시 광진구 능동로 120",
                         37.54241,
                         127.07382,
+                        "campus-map/administration.png",
                         1
                 ),
                 new BuildingSummaryReadModel(
@@ -109,6 +111,7 @@ class CampusMapQueryServiceTest {
                         "서울특별시 광진구 능동로 120",
                         37.54196,
                         127.07531,
+                        "campus-map/business.png",
                         2
                 )
         ));
@@ -138,6 +141,7 @@ class CampusMapQueryServiceTest {
                         "서울특별시 광진구 능동로 120",
                         37.5412,
                         127.0784,
+                        "campus-map/student-center.png",
                         4
                 )
         ));
@@ -158,7 +162,8 @@ class CampusMapQueryServiceTest {
                                 "학생회관",
                                 "서울특별시 광진구 능동로 120",
                                 37.5412,
-                                127.0784
+                                127.0784,
+                                "https://storage.example.com/student-center.png"
                         )
                 ),
                 () -> assertThat(result.campusPlaces()).hasSize(1),
@@ -170,7 +175,7 @@ class CampusMapQueryServiceTest {
         );
         verify(campusMapQueryPort).searchBuildings("학생회관");
         verify(campusMapQueryPort).searchCampusPlaces("학생회관");
-        verify(storagePort).getPresignedUrl("campus-map/student-center.png");
+        verify(storagePort, times(2)).getPresignedUrl("campus-map/student-center.png");
     }
 
     @Test
@@ -343,6 +348,7 @@ class CampusMapQueryServiceTest {
                         "서울특별시 광진구 능동로 120",
                         37.5412,
                         127.0784,
+                        "campus-map/student-center.png",
                         4
                 )
         );


### PR DESCRIPTION
## #️⃣ 이슈
#392 
## 📌 요약
캠퍼스맵 통합 검색 결과의 건물 정보에 이미지 URL을 추가했습니다.
## 🛠️ 상세
- 건물의 이미지 경로를 조회 모델에 포함했습니다.
- 건물 이미지 경로를 Presigned URL로 변환하여 `buildings[].imageUrl`로 반환합니다.
- 이미지 경로가 없는 건물은 `imageUrl`을 `null`로 반환합니다.
- 서비스, 컨트롤러, 영속성 어댑터 테스트를 보강했습니다.
## 💬 기타
- 변경 API: `GET /api/v2/maps/search`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캠퍼스맵의 건물 요약 정보에 건물 이미지 URL이 추가됩니다.
  * 건물 검색 및 장소 검색 결과에서 관련 이미지를 확인할 수 있습니다.
  * 장소와 연결된 건물 요약에 동일한 이미지가 일관되게 표시됩니다.
  * 이미지가 없는 건물은 기존처럼 이미지 없이 표시됩니다.

* **테스트**
  * 건물 이미지 경로와 URL 변환 결과 검증을 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->